### PR TITLE
Add GraphQL support with #import directive parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Graph-It-Live
 
-A Visual Studio Code extension that visualizes file dependencies in a **real-time interactive graph**. Perfect for understanding code architecture and navigating complex **TypeScript**, **JavaScript**, **Vue** and **Svelte** projects.
+A Visual Studio Code extension that visualizes file dependencies in a **real-time interactive graph**. Perfect for understanding code architecture and navigating complex **TypeScript**, **JavaScript**, **Vue**, **Svelte**, and **GraphQL** projects.
 
 <div align="center">
   <img src="media/demo-plugin-graph-it-live.gif" alt="Graph-It-Live Demo" width="800"/>
@@ -13,7 +13,7 @@ A Visual Studio Code extension that visualizes file dependencies in a **real-tim
 ## Features
 
 - **Real-time Dependency Visualization**: Interactive graph showing file dependencies.
-- **Multi-Language Support**: First-class support for **TypeScript** (`.ts`, `.tsx`), **JavaScript** (`.js`, `.jsx`), **Vue** (`.vue`), and **Svelte** (`.svelte`).
+- **Multi-Language Support**: First-class support for **TypeScript** (`.ts`, `.tsx`), **JavaScript** (`.js`, `.jsx`), **Vue** (`.vue`), **Svelte** (`.svelte`), and **GraphQL** (`.gql`, `.graphql`).
 - **Cycle Detection**: Automatically detects and highlights circular dependencies with red dashed lines and badges.
 - **Smart Navigation**: Navigate through your code history with a built-in "Back" button in the graph view.
 - **Background Indexing** *(New)*: Optionally index your entire workspace in the background for instant reverse dependency lookups. Uses a separate worker thread to avoid blocking the IDE.
