### PR TITLE
Refactor to use shared constants for supported file extensions

### DIFF
--- a/src/analyzer/IndexerWorker.ts
+++ b/src/analyzer/IndexerWorker.ts
@@ -11,13 +11,13 @@ import * as path from 'node:path';
 import { Parser } from './Parser';
 import { PathResolver } from './PathResolver';
 import type { Dependency } from './types';
-import { SUPPORTED_FILE_EXTENSIONS } from '../shared/constants';
+import { SUPPORTED_FILE_EXTENSIONS, IGNORED_DIRECTORIES } from '../shared/constants';
 
 // Extensions supported for indexing
 const SUPPORTED_EXTENSIONS = SUPPORTED_FILE_EXTENSIONS;
 
 // Directories to skip during traversal
-const SKIP_DIRECTORIES = new Set(['node_modules', '.git', 'dist', 'build', 'out', 'coverage', '.next', '.nuxt']);
+const SKIP_DIRECTORIES = new Set(IGNORED_DIRECTORIES);
 
 interface WorkerConfig {
   rootDir: string;

--- a/src/analyzer/IndexerWorker.ts
+++ b/src/analyzer/IndexerWorker.ts
@@ -11,9 +11,10 @@ import * as path from 'node:path';
 import { Parser } from './Parser';
 import { PathResolver } from './PathResolver';
 import type { Dependency } from './types';
+import { SUPPORTED_FILE_EXTENSIONS } from '../shared/constants';
 
 // Extensions supported for indexing
-const SUPPORTED_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.vue', '.svelte', '.gql'];
+const SUPPORTED_EXTENSIONS = SUPPORTED_FILE_EXTENSIONS;
 
 // Directories to skip during traversal
 const SKIP_DIRECTORIES = new Set(['node_modules', '.git', 'dist', 'build', 'out', 'coverage', '.next', '.nuxt']);

--- a/src/analyzer/PathResolver.ts
+++ b/src/analyzer/PathResolver.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { normalizePath } from './types';
+import { SUPPORTED_FILE_EXTENSIONS } from '../shared/constants';
 
 /**
  * Resolves module paths to absolute file paths
@@ -384,7 +385,7 @@ export class PathResolver {
    * Try different file extensions
    */
   private async resolveWithExtensions(basePath: string): Promise<string | null> {
-    const extensions = ['.ts', '.tsx', '.js', '.jsx', '.vue', '.svelte', '.mjs', '.cjs', '.gql', '.graphql'];
+    const extensions = SUPPORTED_FILE_EXTENSIONS;
     
     // Try exact path first
     if (await this.fileExists(basePath)) {

--- a/src/analyzer/Spider.ts
+++ b/src/analyzer/Spider.ts
@@ -8,6 +8,7 @@ import { IndexerStatus, IndexerStatusSnapshot } from './IndexerStatus';
 import { IndexerWorkerHost } from './IndexerWorkerHost';
 import { Dependency, SpiderConfig, IndexingProgressCallback, normalizePath, SpiderError } from './types';
 import { getLogger } from '../shared/logger';
+import { IGNORED_DIRECTORIES } from '../shared/constants';
 
 /** Logger instance for Spider */
 const log = getLogger('Spider');
@@ -17,7 +18,7 @@ const log = getLogger('Spider');
  */
 function isInNodeModules(filePath: string): boolean {
   const normalized = normalizePath(filePath);
-  return normalized.includes('/node_modules/') || normalized.includes('/node_modules');
+  return IGNORED_DIRECTORIES.some(dir => normalized.includes(`/${dir}/`) || normalized.includes(`/${dir}`));
 }
 
 import { SymbolAnalyzer } from './SymbolAnalyzer';

--- a/src/mcp/McpWorker.ts
+++ b/src/mcp/McpWorker.ts
@@ -63,6 +63,7 @@ import type {
 } from './types';
 import { enrichDependency, validateToolParams, validateFilePath } from './types';
 import { getLogger, getLogLevelFromEnv, loggerFactory } from '../shared/logger';
+import { SUPPORTED_FILE_EXTENSIONS } from '../shared/constants';
 
 // Configure log level from environment variable
 loggerFactory.setDefaultLevel(getLogLevelFromEnv('LOG_LEVEL'));
@@ -120,7 +121,7 @@ const FILE_CHANGE_DEBOUNCE_MS = 300;
 const pendingInvalidations = new Map<string, NodeJS.Timeout>();
 
 /** Extensions to watch for changes */
-const WATCHED_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx', '.vue', '.svelte', '.gql', '.graphql'];
+const WATCHED_EXTENSIONS = SUPPORTED_FILE_EXTENSIONS;
 
 // ============================================================================
 // Message Handling

--- a/src/mcp/McpWorker.ts
+++ b/src/mcp/McpWorker.ts
@@ -63,7 +63,7 @@ import type {
 } from './types';
 import { enrichDependency, validateToolParams, validateFilePath } from './types';
 import { getLogger, getLogLevelFromEnv, loggerFactory } from '../shared/logger';
-import { SUPPORTED_FILE_EXTENSIONS } from '../shared/constants';
+import { SUPPORTED_FILE_EXTENSIONS, IGNORED_DIRECTORIES } from '../shared/constants';
 
 // Configure log level from environment variable
 loggerFactory.setDefaultLevel(getLogLevelFromEnv('LOG_LEVEL'));
@@ -275,13 +275,7 @@ function setupFileWatcher(): void {
   try {
     fileWatcher = watch(globPattern, {
       ignored: [
-        '**/node_modules/**',
-        '**/.git/**',
-        '**/dist/**',
-        '**/build/**',
-        '**/coverage/**',
-        '**/.next/**',
-        '**/.nuxt/**',
+        ...IGNORED_DIRECTORIES.map(dir => `**/${dir}/**`),
       ],
       persistent: true,
       ignoreInitial: true, // Don't fire events for existing files

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -10,3 +10,14 @@ export const SUPPORTED_FILE_EXTENSIONS = [
     '.gql',
     '.graphql',
 ];
+
+export const IGNORED_DIRECTORIES = [
+    'node_modules',
+    '.git',
+    'dist',
+    'build',
+    'out',
+    'coverage',
+    '.next',
+    '.nuxt',
+];

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,12 @@
+export const SUPPORTED_FILE_EXTENSIONS = [
+    '.ts',
+    '.tsx',
+    '.js',
+    '.jsx',
+    '.vue',
+    '.svelte',
+    '.mjs',
+    '.cjs',
+    '.gql',
+    '.graphql',
+];

--- a/src/webview/utils/graphUtils.ts
+++ b/src/webview/utils/graphUtils.ts
@@ -1,4 +1,5 @@
 import { GraphData } from '../../shared/types';
+import { SUPPORTED_FILE_EXTENSIONS } from '../../shared/constants';
 
 /**
  * Extract filename from a full path
@@ -61,7 +62,7 @@ export const isExternalPackage = (path: string): boolean => {
     if (!path) return false;
     
     // Known file extensions = not external
-    const fileExtensions = ['.ts', '.tsx', '.js', '.jsx', '.vue', '.svelte', '.gql', '.graphql'];
+    const fileExtensions = SUPPORTED_FILE_EXTENSIONS;
     for (const ext of fileExtensions) {
         if (path.endsWith(ext)) return false;
     }


### PR DESCRIPTION
Define shared constants for supported file extensions to improve maintainability and consistency across the codebase. This change replaces hardcoded arrays with a single source of truth for file extensions.