### PR TITLE
Install VS Code Extension Manager in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ jobs:
     - name: Install Dependencies
       run: npm ci
       
+    # Install vsce before packaging
+    - name: Install VS Code Extension Manager
+      run: npm install -g @vscode/vsce
+
     - name: Lint
       run: npm run lint
       


### PR DESCRIPTION
Add installation of the VS Code Extension Manager to the CI workflow to ensure proper packaging of the extension.