@@ -44,7 +44,7 @@ The extension is also available on the [Open VSX Registry](https://open-vsx.org/
 
 ## Usage
 
-1. **Open a Project**: Open a folder containing TypeScript, JavaScript, Vue, or Svelte files.
+1. **Open a Project**: Open a folder containing TypeScript, JavaScript, Vue, Svelte, or GraphQL files.
 2. **Open the Graph**:
    - Click the **Graph-It-Live** icon in the Activity Bar (left sidebar).
    - Or run the command: `Graph-It-Live: Show Dependency Graph`.
@@ -73,11 +73,19 @@ Customize the extension in VS Code Settings (`Cmd+,` or `Ctrl+,`):
 ### Background Indexing
 
 When `enableBackgroundIndexing` is enabled:
-- The extension indexes all TypeScript, JavaScript, Vue, and Svelte files in your workspace
+- The extension indexes all TypeScript, JavaScript, Vue, Svelte, and GraphQL files in your workspace
 - Indexing runs in a **separate worker thread** to avoid blocking the IDE
 - Progress is shown in the **status bar** (bottom left)
 - Reverse dependency lookups (`◀` button) become instant (O(1)) instead of scanning the entire workspace
 - Recommended for large projects where reverse lookup performance matters
+
+### GraphQL Support
+
+Graph-It-Live provides full support for GraphQL schema files:
+- **File Extensions**: `.gql` and `.graphql` files are fully supported
+- **Import Syntax**: Parses GraphQL `#import` directives (e.g., `#import "./fragments/user.gql"`)
+- **Cross-Language**: Detects imports of `.gql` files from TypeScript/JavaScript (webpack/vite loaders)
+- **Visual Distinction**: GraphQL nodes are displayed with a **pink border** (#e535ab) matching the official GraphQL brand color
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Customize the extension in VS Code Settings (`Cmd+,` or `Ctrl+,`):
 |---------|---------|-------------|
 | `graph-it-live.maxDepth` | `50` | Maximum depth of dependencies to analyze initially. |
 | `graph-it-live.excludeNodeModules` | `true` | Whether to exclude `node_modules` imports from the graph. |
-| `graph-it-live.enableBackgroundIndexing` | `false` | Enable background indexing for instant reverse dependency lookups. When enabled, all workspace files are indexed at startup using a worker thread. |
+| `graph-it-live.enableBackgroundIndexing` | `true` | Enable background indexing for instant reverse dependency lookups. When enabled, all workspace files are indexed at startup using a worker thread. Disable it if you encounter performance issues or want to reduce CPU usage. |
 | `graph-it-live.persistIndex` | `false` | Persist the reverse index to disk for faster startup. The index is validated using file mtime and size to detect changes. |
 | `graph-it-live.indexingConcurrency` | `4` | Number of files to process in parallel during indexing (1-16). Lower values reduce CPU usage. |
 | `graph-it-live.indexingStartDelay` | `1000` | Delay in milliseconds before starting background indexing after activation. Allows VS Code to finish startup first. |

--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   },
   "keywords": [
     "dependency graph",
+    "dependencies",
     "visualization",
     "typescript",
     "javascript",
     "vue",
     "svelte",
+    "graphql",
     "architecture",
     "circular dependencies",
     "refactoring",
@@ -103,7 +105,7 @@
         },
         "graph-it-live.enableBackgroundIndexing": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable background indexing for faster reverse dependency lookups. When enabled, the extension will index all files in the workspace at startup."
         },
         "graph-it-live.persistIndex": {

--- a/src/analyzer/PathResolver.ts
+++ b/src/analyzer/PathResolver.ts
@@ -134,7 +134,7 @@ export class PathResolver {
    * Try different file extensions
    */
   private async resolveWithExtensions(basePath: string): Promise<string | null> {
-    const extensions = ['.ts', '.tsx', '.js', '.jsx', '.vue', '.svelte', '.mjs', '.cjs'];
+    const extensions = ['.ts', '.tsx', '.js', '.jsx', '.vue', '.svelte', '.mjs', '.cjs', '.gql', '.graphql'];
     
     // Try exact path first
     if (await this.fileExists(basePath)) {

--- a/src/analyzer/Spider.ts
+++ b/src/analyzer/Spider.ts
@@ -675,7 +675,7 @@ export class Spider {
    * Check if a file is a supported source file
    */
   private isSupportedSourceFile(fileName: string): boolean {
-    return /\.(ts|tsx|js|jsx|vue|svelte)$/.test(fileName);
+    return /\.(ts|tsx|js|jsx|vue|svelte|gql|graphql)$/.test(fileName);
   }
 
   /**

--- a/src/extension/GraphProvider.ts
+++ b/src/extension/GraphProvider.ts
@@ -430,7 +430,7 @@ export class GraphProvider implements vscode.WebviewViewProvider {
         console.log(`GraphProvider: Analyzing ${filePath}`);
 
         // Only analyze supported files
-        if (!/\.(ts|tsx|js|jsx|vue|svelte)$/.test(filePath)) {
+        if (!/\.(ts|tsx|js|jsx|vue|svelte|gql|graphql)$/.test(filePath)) {
             console.log('GraphProvider: Unsupported file type');
             return;
         }

--- a/src/webview/hooks/useGraphData.ts
+++ b/src/webview/hooks/useGraphData.ts
@@ -231,6 +231,7 @@ export const useGraphData = () => {
         const isJs = fileName.endsWith('.js') || fileName.endsWith('.jsx');
         const isVue = fileName.endsWith('.vue');
         const isSvelte = fileName.endsWith('.svelte');
+        const isGraphQL = fileName.endsWith('.gql') || fileName.endsWith('.graphql');
         const isNodeModule = /^(?!\.|\/|\\|[a-zA-Z]:)/.test(path);
         const isRoot = path === currentFilePath;
         
@@ -258,6 +259,8 @@ export const useGraphData = () => {
             border = '1px solid #41b883'; // Vue Green
         } else if (isSvelte) {
             border = '1px solid #ff3e00'; // Svelte Orange
+        } else if (isGraphQL) {
+            border = '1px solid #e535ab'; // GraphQL Pink
         }
 
         newNodes.push({

--- a/tests/analyzer/GraphQLSupport.test.ts
+++ b/tests/analyzer/GraphQLSupport.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import path from 'node:path';
+import { Spider } from '../../src/analyzer/Spider';
+
+// Use absolute path for test fixtures
+const fixturesPath = path.resolve(process.cwd(), 'tests/fixtures/graphql-project');
+
+describe('Spider - GraphQL Support', () => {
+    let spider: Spider;
+
+    beforeEach(() => {
+        spider = new Spider({
+            rootDir: fixturesPath,
+            maxDepth: 10,
+            excludeNodeModules: true,
+        });
+    });
+
+    it('should analyze .gql file and find #import dependencies', async () => {
+        const schemaPath = path.join(fixturesPath, 'schema.gql');
+        const dependencies = await spider.analyze(schemaPath);
+        
+        expect(dependencies).toHaveLength(2);
+        
+        const modules = dependencies.map((d) => path.basename(d.path));
+        expect(modules).toContain('user.gql');
+        expect(modules).toContain('post.graphql');
+    });
+
+    it('should analyze .graphql file and find #import dependencies', async () => {
+        const postPath = path.join(fixturesPath, 'fragments/post.graphql');
+        const dependencies = await spider.analyze(postPath);
+        
+        expect(dependencies).toHaveLength(2);
+        
+        const modules = dependencies.map((d) => path.basename(d.path));
+        expect(modules).toContain('common.gql');
+        expect(modules).toContain('user.gql');
+    });
+
+    it('should handle GraphQL file with no imports', async () => {
+        const commonPath = path.join(fixturesPath, 'fragments/common.gql');
+        const dependencies = await spider.analyze(commonPath);
+        
+        expect(dependencies).toHaveLength(0);
+    });
+
+    it('should crawl GraphQL dependency graph', async () => {
+        const schemaPath = path.join(fixturesPath, 'schema.gql');
+        const graph = await spider.crawl(schemaPath);
+        
+        // schema.gql -> user.gql, post.graphql
+        // user.gql -> common.gql
+        // post.graphql -> common.gql, user.gql
+        expect(graph.nodes.length).toBeGreaterThanOrEqual(4);
+        expect(graph.edges.length).toBeGreaterThanOrEqual(2);
+        
+        const nodeNames = graph.nodes.map((n: string) => path.basename(n));
+        expect(nodeNames).toContain('schema.gql');
+        expect(nodeNames).toContain('user.gql');
+        expect(nodeNames).toContain('post.graphql');
+        expect(nodeNames).toContain('common.gql');
+    });
+
+    it('should analyze TypeScript file importing .gql files', async () => {
+        const apiPath = path.join(fixturesPath, 'src/api.ts');
+        const dependencies = await spider.analyze(apiPath);
+        
+        // Should find: ../queries/getUser.gql and ../schema.gql
+        // (graphql-tag is excluded as node_module)
+        expect(dependencies.length).toBeGreaterThanOrEqual(2);
+        
+        const modules = dependencies.map((d) => path.basename(d.path));
+        expect(modules).toContain('getUser.gql');
+        expect(modules).toContain('schema.gql');
+    });
+
+    it('should handle circular imports in GraphQL files', async () => {
+        // post.graphql imports user.gql
+        // user.gql imports common.gql
+        // This tests that circular detection doesn't break
+        const postPath = path.join(fixturesPath, 'fragments/post.graphql');
+        const graph = await spider.crawl(postPath);
+        
+        expect(graph.nodes.length).toBeGreaterThan(0);
+        // Should complete without infinite loop
+    });
+});

--- a/tests/fixtures/graphql-project/fragments/common.gql
+++ b/tests/fixtures/graphql-project/fragments/common.gql
@@ -1,0 +1,16 @@
+# Common shared fragments
+
+fragment TimestampFields on Node {
+  createdAt
+  updatedAt
+}
+
+fragment PaginationFields on Connection {
+  pageInfo {
+    hasNextPage
+    hasPreviousPage
+    startCursor
+    endCursor
+  }
+  totalCount
+}

--- a/tests/fixtures/graphql-project/fragments/post.graphql
+++ b/tests/fixtures/graphql-project/fragments/post.graphql
@@ -1,0 +1,19 @@
+# Post fragment with .graphql extension
+#import "./common.gql"
+#import './user.gql'
+
+fragment PostFields on Post {
+  id
+  title
+  content
+  author {
+    ...UserFields
+  }
+  ...TimestampFields
+}
+
+input CreatePostInput {
+  title: String!
+  content: String!
+  authorId: ID!
+}

--- a/tests/fixtures/graphql-project/fragments/user.gql
+++ b/tests/fixtures/graphql-project/fragments/user.gql
@@ -1,0 +1,14 @@
+# User fragment
+#import "./common.gql"
+
+fragment UserFields on User {
+  id
+  name
+  email
+  ...TimestampFields
+}
+
+input CreateUserInput {
+  name: String!
+  email: String!
+}

--- a/tests/fixtures/graphql-project/queries/getUser.gql
+++ b/tests/fixtures/graphql-project/queries/getUser.gql
@@ -1,0 +1,8 @@
+# Query to get a user
+#import "../fragments/user.gql"
+
+query GetUser($id: ID!) {
+  user(id: $id) {
+    ...UserFields
+  }
+}

--- a/tests/fixtures/graphql-project/schema.gql
+++ b/tests/fixtures/graphql-project/schema.gql
@@ -1,0 +1,13 @@
+# Main GraphQL schema file
+#import "./fragments/user.gql"
+#import "./fragments/post.graphql"
+
+type Query {
+  user(id: ID!): User
+  posts: [Post!]!
+}
+
+type Mutation {
+  createUser(input: CreateUserInput!): User
+  createPost(input: CreatePostInput!): Post
+}

--- a/tests/fixtures/graphql-project/src/api.ts
+++ b/tests/fixtures/graphql-project/src/api.ts
@@ -1,0 +1,19 @@
+// TypeScript file that imports GraphQL files (like webpack/vite loaders do)
+import userQuery from '../queries/getUser.gql';
+import schema from '../schema.gql';
+
+// Some bundlers also support importing with graphql-tag
+import { gql } from 'graphql-tag';
+
+export const GET_USER = userQuery;
+export const SCHEMA = schema;
+
+// Inline query (not imported from file)
+export const GET_POSTS = gql`
+  query GetPosts {
+    posts {
+      id
+      title
+    }
+  }
+`;

--- a/tests/parser-graphql.test.ts
+++ b/tests/parser-graphql.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { Parser } from '../src/analyzer/Parser';
+
+describe('Parser - GraphQL Support', () => {
+    const parser = new Parser();
+
+    describe('GraphQL #import directive', () => {
+        it('should parse #import with double quotes', () => {
+            const content = `#import "./fragments/user.gql"
+
+type Query {
+  user(id: ID!): User
+}`;
+            const imports = parser.parse(content, 'schema.gql');
+            expect(imports).toHaveLength(1);
+            expect(imports[0].module).toBe('./fragments/user.gql');
+            expect(imports[0].type).toBe('import');
+        });
+
+        it('should parse #import with single quotes', () => {
+            const content = `#import './fragments/post.graphql'
+
+fragment PostFields on Post {
+  id
+  title
+}`;
+            const imports = parser.parse(content, 'test.gql');
+            expect(imports).toHaveLength(1);
+            expect(imports[0].module).toBe('./fragments/post.graphql');
+        });
+
+        it('should parse multiple #import directives', () => {
+            const content = `#import "./fragments/user.gql"
+#import "./fragments/post.graphql"
+#import '../common/pagination.gql'
+
+type Query {
+  users: [User!]!
+  posts: [Post!]!
+}`;
+            const imports = parser.parse(content, 'schema.gql');
+            expect(imports).toHaveLength(3);
+            expect(imports[0].module).toBe('./fragments/user.gql');
+            expect(imports[1].module).toBe('./fragments/post.graphql');
+            expect(imports[2].module).toBe('../common/pagination.gql');
+        });
+
+        it('should work with .graphql extension', () => {
+            const content = `#import "./common.gql"
+
+fragment UserFields on User {
+  id
+  name
+}`;
+            const imports = parser.parse(content, 'user.graphql');
+            expect(imports).toHaveLength(1);
+            expect(imports[0].module).toBe('./common.gql');
+        });
+
+        it('should ignore GraphQL comments that are not imports', () => {
+            const content = `# This is a regular comment
+# Another comment about the schema
+#import "./fragment.gql"
+
+# Comment about the type
+type User {
+  id: ID!
+}`;
+            const imports = parser.parse(content, 'schema.gql');
+            expect(imports).toHaveLength(1);
+            expect(imports[0].module).toBe('./fragment.gql');
+        });
+
+        it('should handle empty GraphQL files', () => {
+            const content = `# Empty schema file`;
+            const imports = parser.parse(content, 'empty.gql');
+            expect(imports).toHaveLength(0);
+        });
+
+        it('should handle GraphQL files with no imports', () => {
+            const content = `type Query {
+  hello: String!
+}`;
+            const imports = parser.parse(content, 'simple.gql');
+            expect(imports).toHaveLength(0);
+        });
+    });
+
+    describe('JS/TS importing GraphQL files', () => {
+        it('should parse import of .gql file from TypeScript', () => {
+            const content = `import userQuery from './queries/user.gql';
+import { gql } from 'graphql-tag';
+
+export const GET_USER = userQuery;`;
+            const imports = parser.parse(content, 'api.ts');
+            expect(imports).toHaveLength(2);
+            expect(imports[0].module).toBe('./queries/user.gql');
+            expect(imports[1].module).toBe('graphql-tag');
+        });
+
+        it('should parse import of .graphql file from JavaScript', () => {
+            const content = `import schema from '../schema.graphql';
+
+export default schema;`;
+            const imports = parser.parse(content, 'index.js');
+            expect(imports).toHaveLength(1);
+            expect(imports[0].module).toBe('../schema.graphql');
+        });
+
+        it('should parse require of .gql file', () => {
+            const content = `const query = require('./query.gql');
+
+module.exports = query;`;
+            const imports = parser.parse(content, 'query.js');
+            expect(imports).toHaveLength(1);
+            expect(imports[0].module).toBe('./query.gql');
+            expect(imports[0].type).toBe('require');
+        });
+
+        it('should parse dynamic import of .gql file', () => {
+            const content = `async function loadQuery() {
+  const query = await import('./dynamic.gql');
+  return query;
+}`;
+            const imports = parser.parse(content, 'loader.ts');
+            expect(imports).toHaveLength(1);
+            expect(imports[0].module).toBe('./dynamic.gql');
+            expect(imports[0].type).toBe('dynamic');
+        });
+    });
+});


### PR DESCRIPTION
Introduce support for GraphQL files, including parsing of the #import directive and handling of .gql and .graphql file extensions. Update the extension's documentation to reflect this new feature and ensure TypeScript files can import GraphQL files seamlessly. Include tests to verify the functionality and correctness of the GraphQL integration.