### PR TITLE
Add regression tests for ReverseIndex reference preservation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,20 +21,16 @@
 
 **Refresh Button Bug**:
 - **Fixed refresh clearing symbol view**: Clicking the refresh button in symbol view would incorrectly switch back to file view, causing GraphQL files and other files in symbol mode to appear empty
-  - Root cause: `refreshGraph` message handler was calling `updateGraph()` instead of `refreshGraph()`, which didn't preserve the current view mode
-  - Solution: Changed handler to call `this.refreshGraph()` which properly maintains symbol/file view state
+
+**ReverseIndex Degradation During Navigation**:
+- **Fixed progressive loss of dependencies and references**: When navigating between files through the webview, references would progressively disappear because cached files weren't updating the ReverseIndex
+
+
 
 **MCP Server File Watching**:
 - Verified automatic cache invalidation via chokidar works correctly (300ms debouncing)
 - Confirmed file watching handles change/add/unlink events properly
 
-### Testing
-
-- Added 10 comprehensive integration tests in `tests/mcp/McpWorker.test.ts`:
-  - 7 tests for ReverseIndex regression scenarios
-  - 3 tests for file watching simulation
-- Added regression test scenario to `scripts/test-mcp.js` (4-step verification)
-- All 583 tests pass (including 6 previous ReverseIndex regression tests)
 
 ## v1.3.1
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,31 +6,18 @@
 
 **Critical ReverseIndex Bug Fix**:
 - **Fixed reference persistence issue**: References would disappear from the reverse index after file re-analysis, causing the "Get References" button to incorrectly show no parent files. This affected both the VS Code extension and the MCP server.
-  - Root cause: `ReverseIndex.removeDependenciesFromSource()` was prematurely deleting empty target maps during re-analysis, causing a race condition
-  - Solution: Implemented lazy cleanup pattern - empty maps are only cleaned up during `getReferencingFiles()` queries, not during updates
-  - Added explicit `cleanup()` public method for manual garbage collection if needed
-  - Applied same fixes to `SymbolReverseIndex` for symbol-level dependencies
 
 **Webview State Management**:
 - **Fixed stale references display**: After navigating to a new file, the webview would retain old references and not request new ones
-  - Solution: Reset `referencingFiles` state to empty array in `handleUpdateGraphMessage()` to force fresh queries
 
 **Initial Indexing Display**:
 - **Fixed missing parent counts on initial load**: When opening a file before background indexing completed, parent counts wouldn't appear
-  - Solution: Added automatic view refresh after indexing completion in `GraphProvider._startBackgroundIndexingWithProgress()`
 
 **Refresh Button Bug**:
 - **Fixed refresh clearing symbol view**: Clicking the refresh button in symbol view would incorrectly switch back to file view, causing GraphQL files and other files in symbol mode to appear empty
 
 **ReverseIndex Degradation During Navigation**:
 - **Fixed progressive loss of dependencies and references**: When navigating between files through the webview, references would progressively disappear because cached files weren't updating the ReverseIndex
-
-
-
-**MCP Server File Watching**:
-- Verified automatic cache invalidation via chokidar works correctly (300ms debouncing)
-- Confirmed file watching handles change/add/unlink events properly
-
 
 ## v1.3.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,6 @@
         "@modelcontextprotocol/sdk": "^1.24.3",
         "@types/dagre": "^0.7.53",
         "chokidar": "^5.0.0",
-        "d3": "^7.9.0",
-        "d3-hierarchy": "^3.1.2",
         "dagre": "^0.8.5",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
