### PR TITLE
Enable MCP server by default and streamline logger configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@eslint/js": "^9.39.2",
         "@playwright/test": "^1.57.0",
         "@types/mocha": "^10.0.10",
-        "@types/node": "^20.19.26",
+        "@types/node": "^20.19.27",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/vscode": "^1.96.0",
@@ -2332,9 +2332,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.26",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.26.tgz",
-      "integrity": "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==",
+      "version": "20.19.27",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+      "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@types/react-dom": "^19.2.3",
         "@types/vscode": "^1.96.0",
         "@vitest/coverage-v8": "^4.0.15",
+        "@vitest/ui": "^4.0.15",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.7.1",
         "esbuild": "^0.27.1",
@@ -1236,6 +1237,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@reactflow/background": {
       "version": "11.3.14",
@@ -2767,6 +2775,28 @@
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/ui": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.15.tgz",
+      "integrity": "sha512-sxSyJMaKp45zI0u+lHrPuZM1ZJQ8FaVD35k+UxVrha1yyvQ+TZuUYllUixwvQXlB7ixoDc7skf3lQPopZIvaQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.15",
+        "fflate": "^0.8.2",
+        "flatted": "^3.3.3",
+        "pathe": "^2.0.3",
+        "sirv": "^3.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.0.15"
       }
     },
     "node_modules/@vitest/utils": {
@@ -4959,6 +4989,13 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6845,6 +6882,16 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -8415,6 +8462,21 @@
         "simple-concat": "^1.0.0"
       }
     },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -8942,6 +9004,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/ts-api-utils": {

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/vscode": "^1.96.0",
     "@vitest/coverage-v8": "^4.0.15",
+    "@vitest/ui": "^4.0.15",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.7.1",
     "esbuild": "^0.27.1",

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
     "@eslint/js": "^9.39.2",
     "@playwright/test": "^1.57.0",
     "@types/mocha": "^10.0.10",
-    "@types/node": "^20.19.26",
+    "@types/node": "^20.19.27",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/vscode": "^1.96.0",

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
         },
         "graph-it-live.enableMcpServer": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable MCP (Model Context Protocol) server for LLM integration. When enabled, exposes dependency analysis tools to GitHub Copilot and other MCP-compatible AI assistants.",
           "markdownDescription": "Enable **MCP (Model Context Protocol)** server for LLM integration. When enabled, exposes dependency analysis tools to GitHub Copilot and other MCP-compatible AI assistants.\n\n[Learn more about MCP](https://code.visualstudio.com/api/extension-guides/ai/mcp)"
         },

--- a/src/mcp/McpWorker.ts
+++ b/src/mcp/McpWorker.ts
@@ -8,15 +8,6 @@
  * NO import * as vscode from 'vscode' allowed!
  */
 
-import { setLoggerBackend, StderrLogger } from '../shared/logger';
-
-// Configure all loggers in this thread to use StderrLogger
-setLoggerBackend({
-  createLogger(prefix: string, level) {
-    return new StderrLogger(prefix, level);
-  }
-});
-
 import { parentPort } from 'node:worker_threads';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
@@ -71,7 +62,14 @@ import type {
   ImpactedItem,
 } from './types';
 import { enrichDependency, validateToolParams, validateFilePath } from './types';
-import { getLogger, getLogLevelFromEnv, loggerFactory } from '../shared/logger';
+import { getLogger, getLogLevelFromEnv, loggerFactory, setLoggerBackend, StderrLogger } from '../shared/logger';
+
+// Configure all loggers in this thread to use StderrLogger
+setLoggerBackend({
+  createLogger(prefix: string, level) {
+    return new StderrLogger(prefix, level);
+  }
+});
 import { SUPPORTED_FILE_EXTENSIONS, IGNORED_DIRECTORIES } from '../shared/constants';
 
 // Configure log level from environment variable
@@ -283,9 +281,8 @@ function setupFileWatcher(): void {
 
   try {
     fileWatcher = watch(globPattern, {
-      ignored: [
-        ...IGNORED_DIRECTORIES.map(dir => `**/${dir}/**`),
-      ],
+      ignored: 
+        IGNORED_DIRECTORIES.map(dir => `**/${dir}/**`),
       persistent: true,
       ignoreInitial: true, // Don't fire events for existing files
       awaitWriteFinish: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -13,7 +13,7 @@ export default defineConfig({
     exclude: ["tests/benchmarks/**", "tests/vscode-e2e/**", "tests/e2e/**"],
     coverage: {
       provider: "v8",
-      reporter: ["text", "json", "html"],
+      reporter: ["text", "json", "html", "lcov"],
       include: ["src/**/*.ts"],
       //include: ['src/analyzer/**/*.ts', 'src/webview/**/*.ts', 'src/shared/**/*.ts', 'src/mcp/**/*.ts', 'src/extension/**/*.ts'],
       exclude: [


### PR DESCRIPTION
Enable the MCP server by default to enhance LLM integration and simplify the logger configuration in McpWorker for improved logging management.