### PR TITLE
Add Snyk Security Extension rules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ mcp.json
 playwright-report/
 test-results/
 
+
+# Snyk Security Extension - AI Rules (auto-generated)
+.github/instructions/snyk_rules.instructions.md


### PR DESCRIPTION
Include auto-generated rules for the Snyk Security Extension in the .gitignore file to prevent tracking of specific files.