@@ -3930,125 +3928,11 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/d3": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -4075,101 +3959,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
-      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -4186,112 +3980,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -4456,15 +4149,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/delaunator": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
-      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -5786,6 +5470,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -5886,15 +5571,6 @@
       "dev": true,
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -8252,12 +7928,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/robust-predicates": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
-      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
-      "license": "Unlicense"
-    },
     "node_modules/rollup": {
       "version": "4.53.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
@@ -8352,12 +8022,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -240,8 +240,6 @@
     "@modelcontextprotocol/sdk": "^1.24.3",
     "@types/dagre": "^0.7.53",
     "chokidar": "^5.0.0",
-    "d3": "^7.9.0",
-    "d3-hierarchy": "^3.1.2",
     "dagre": "^0.8.5",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/src/extension/GraphProvider.ts
+++ b/src/extension/GraphProvider.ts
@@ -798,7 +798,7 @@ export class GraphProvider implements vscode.WebviewViewProvider {
             openFile: async (m: OpenFileMessage) => { if (m.path) await this.handleOpenFile(m.path, m.line); },
             expandNode: async (m: ExpandNodeMessage) => { if (m.nodeId) await this.handleExpandNode(m.nodeId, m.knownNodes); },
             setExpandAll: async (m: SetExpandAllMessage) => { log.debug('Setting expandAll to', m.expandAll); this._context.globalState.update('expandAll', m.expandAll); },
-            refreshGraph: async () => { log.debug('Refreshing graph'); this.updateGraph(); },
+            refreshGraph: async () => { log.debug('Refreshing graph'); await this.refreshGraph(); },
             findReferencingFiles: async (m: FindReferencingFilesMessage) => { if (m.nodeId) await this.handleFindReferencingFiles(m.nodeId); },
             drillDown: async (m: DrillDownMessage) => { if (m.filePath) await this.handleDrillDown(m.filePath); },
             ready: async () => { log.debug('Webview ready, sending initial graph'); this.updateGraph(); },

--- a/src/extension/GraphProvider.ts
+++ b/src/extension/GraphProvider.ts
@@ -291,6 +291,16 @@ export class GraphProvider implements vscode.WebviewViewProvider {
                     this._statusBarItem.text = `$(check) Graph-It-Live: ${result.indexedFiles} files indexed`;
                     // Persist the index if enabled
                     await this._persistIndex();
+                    
+                    // Refresh the current view to show parent counts now that indexing is complete
+                    log.debug('Indexing complete, refreshing view to show parent counts');
+                    if (this._currentSymbolFilePath) {
+                        // In symbol view - refresh to update "Imported By" list
+                        await this.handleDrillDown(this._currentSymbolFilePath, true);
+                    } else {
+                        // In file view - refresh to show parent counts on nodes
+                        this.updateGraph(true);
+                    }
                 }
 
                 // Hide status bar after a short delay

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -107,8 +107,9 @@ const App: React.FC = () => {
         setGraphData(message.data);
         setCurrentFilePath(message.filePath);
         setEmptyStateMessage(null);
-        // Reset parent visibility on new navigation
+        // Reset parent visibility and referencing files on new navigation
         setShowParents(false);
+        setReferencingFiles([]);
     }, []);
 
     // Handler for symbolGraph message

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -252,19 +252,24 @@ const App: React.FC = () => {
 
     const handleFindReferences = (path: string) => {
         log.debug('App: Find references clicked for:', path, 'showParents:', showParents, 'referencingFilesCount:', referencingFiles.length);
-        if (!showParents && referencingFiles.length === 0) {
-            // If we don't currently show parents and we haven't fetched referencing files yet,
-            // request them from the extension
+        
+        if (showParents) {
+            // If parents are currently visible, just hide them (no need to re-fetch)
+            setShowParents(false);
+        } else if (referencingFiles.length === 0) {
+            // We haven't fetched referencing files yet, request them from the extension
+            // IMPORTANT: Don't toggle showParents yet - wait for the response
             if (vscode) {
                 vscode.postMessage({
                     command: 'findReferencingFiles',
                     nodeId: path,
                 });
             }
+            // handleReferencingFilesMessage will set showParents=true when data arrives
+        } else {
+            // We already have the data, just toggle visibility
+            setShowParents(true);
         }
-
-        // Toggle visibility
-        setShowParents((prev) => !prev);
     };
 
     

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -110,6 +110,12 @@ const App: React.FC = () => {
         // Reset parent visibility and referencing files on new navigation
         setShowParents(false);
         setReferencingFiles([]);
+        
+        // CRITICAL: Synchronize expandAll state with extension's persisted state
+        // This ensures the webview button reflects the actual state on first render
+        if (message.expandAll !== undefined) {
+            setExpandAll(message.expandAll);
+        }
     }, []);
 
     // Handler for symbolGraph message

--- a/src/webview/components/ReactFlowGraph.tsx
+++ b/src/webview/components/ReactFlowGraph.tsx
@@ -522,10 +522,12 @@ const ReactFlowGraphContent: React.FC<ReactFlowGraphProps> = ({
         
         // Traverse children starting from current file
         const queue = [normalizedCurrentPath];
+        const visited = new Set<string>(); // Track processed nodes to avoid infinite loops
 
         while (queue.length > 0) {
             const node = queue.shift()!;
-            if (visibleNodes.has(node)) continue;
+            if (visited.has(node)) continue; // Skip if already processed
+            visited.add(node);
             visibleNodes.add(node);
 
             const nodeChildren = children.get(node) || [];

--- a/tests/analyzer/ReverseIndexBugFix.test.ts
+++ b/tests/analyzer/ReverseIndexBugFix.test.ts
@@ -177,8 +177,9 @@ describe('ReverseIndex - Bug Fix: References not disappearing on re-analysis', (
         expect(refsAfterB).toBeDefined();
         expect(refsAfterB.length).toBeGreaterThanOrEqual(refsBeforeB.length);
         
-        // Verify fileB is in the references
-        const hasBReference = refsAfterB.some(ref => ref.path === fileB);
+        // Verify fileB is in the references - normalize paths for cross-platform comparison
+        const normalizedFileB = path.normalize(fileB);
+        const hasBReference = refsAfterB.some(ref => path.normalize(ref.path) === normalizedFileB);
         expect(hasBReference).toBe(true);
     });
 
@@ -186,7 +187,7 @@ describe('ReverseIndex - Bug Fix: References not disappearing on re-analysis', (
         // Simulate real user behavior: navigate between several files multiple times
         const fileA = path.join(fixturesPath, 'src/utils.ts');
         const fileB = path.join(fixturesPath, 'src/main.ts');
-        const fileC = path.join(fixturesPath, 'src/types.ts');
+        const fileC = path.join(fixturesPath, 'src/circular.ts');
 
         // Navigate: A → B → C → A → B → C
         await spider.crawl(fileA);
@@ -207,6 +208,8 @@ describe('ReverseIndex - Bug Fix: References not disappearing on re-analysis', (
         expect(refsC).toBeDefined();
 
         // fileB imports fileA, so fileA should have at least fileB as reference
-        expect(refsA.some(ref => ref.path === fileB)).toBe(true);
+        // Normalize paths for cross-platform comparison
+        const normalizedFileB = path.normalize(fileB);
+        expect(refsA.some(ref => path.normalize(ref.path) === normalizedFileB)).toBe(true);
     });
 });

--- a/tests/analyzer/ReverseIndexBugFix.test.ts
+++ b/tests/analyzer/ReverseIndexBugFix.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Spider } from '../../src/analyzer/Spider';
+import path from 'node:path';
+
+// Use absolute path for test fixtures
+const fixturesPath = path.resolve(process.cwd(), 'tests/fixtures/sample-project');
+
+describe('ReverseIndex - Bug Fix: References not disappearing on re-analysis', () => {
+    let spider: Spider;
+
+    beforeEach(() => {
+        spider = new Spider({
+            rootDir: fixturesPath,
+            tsConfigPath: path.join(fixturesPath, 'tsconfig.json'),
+            enableReverseIndex: true,
+            indexingConcurrency: 4,
+        });
+    });
+
+    it('should preserve references after re-analyzing a file that imports utils.ts', async () => {
+        // Step 1: Build full index
+        await spider.buildFullIndex();
+
+        const utilsFile = path.join(fixturesPath, 'src/utils.ts');
+        const mainFile = path.join(fixturesPath, 'src/main.ts');
+
+        // Step 2: Verify initial state - utils.ts should have references
+        const refsInitial = await spider.findReferencingFiles(utilsFile);
+        expect(refsInitial.length).toBeGreaterThan(0);
+        expect(refsInitial.some(r => r.path.includes('main.ts'))).toBe(true);
+
+        // Step 3: Re-analyze main.ts (simulates a file save)
+        await spider.reanalyzeFile(mainFile);
+
+        // Step 4: BUG CHECK - utils.ts references should NOT disappear
+        const refsAfterReanalyze = await spider.findReferencingFiles(utilsFile);
+        
+        // This was the bug: refsAfterReanalyze.length === 0 after re-analyzing main.ts
+        expect(refsAfterReanalyze.length).toBeGreaterThan(0);
+        expect(refsAfterReanalyze.some(r => r.path.includes('main.ts'))).toBe(true);
+        
+        // The number of references should be the same or similar
+        expect(refsAfterReanalyze.length).toBeGreaterThanOrEqual(refsInitial.length - 1);
+    });
+
+    it('should maintain references for utils.ts even when multiple files are re-analyzed', async () => {
+        await spider.buildFullIndex();
+
+        const utilsFile = path.join(fixturesPath, 'src/utils.ts');
+        const mainFile = path.join(fixturesPath, 'src/main.ts');
+        const buttonFile = path.join(fixturesPath, 'src/components/Button.tsx');
+
+        // Get initial references
+        const refsInitial = await spider.findReferencingFiles(utilsFile);
+        const initialCount = refsInitial.length;
+        expect(initialCount).toBeGreaterThan(0);
+
+        // Re-analyze multiple files in sequence (common scenario during development)
+        await spider.reanalyzeFile(mainFile);
+        await spider.reanalyzeFile(buttonFile);
+
+        // References should still be present
+        const refsAfter = await spider.findReferencingFiles(utilsFile);
+        expect(refsAfter.length).toBe(initialCount);
+    });
+
+    it('should correctly update references when imports are actually removed', async () => {
+        await spider.buildFullIndex();
+
+        const utilsFile = path.join(fixturesPath, 'src/utils.ts');
+        
+        // Get initial references
+        const refsInitial = await spider.findReferencingFiles(utilsFile);
+        const initialCount = refsInitial.length;
+
+        // Simulate removing a file that imports utils.ts
+        const mainFile = path.join(fixturesPath, 'src/main.ts');
+        spider.handleFileDeleted(mainFile);
+
+        // References should decrease by 1 (if main.ts imported utils.ts)
+        const refsAfterDelete = await spider.findReferencingFiles(utilsFile);
+        const hadMainReference = refsInitial.some(r => r.path.includes('main.ts'));
+        
+        if (hadMainReference) {
+            expect(refsAfterDelete.length).toBe(initialCount - 1);
+            expect(refsAfterDelete.some(r => r.path.includes('main.ts'))).toBe(false);
+        }
+    });
+
+    it('should cleanup empty maps when cleanup() is called', async () => {
+        await spider.buildFullIndex();
+
+        const mainFile = path.join(fixturesPath, 'src/main.ts');
+        
+        // Re-analyze a file - this may create potential empty maps internally
+        await spider.reanalyzeFile(mainFile);
+
+        // Verify index still works correctly after re-analysis
+        expect(spider.hasReverseIndex()).toBe(true);
+        
+        // Can still find references for utils.ts
+        const utilsFile = path.join(fixturesPath, 'src/utils.ts');
+        const refs = await spider.findReferencingFiles(utilsFile);
+        expect(refs).toBeDefined();
+    });
+
+    it('should perform lazy cleanup when accessing references', async () => {
+        await spider.buildFullIndex();
+
+        const utilsFile = path.join(fixturesPath, 'src/utils.ts');
+        
+        // Access references multiple times
+        const refs1 = await spider.findReferencingFiles(utilsFile);
+        const refs2 = await spider.findReferencingFiles(utilsFile);
+        const refs3 = await spider.findReferencingFiles(utilsFile);
+
+        // All calls should return consistent results
+        expect(refs2.length).toBe(refs1.length);
+        expect(refs3.length).toBe(refs1.length);
+    });
+
+    it('should handle the exact scenario described in the bug report', async () => {
+        // This test reproduces the exact scenario:
+        // 1. utils.ts has references (shown in webview)
+        // 2. User clicks "Get References" button on utils.ts node
+        // 3. No parents are displayed (bug)
+
+        await spider.buildFullIndex();
+
+        const utilsFile = path.join(fixturesPath, 'src/utils.ts');
+        
+        // Simulate clicking "Get References" button
+        // This calls findReferencingFiles internally
+        const refs = await spider.findReferencingFiles(utilsFile);
+
+        // Bug check: refs should NOT be empty
+        expect(refs).toBeDefined();
+        expect(Array.isArray(refs)).toBe(true);
+        expect(refs.length).toBeGreaterThan(0);
+
+        // Verify the references are valid
+        for (const ref of refs) {
+            expect(ref.path).toBeDefined();
+            expect(ref.path).toBeTruthy();
+            expect(typeof ref.path).toBe('string');
+        }
+    });
+});

--- a/tests/mcp/McpWorker.test.ts
+++ b/tests/mcp/McpWorker.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration tests for McpWorker - ReverseIndex behavior
+ *
+ * Tests that the ReverseIndex correctly maintains references after file re-analysis,
+ * which is critical for the MCP server's find_referencing_files functionality.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { Spider } from '../../src/analyzer/Spider';
+
+describe('McpWorker - ReverseIndex Integration', () => {
+  let spider: Spider;
+  let tempDir: string;
+  let fileA: string;
+  let fileB: string;
+
+  beforeEach(async () => {
+    // Create a temporary test workspace
+    tempDir = path.join(__dirname, '../fixtures/temp-mcp-test');
+    await fs.mkdir(tempDir, { recursive: true });
+
+    fileA = path.join(tempDir, 'fileA.ts');
+    fileB = path.join(tempDir, 'fileB.ts');
+
+    // fileA imports fileB
+    await fs.writeFile(fileA, `import { helper } from './fileB';\nexport const result = helper();`);
+    await fs.writeFile(fileB, `export function helper() { return 42; }`);
+
+    // Initialize Spider with reverse index enabled (like MCP server does)
+    spider = new Spider({
+      rootDir: tempDir,
+      excludeNodeModules: true,
+      maxDepth: 10,
+      enableReverseIndex: true, // Critical: same as MCP server config
+    });
+  });
+
+  afterEach(async () => {
+    // Cleanup temp directory
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {
+      // Ignore cleanup errors
+    });
+  });
+
+  it('should preserve references after file re-analysis (Bug #1 regression)', async () => {
+    // Step 1: Initial analysis - A imports B
+    await spider.crawl(fileA);
+    
+    // Step 2: Query references for B - should find A
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+    expect(references[0].path).toBe(fileA);
+    expect(references[0].module).toBe('./fileB');
+
+    // Step 3: Simulate file change - modify and re-analyze A
+    await fs.writeFile(fileA, `import { helper } from './fileB';\nexport const result = helper() + 1;`);
+    spider.invalidateFile(fileA);
+    await spider.reanalyzeFile(fileA);
+
+    // Step 4: Query references for B again - A should STILL be there
+    // This is the critical test: before the fix, references would disappear
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+    expect(references[0].path).toBe(fileA);
+    expect(references[0].module).toBe('./fileB');
+  });
+
+  it('should handle multiple sequential re-analyses without losing references', async () => {
+    // Initial analysis
+    await spider.crawl(fileA);
+    
+    // First check
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+
+    // Re-analyze multiple times (simulating repeated file changes)
+    for (let i = 0; i < 5; i++) {
+      await fs.writeFile(fileA, `import { helper } from './fileB';\nexport const result = helper() + ${i};`);
+      spider.invalidateFile(fileA);
+      await spider.reanalyzeFile(fileA);
+      
+      references = await spider.findReferencingFiles(fileB);
+      expect(references).toHaveLength(1);
+    }
+  });
+
+  it('should update references when import is removed', async () => {
+    // Initial state: A imports B
+    await spider.crawl(fileA);
+    
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+
+    // Remove the import from A
+    await fs.writeFile(fileA, `export const result = 42;`);
+    spider.invalidateFile(fileA);
+    await spider.reanalyzeFile(fileA);
+
+    // B should have no references now
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(0);
+  });
+
+  it('should update references when import is added', async () => {
+    // Initial state: A does NOT import B
+    await fs.writeFile(fileA, `export const result = 42;`);
+    await spider.crawl(fileA);
+    
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(0);
+
+    // Add import to B
+    await fs.writeFile(fileA, `import { helper } from './fileB';\nexport const result = helper();`);
+    spider.invalidateFile(fileA);
+    await spider.reanalyzeFile(fileA);
+
+    // B should now have A as reference
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+    expect(references[0].path).toBe(fileA);
+  });
+
+  it('should handle file deletion correctly', async () => {
+    // Initial state: A imports B
+    await spider.crawl(fileA);
+    
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+
+    // Delete file A
+    await fs.unlink(fileA);
+    spider.handleFileDeleted(fileA);
+
+    // B should have no references after A is deleted
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(0);
+  });
+
+  it('should maintain correct references with multiple importers', async () => {
+    // Create fileC that also imports fileB
+    const fileC = path.join(tempDir, 'fileC.ts');
+    await fs.writeFile(fileC, `import { helper } from './fileB';\nexport const value = helper();`);
+
+    // Analyze both files
+    await spider.crawl(fileA);
+    await spider.crawl(fileC);
+    
+    // B should have 2 references
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(2);
+    const paths = references.map(r => r.path).sort();
+    expect(paths).toEqual([fileA, fileC].sort());
+
+    // Re-analyze A
+    await fs.writeFile(fileA, `import { helper } from './fileB';\nexport const result = helper() + 1;`);
+    spider.invalidateFile(fileA);
+    await spider.reanalyzeFile(fileA);
+
+    // Both references should still be there
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(2);
+    expect(references.map(r => r.path).sort()).toEqual([fileA, fileC].sort());
+
+    // Cleanup fileC
+    await fs.unlink(fileC);
+  });
+
+  it('should handle MCP server typical workflow: analyze → query → modify → query', async () => {
+    // Simulate typical MCP server usage pattern:
+    
+    // 1. Client calls crawlDependencyGraph
+    const graph = await spider.crawl(fileA);
+    expect(graph.nodes).toContain(fileA);
+    expect(graph.nodes).toContain(fileB);
+    
+    // 2. Client calls findReferencingFiles for fileB
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+    expect(references[0].path).toBe(fileA);
+    
+    // 3. File watcher detects change, calls invalidateFile + reanalyzeFile
+    await fs.writeFile(fileA, `import { helper } from './fileB';\n// Modified\nexport const result = helper();`);
+    spider.invalidateFile(fileA);
+    await spider.reanalyzeFile(fileA);
+    
+    // 4. Client calls findReferencingFiles again - MUST still work
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+    expect(references[0].path).toBe(fileA);
+    
+    // 5. Verify we can still crawl from fileA
+    const graph2 = await spider.crawl(fileA);
+    expect(graph2.nodes).toContain(fileB);
+  });
+});
+
+describe('McpWorker - File Watching Simulation', () => {
+  let spider: Spider;
+  let tempDir: string;
+  let fileA: string;
+  let fileB: string;
+
+  beforeEach(async () => {
+    tempDir = path.join(__dirname, '../fixtures/temp-mcp-watch-test');
+    await fs.mkdir(tempDir, { recursive: true });
+
+    fileA = path.join(tempDir, 'app.ts');
+    fileB = path.join(tempDir, 'utils.ts');
+
+    await fs.writeFile(fileA, `import { format } from './utils';\nexport const text = format('hello');`);
+    await fs.writeFile(fileB, `export function format(s: string) { return s.toUpperCase(); }`);
+
+    spider = new Spider({
+      rootDir: tempDir,
+      excludeNodeModules: true,
+      maxDepth: 10,
+      enableReverseIndex: true,
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {
+      // Ignore cleanup errors
+    });
+  });
+
+  it('should invalidate cache when file changes (simulating chokidar watch)', async () => {
+    // Initial analysis
+    await spider.crawl(fileA);
+    
+    // Verify cache is populated
+    const cache = (spider as any).cache;
+    expect(cache.has(fileA)).toBe(true);
+    
+    // Simulate chokidar 'change' event → performFileInvalidation
+    spider.invalidateFile(fileA);
+    
+    // Cache should be cleared for fileA
+    expect(cache.has(fileA)).toBe(false);
+    
+    // Re-analyzing should work
+    await spider.reanalyzeFile(fileA);
+    expect(cache.has(fileA)).toBe(true);
+    
+    // References should still be correct
+    const references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+    expect(references[0].path).toBe(fileA);
+  });
+
+  it('should handle file deletion event (simulating chokidar unlink)', async () => {
+    // Initial analysis
+    await spider.crawl(fileA);
+    
+    // Verify references exist
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1);
+    
+    // Simulate chokidar 'unlink' event → performFileInvalidation → handleFileDeleted
+    await fs.unlink(fileA);
+    spider.handleFileDeleted(fileA);
+    
+    // References should be removed
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(0);
+    
+    // Cache should be cleared
+    const cache = (spider as any).cache;
+    expect(cache.has(fileA)).toBe(false);
+  });
+
+  it('should handle file creation event (simulating chokidar add)', async () => {
+    // Create a new file that imports utils
+    const fileC = path.join(tempDir, 'newFile.ts');
+    await fs.writeFile(fileC, `import { format } from './utils';\nexport const msg = format('new');`);
+    
+    // Initial state: only fileA analyzed
+    await spider.crawl(fileA);
+    let references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(1); // Only fileA
+    
+    // Simulate chokidar 'add' event → performFileInvalidation (cache invalidation)
+    // Then user queries the new file
+    spider.invalidateFile(fileC); // In case it was somehow cached
+    await spider.crawl(fileC);
+    
+    // Now fileB should have 2 references
+    references = await spider.findReferencingFiles(fileB);
+    expect(references).toHaveLength(2);
+    const paths = references.map(r => r.path).sort();
+    expect(paths).toEqual([fileA, fileC].sort());
+    
+    // Cleanup
+    await fs.unlink(fileC);
+  });
+});


### PR DESCRIPTION
Implement regression tests to verify that references are preserved after re-analysis in the ReverseIndex. Additionally, enhance the handling of dependencies and cleanup processes to prevent losing references during re-analysis.