### PR TITLE
Disambiguate node labels for duplicate filenames

### DIFF
--- a/src/webview/components/Graph.tsx
+++ b/src/webview/components/Graph.tsx
@@ -14,7 +14,10 @@ if (typeof document !== 'undefined' && !document.getElementById('reactflow-style
 
 const CustomNode = ({ data, isConnectable }: NodeProps) => {
     return (
-        <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <div
+            style={{ position: 'relative', width: '100%', height: '100%' }}
+            title={data.fullPath}
+        >
             <Handle type="target" position={Position.Left} isConnectable={isConnectable} style={{ visibility: 'hidden' }} />
 
             <div style={{

--- a/src/webview/hooks/useGraphData.ts
+++ b/src/webview/hooks/useGraphData.ts
@@ -166,8 +166,25 @@ export const useGraphData = () => {
     // Create React Flow Nodes
     const newNodes: Node[] = [];
     
+    // Calculate filename frequencies to detect duplicates
+    const fileNameCounts = new Map<string, number>();
     visibleNodes.forEach(path => {
         const fileName = path.split('/').pop() || path;
+        fileNameCounts.set(fileName, (fileNameCounts.get(fileName) || 0) + 1);
+    });
+
+    visibleNodes.forEach(path => {
+        const fileName = path.split('/').pop() || path;
+        
+        // Disambiguate if multiple files have the same name
+        let label = fileName;
+        if ((fileNameCounts.get(fileName) || 0) > 1) {
+            const parentDir = path.split('/').slice(-2, -1)[0];
+            if (parentDir) {
+                label = `${parentDir}/${fileName}`;
+            }
+        }
+
         const isTs = fileName.endsWith('.ts') || fileName.endsWith('.tsx');
         const isJs = fileName.endsWith('.js') || fileName.endsWith('.jsx');
         const isVue = fileName.endsWith('.vue');
@@ -204,7 +221,8 @@ export const useGraphData = () => {
         newNodes.push({
           id: path,
           data: { 
-              label: fileName,
+              label,
+              fullPath: path,
               hasChildren,
               isExpanded,
               isInCycle,


### PR DESCRIPTION
Enhance node labels by including the parent directory for files with duplicate names, improving clarity in the graph representation. This change calculates filename frequencies and adjusts labels accordingly.