### PR TITLE
Simultaneous call graph indexation and new MCP query tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Graph-It-Live includes an optional **MCP server** that exposes its full analysis
 
 ### Available Tools
 
-The MCP server exposes **20 tools** for AI/LLM consumption:
+The MCP server exposes **21 tools** for AI/LLM consumption:
 
 | Tool | Description |
 | :--- | :---------- |
@@ -374,6 +374,7 @@ The MCP server exposes **20 tools** for AI/LLM consumption:
 | `graphitlive_rebuild_index` | Rebuild the entire dependency index from scratch |
 | `graphitlive_analyze_file_logic` | Analyze symbol-level call hierarchy and code flow within a file |
 | `graphitlive_generate_codemap` | Generate a comprehensive structured overview of any source file |
+| `graphitlive_query_call_graph` | Query cross-file callers/callees via BFS on the call graph SQLite database |
 
 ### TOON Format (Token-Optimized Output)
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,13 @@
 - **Symbol View — Incoming dependencies**: The "← called by" section now shows **external callers** (symbols from other files that call into the current file). Previously only intra-file callers were displayed. `SymbolViewService` now analyses all referencing files and collects symbol-level incoming edges
 - **Symbol View — Cross-file callers via Call Graph**: When the call graph SQLite database is indexed, external callers discovered by tree-sitter analysis are merged into the symbol view's "← called by" section — providing broader coverage than Spider-only import analysis. Results are deduplicated against Spider-based incoming dependencies
 - **Symbol View — Intra-file call enrichment**: AST-based call edges (from `LspCallHierarchyAnalyzer`) and cycle detection data are now merged into the symbol tree, providing richer "→ calls" / "← called by" annotations even for internal symbols
+- **Simultaneous indexation**: Call graph pre-indexing now starts immediately alongside the reverse index on activation, removing the previous 2-second stagger. Both indexers are independent (different parsers, no shared resources), resulting in faster overall startup
+- **MCP tool: `graphitlive_query_call_graph`** (tool #21): New cross-file call graph query tool for AI/LLM agents. Query callers and callees of any symbol via BFS traversal on the sql.js SQLite call graph database. Features:
+  - Configurable direction (`callers`, `callees`, `both`) and depth (1–10)
+  - Filter by relation type (`CALLS`, `INHERITS`, `IMPLEMENTS`, `USES`)
+  - Lazy-initializes the call graph DB in the MCP worker on first invocation (transparent to users)
+  - Cycle detection and cross-file edge resolution
+  - Returns structured results with source/target file paths, line numbers, and relation metadata
 
 ### Bug Fixes
 
@@ -21,8 +28,8 @@
 
 ### Testing
 
-- 1517 unit tests + 90 E2E tests passing across 136 test files
-- New tests: symbol dedup for overloads, merged interfaces, containerName regression, incoming dependencies collection, error resilience for referencing file analysis, call graph enrichment (merge, dedup, not-indexed skip, error handling, exported-only filtering, method name collision false-positive rejection, valid export retention despite collision), ICallGraphQueryService contract tests
+- 1536 unit tests + 90 E2E tests passing across 137 test files
+- New tests: symbol dedup for overloads, merged interfaces, containerName regression, incoming dependencies collection, error resilience for referencing file analysis, call graph enrichment (merge, dedup, not-indexed skip, error handling, exported-only filtering, method name collision false-positive rejection, valid export retention despite collision), ICallGraphQueryService contract tests, QueryCallGraphParamsSchema validation (direction, depth bounds, relation type filters, path traversal), MCP call graph tool execution (symbol lookup, BFS callers/callees, direction/depth defaults, relation type filtering, metadata)
 
 ## v1.7.2
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graph-it-live",
   "displayName": "Graph-It-Live",
-  "description": "AI-first dependency graph & code intelligence for VS Code. Visualize file imports, symbol call hierarchies, and cross-file call graphs. Detect circular dependencies, dead code, and breaking changes. Built-in MCP Server with 20 tools for GitHub Copilot, Cursor, Claude, Windsurf, and Antigravity. Generate AI-friendly codemaps. TypeScript, JavaScript, Python, Rust, Vue, Svelte, GraphQL.",
+  "description": "AI-first dependency graph & code intelligence for VS Code. Visualize file imports, symbol call hierarchies, and cross-file call graphs. Detect circular dependencies, dead code, and breaking changes. Built-in MCP Server with 21 tools for GitHub Copilot, Cursor, Claude, Windsurf, and Antigravity. Generate AI-friendly codemaps. TypeScript, JavaScript, Python, Rust, Vue, Svelte, GraphQL.",
   "version": "0.0.1",
   "publisher": "magic5644",
   "author": {

--- a/scripts/test-mcp.js
+++ b/scripts/test-mcp.js
@@ -35,6 +35,7 @@ const server = spawn('node', [serverPath], { //NOSONAR
   env: {
     ...process.env,
     WORKSPACE_ROOT: path.join(rootDir, 'tests/fixtures/sample-project'),
+    EXTENSION_PATH: rootDir,
   },
   stdio: ['pipe', 'pipe', 'pipe'],
 });
@@ -764,6 +765,104 @@ export function add(a: number, b: number): number {
       arguments: {
         filePath: '/non/existent/codemap-target.ts',
         format: 'json'
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 500));
+
+  // =========================================================================
+  // 32. graphitlive_query_call_graph — callees of a known symbol
+  // =========================================================================
+  log('\n📤 [graphitlive_query_call_graph] Querying callees of main function...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_query_call_graph',
+      arguments: {
+        filePath: path.join(fixturesPath, 'main.ts'),
+        symbolName: 'main',
+        direction: 'callees',
+        depth: 3
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 2000)); // First call triggers indexing
+
+  // =========================================================================
+  // 33. graphitlive_query_call_graph — callers of a symbol
+  // =========================================================================
+  log('\n📤 [graphitlive_query_call_graph] Querying callers of greet function...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_query_call_graph',
+      arguments: {
+        filePath: path.join(fixturesPath, 'utils.ts'),
+        symbolName: 'greet',
+        direction: 'callers',
+        depth: 2
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 500));
+
+  // =========================================================================
+  // 34. graphitlive_query_call_graph — both directions (default)
+  // =========================================================================
+  log('\n📤 [graphitlive_query_call_graph] Querying both directions for greet...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_query_call_graph',
+      arguments: {
+        filePath: path.join(fixturesPath, 'utils.ts'),
+        symbolName: 'greet'
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 500));
+
+  // =========================================================================
+  // 35. graphitlive_query_call_graph — non-existent symbol
+  // =========================================================================
+  log('\n📤 [graphitlive_query_call_graph] Testing non-existent symbol...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_query_call_graph',
+      arguments: {
+        filePath: path.join(fixturesPath, 'utils.ts'),
+        symbolName: 'nonExistentFunction',
+        direction: 'both'
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 500));
+
+  // =========================================================================
+  // 36. graphitlive_query_call_graph — with relation type filter
+  // =========================================================================
+  log('\n📤 [graphitlive_query_call_graph] Querying with CALLS relation filter...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_query_call_graph',
+      arguments: {
+        filePath: path.join(fixturesPath, 'main.ts'),
+        symbolName: 'main',
+        direction: 'callees',
+        depth: 2,
+        relationTypes: ['CALLS']
       }
     }
   });

--- a/src/extension/GraphProvider.ts
+++ b/src/extension/GraphProvider.ts
@@ -851,17 +851,15 @@ export class GraphProvider implements vscode.WebviewViewProvider {
     // Schedule deferred indexing now that view is ready
     this.indexingManager?.scheduleDeferredIndexing();
 
-    // Pre-index call graph in background, independent of the reverse-index lifecycle.
-    // Delayed 2 s so it doesn't compete with the initial graph render.
+    // Pre-index call graph in background, alongside the reverse-index lifecycle.
+    // Both indexers are independent (different parsers, no shared resources).
     const config = vscode.workspace.getConfiguration("graph-it-live");
     if (config.get<boolean>("preIndexCallGraph", true)) {
       const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
       if (workspaceRoot && this._callGraphViewService) {
-        setTimeout(() => {
-          this._callGraphViewService
-            ?.indexWorkspaceIfNeeded(workspaceRoot)
-            .catch(() => { /* best-effort */ });
-        }, 2000);
+        this._callGraphViewService
+          .indexWorkspaceIfNeeded(workspaceRoot)
+          .catch(() => { /* best-effort */ });
       }
     }
 

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -137,6 +137,7 @@ import {
   type PaginationInfo,
   ParseImportsParamsSchema,
   type ParseImportsResult,
+  QueryCallGraphParamsSchema,
   type RebuildIndexResult,
   ResolveModulePathParamsSchema,
   type ResolveModulePathResult,
@@ -1705,6 +1706,68 @@ Supported languages: TypeScript, JavaScript, Python, Rust, Vue, Svelte`,
     const response = await invokeToolWithResponse("generate_codemap", {
       filePath,
     });
+
+    return formatToolResponse(response, responseFormat);
+  },
+);
+
+// Tool: graphitlive_query_call_graph
+server.registerTool(
+  "graphitlive_query_call_graph",
+  {
+    title: "Query Cross-File Call Graph",
+    description: `CRITICAL: USE THIS TOOL WHEN the user wants to trace function calls across multiple files — "who calls X?" or "what does X call?" at the call-graph level.
+
+WHEN TO USE:
+- User asks "Who calls this function from other files?"
+- User asks "What functions does this method call?"
+- User needs cross-file call chain analysis (not just imports)
+- User wants to trace execution flow across the entire codebase
+- Pre-refactoring impact analysis at function-call level
+- Detecting circular call chains across modules
+
+EXAMPLES:
+- "Trace all callers of handleRequest across the codebase"
+- "What functions does processOrder call, recursively?"
+- "Show me the full call chain for authenticate — 3 levels deep"
+- "Find circular call dependencies involving parseConfig"
+
+WHY YOU NEED THIS:
+Unlike graphitlive_get_symbol_callers (which uses import-level reverse dependencies), this tool uses a **SQLite-backed call graph** built from tree-sitter AST analysis.
+It provides actual function-call relationships (CALLS, INHERITS, IMPLEMENTS, USES), not just import statements.
+This answers "which specific function calls my function at runtime?" with cross-file resolution.
+
+First invocation indexes the entire workspace (3-8s). Subsequent queries are instant.
+
+RETURNS:
+- symbol: The matched symbol (name, type, file, line)
+- callers: Functions that call this symbol (with file, line, relation type)
+- callees: Functions called by this symbol (with file, line, relation type)
+- Cycle detection (isCyclic flag on edges)
+- indexedFiles: Number of files in the call graph index`,
+    inputSchema: QueryCallGraphParamsSchema.extend({
+      response_format: ResponseFormatSchema.describe(
+        "Output format: 'json', 'markdown', or 'toon' (default: toon - RECOMMENDED for 30-60% token savings)",
+      ),
+    }),
+    outputSchema: McpToolResponseSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async ({ filePath, symbolName, direction, depth, relationTypes, response_format }) => {
+    const workerCheck = await ensureWorkerReady();
+    const responseFormat = response_format ?? "toon";
+    if (workerCheck.error)
+      return formatToolResponse(workerCheck.response, responseFormat);
+
+    const response = await invokeToolWithResponse(
+      "query_call_graph",
+      { filePath, symbolName, direction, depth, relationTypes },
+    );
 
     return formatToolResponse(response, responseFormat);
   },

--- a/src/mcp/shared/state.ts
+++ b/src/mcp/shared/state.ts
@@ -9,6 +9,8 @@
 
 import type { FSWatcher } from "chokidar";
 import type { AstWorkerHost } from "../../analyzer/ast/AstWorkerHost";
+import type { CallGraphIndexer } from "../../analyzer/callgraph/CallGraphIndexer";
+import type { GraphExtractor } from "../../analyzer/callgraph/GraphExtractor";
 import type { Parser } from "../../analyzer/Parser";
 import type { Spider } from "../../analyzer/Spider";
 import type { SymbolReverseIndex } from "../../analyzer/SymbolReverseIndex";
@@ -40,6 +42,9 @@ export class WorkerState {
   };
   private _fileWatcher: FSWatcher | null = null;
     private readonly _pendingInvalidations = new Map<string, NodeJS.Timeout>();
+  private _callGraphIndexer: CallGraphIndexer | null = null;
+  private _graphExtractor: GraphExtractor | null = null;
+  private _callGraphIndexedRoot: string | null = null;
 
   // ============================================================================
   // Core Components
@@ -83,6 +88,34 @@ export class WorkerState {
 
   set symbolReverseIndex(value: SymbolReverseIndex | null) {
     this._symbolReverseIndex = value;
+  }
+
+  // ============================================================================
+  // Call Graph Components
+  // ============================================================================
+
+  get callGraphIndexer(): CallGraphIndexer | null {
+    return this._callGraphIndexer;
+  }
+
+  set callGraphIndexer(value: CallGraphIndexer | null) {
+    this._callGraphIndexer = value;
+  }
+
+  get graphExtractor(): GraphExtractor | null {
+    return this._graphExtractor;
+  }
+
+  set graphExtractor(value: GraphExtractor | null) {
+    this._graphExtractor = value;
+  }
+
+  get callGraphIndexedRoot(): string | null {
+    return this._callGraphIndexedRoot;
+  }
+
+  set callGraphIndexedRoot(value: string | null) {
+    this._callGraphIndexedRoot = value;
   }
 
   // ============================================================================
@@ -226,6 +259,17 @@ export class WorkerState {
 
     this._symbolReverseIndex = null;
 
+    // Dispose call graph resources
+    if (this._graphExtractor) {
+      this._graphExtractor.dispose();
+      this._graphExtractor = null;
+    }
+    if (this._callGraphIndexer) {
+      this._callGraphIndexer.dispose();
+      this._callGraphIndexer = null;
+    }
+    this._callGraphIndexedRoot = null;
+
     // Clear components
     this._spider = null;
     this._parser = null;
@@ -249,6 +293,8 @@ export class WorkerState {
     warmupCompleted: boolean;
     hasFileWatcher: boolean;
     pendingInvalidationCount: number;
+    hasCallGraphIndexer: boolean;
+    callGraphIndexedRoot: string | null;
   } {
     return {
       isReady: this._isReady,
@@ -261,6 +307,8 @@ export class WorkerState {
       warmupCompleted: this._warmupInfo.completed,
       hasFileWatcher: this._fileWatcher !== null,
       pendingInvalidationCount: this._pendingInvalidations.size,
+      hasCallGraphIndexer: this._callGraphIndexer !== null,
+      callGraphIndexedRoot: this._callGraphIndexedRoot,
     };
   }
 }

--- a/src/mcp/shared/state.ts
+++ b/src/mcp/shared/state.ts
@@ -192,7 +192,10 @@ export class WorkerState {
    */
   getSpider(): Spider {
     this.requireReady();
-    return this._spider!;
+    // requireReady() guarantees non-null; local alias helps TS narrow
+    const spider = this._spider;
+    if (!spider) throw new Error("Spider not available after requireReady()");
+    return spider;
   }
 
   /**
@@ -200,7 +203,9 @@ export class WorkerState {
    */
   getParser(): Parser {
     this.requireReady();
-    return this._parser!;
+    const parser = this._parser;
+    if (!parser) throw new Error("Parser not available after requireReady()");
+    return parser;
   }
 
   /**
@@ -208,7 +213,9 @@ export class WorkerState {
    */
   getResolver(): PathResolver {
     this.requireReady();
-    return this._resolver!;
+    const resolver = this._resolver;
+    if (!resolver) throw new Error("Resolver not available after requireReady()");
+    return resolver;
   }
 
   /**

--- a/src/mcp/tools/callgraph.ts
+++ b/src/mcp/tools/callgraph.ts
@@ -1,0 +1,369 @@
+/**
+ * MCP Call Graph Tool — Cross-file call graph queries via SQLite.
+ *
+ * Lazy-initializes a CallGraphIndexer + GraphExtractor on first invocation,
+ * indexes the entire workspace, then answers callers/callees/neighbourhood
+ * queries against the in-memory sql.js database.
+ *
+ * NO vscode imports — this module is VS Code agnostic.
+ */
+
+import { CallGraphIndexer } from "@/analyzer/callgraph/CallGraphIndexer";
+import type { CallGraphEdge } from "@/analyzer/callgraph/CallGraphIndexer";
+import { detectCycleEdges } from "@/analyzer/callgraph/cycleUtils";
+import { fileExtToLang, GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
+import type { ExtractorConfig } from "@/analyzer/callgraph/GraphExtractor";
+import { SourceFileCollector } from "@/analyzer/SourceFileCollector";
+import type { RelationType } from "@/shared/callgraph-types";
+import { getLogger } from "@/shared/logger";
+import { normalizePath } from "@/shared/path";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { workerState } from "../shared/state";
+import type { QueryCallGraphParams } from "../types";
+
+const log = getLogger("McpCallGraph");
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+interface CallGraphSymbol {
+  id: string;
+  name: string;
+  type: string;
+  lang: string;
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  isExported: boolean;
+}
+
+interface CallGraphRelation {
+  sourceId: string;
+  sourceName: string;
+  sourceFile: string;
+  targetId: string;
+  targetName: string;
+  targetFile: string;
+  relation: string;
+  sourceLine: number;
+  isCyclic: boolean;
+}
+
+export interface QueryCallGraphResult {
+  symbol: CallGraphSymbol | null;
+  callers: CallGraphRelation[];
+  callees: CallGraphRelation[];
+  totalCallers: number;
+  totalCallees: number;
+  depth: number;
+  direction: string;
+  indexedFiles: number;
+  indexTimeMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy initialization
+// ---------------------------------------------------------------------------
+
+let indexPromise: Promise<void> | null = null;
+
+async function ensureCallGraphReady(): Promise<void> {
+  const config = workerState.getConfig();
+  const workspaceRoot = config.rootDir;
+
+  // Already indexed for this workspace
+  if (
+    workerState.callGraphIndexer &&
+    workerState.callGraphIndexedRoot === workspaceRoot
+  ) {
+    return;
+  }
+
+  // Avoid duplicate indexing
+  if (indexPromise !== null) return indexPromise;
+
+  indexPromise = doInitAndIndex(config.extensionPath, workspaceRoot);
+  try {
+    await indexPromise;
+  } finally {
+    indexPromise = null;
+  }
+}
+
+async function doInitAndIndex(
+  extensionPath: string | undefined,
+  workspaceRoot: string,
+): Promise<void> {
+  if (!extensionPath) {
+    throw new Error("extensionPath required for call graph WASM parsers");
+  }
+
+  const startTime = Date.now();
+
+  // Initialize CallGraphIndexer (sql.js WASM)
+  const wasmPath = path.join(extensionPath, "dist", "wasm", "sqljs.wasm");
+  await fs.access(wasmPath); // fail fast if missing
+  const indexer = new CallGraphIndexer(wasmPath);
+  await indexer.init();
+
+  // Initialize GraphExtractor (tree-sitter WASM)
+  const extractorConfig: ExtractorConfig = {
+    extensionPath,
+    workspaceRoot,
+  };
+  const extractor = new GraphExtractor(extractorConfig);
+
+  // Collect source files
+  const collector = new SourceFileCollector({
+    excludeNodeModules: true,
+    yieldIntervalMs: 30,
+    isCancelled: () => false,
+  });
+  const allFiles = await collector.collectAllSourceFiles(workspaceRoot);
+  const callgraphFiles = allFiles
+    .map(normalizePath)
+    .filter((f) => fileExtToLang(f) !== null);
+
+  log.info(`Indexing ${callgraphFiles.length} files for call graph…`);
+
+  // Extract + index all files in batches
+  const allEdges: CallGraphEdge[] = [];
+  indexer.beginBatch();
+  try {
+    for (const filePath of callgraphFiles) {
+      const lang = fileExtToLang(filePath);
+      if (!lang) continue;
+      try {
+        const stat = await fs.stat(filePath);
+        const result = await extractor.extractFile(filePath, lang, stat.mtimeMs);
+        if (result.nodes.length > 0) {
+          indexer.indexFile(result.nodes, result.edges, filePath, lang, stat.mtimeMs);
+          allEdges.push(...result.edges);
+        }
+      } catch {
+        // Skip files that fail to parse (binary files, encoding issues, etc.)
+      }
+    }
+    indexer.commitBatch();
+  } catch (err) {
+    indexer.rollbackBatch();
+    throw err;
+  }
+
+  // Cycle detection
+  const nonUsesEdges = allEdges
+    .filter((e) => e.typeRelation !== "USES")
+    .map((e) => ({ source: e.sourceId, target: e.targetId }));
+  if (nonUsesEdges.length > 0) {
+    const cycleEdgeKeys = detectCycleEdges(nonUsesEdges);
+    const cyclicPairs = allEdges.filter((e) =>
+      cycleEdgeKeys.has(`${e.sourceId}->${e.targetId}`),
+    );
+    if (cyclicPairs.length > 0) {
+      indexer.markCycles(
+        cyclicPairs.map((e) => ({ sourceId: e.sourceId, targetId: e.targetId })),
+      );
+    }
+  }
+
+  // Resolve cross-file edges
+  const resolveStats = indexer.resolveExternalEdges();
+  log.info(
+    `Cross-file resolution: resolved=${resolveStats.resolved} unresolved=${resolveStats.deleted}`,
+  );
+
+  // Dispose any previous instances
+  if (workerState.graphExtractor) workerState.graphExtractor.dispose();
+  if (workerState.callGraphIndexer) workerState.callGraphIndexer.dispose();
+
+  // Store in worker state
+  workerState.callGraphIndexer = indexer;
+  workerState.graphExtractor = extractor;
+  workerState.callGraphIndexedRoot = workspaceRoot;
+
+  const duration = Date.now() - startTime;
+  log.info(`Call graph indexed ${callgraphFiles.length} files in ${duration}ms`);
+}
+
+// ---------------------------------------------------------------------------
+// Tool execution
+// ---------------------------------------------------------------------------
+
+export async function executeQueryCallGraph(
+  params: QueryCallGraphParams,
+): Promise<QueryCallGraphResult> {
+  const startTime = Date.now();
+  await ensureCallGraphReady();
+
+  const indexer = workerState.callGraphIndexer;
+  if (!indexer) {
+    throw new Error("Call graph indexer not initialized");
+  }
+  const db = indexer.getDb();
+  const indexTimeMs = Date.now() - startTime;
+
+  const normalizedPath = normalizePath(params.filePath);
+  const direction = params.direction ?? "both";
+  const depth = params.depth ?? 2;
+  const relationFilter = params.relationTypes ?? null;
+
+  // Find matching symbol nodes
+  const symbolRows = db.exec(
+    "SELECT id, name, type, lang, path, start_line, end_line, is_exported FROM nodes WHERE path = ? AND name = ?",
+    [normalizedPath, params.symbolName],
+  );
+
+  if (!symbolRows[0] || symbolRows[0].values.length === 0) {
+    return {
+      symbol: null,
+      callers: [],
+      callees: [],
+      totalCallers: 0,
+      totalCallees: 0,
+      depth,
+      direction,
+      indexedFiles: countIndexedFiles(db),
+      indexTimeMs,
+    };
+  }
+
+  // Use the first matching symbol (most specific would require line info)
+  const row = symbolRows[0].values[0];
+  const symbolId = row[0] as string;
+  const symbol: CallGraphSymbol = {
+    id: symbolId,
+    name: row[1] as string,
+    type: row[2] as string,
+    lang: row[3] as string,
+    filePath: row[4] as string,
+    startLine: row[5] as number,
+    endLine: row[6] as number,
+    isExported: (row[7] as number) === 1,
+  };
+
+  // BFS callers (who calls this symbol?)
+  let callers: CallGraphRelation[] = [];
+  if (direction === "callers" || direction === "both") {
+    callers = bfsRelations(db, symbolId, "callers", depth, relationFilter);
+  }
+
+  // BFS callees (what does this symbol call?)
+  let callees: CallGraphRelation[] = [];
+  if (direction === "callees" || direction === "both") {
+    callees = bfsRelations(db, symbolId, "callees", depth, relationFilter);
+  }
+
+  return {
+    symbol,
+    callers,
+    callees,
+    totalCallers: callers.length,
+    totalCallees: callees.length,
+    depth,
+    direction,
+    indexedFiles: countIndexedFiles(db),
+    indexTimeMs,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// BFS traversal helpers
+// ---------------------------------------------------------------------------
+
+function bfsRelations(
+  db: import("sql.js").Database,
+  rootId: string,
+  dir: "callers" | "callees",
+  maxDepth: number,
+  relationFilter: RelationType[] | null,
+): CallGraphRelation[] {
+  const visited = new Set<string>();
+  const results: CallGraphRelation[] = [];
+  let frontier = new Set<string>([rootId]);
+
+  for (let d = 0; d < maxDepth && frontier.size > 0; d++) {
+    const nextFrontier = new Set<string>();
+    for (const nodeId of frontier) {
+      if (visited.has(nodeId)) continue;
+      visited.add(nodeId);
+      expandNode(db, nodeId, dir, relationFilter, results, visited, nextFrontier);
+    }
+    frontier = nextFrontier;
+  }
+
+  return results;
+}
+
+function expandNode(
+  db: import("sql.js").Database,
+  nodeId: string,
+  dir: "callers" | "callees",
+  relationFilter: RelationType[] | null,
+  results: CallGraphRelation[],
+  visited: Set<string>,
+  nextFrontier: Set<string>,
+): void {
+  const edges = queryEdges(db, nodeId, dir, relationFilter);
+  for (const edge of edges) {
+    results.push(edge);
+    const nextId = dir === "callers" ? edge.sourceId : edge.targetId;
+    if (!visited.has(nextId)) {
+      nextFrontier.add(nextId);
+    }
+  }
+}
+
+function queryEdges(
+  db: import("sql.js").Database,
+  nodeId: string,
+  dir: "callers" | "callees",
+  relationFilter: RelationType[] | null,
+): CallGraphRelation[] {
+  // Build query based on direction
+  const isCallers = dir === "callers";
+  const joinCol = isCallers ? "e.target_id" : "e.source_id";
+  const otherCol = isCallers ? "e.source_id" : "e.target_id";
+
+  let sql = `
+    SELECT e.source_id, e.target_id, e.type_relation, e.is_cyclic, e.source_line,
+           src.name AS src_name, src.path AS src_path,
+           tgt.name AS tgt_name, tgt.path AS tgt_path
+    FROM edges e
+    JOIN nodes src ON src.id = e.source_id
+    JOIN nodes tgt ON tgt.id = e.target_id
+    WHERE ${joinCol} = ?`;
+
+  const sqlParams: (string | number)[] = [nodeId];
+
+  if (relationFilter && relationFilter.length > 0) {
+    const placeholders = relationFilter.map(() => "?").join(",");
+    sql += ` AND e.type_relation IN (${placeholders})`;
+    sqlParams.push(...relationFilter);
+  }
+
+  // Skip edges pointing at unresolved external stubs
+  sql += ` AND ${otherCol} NOT LIKE '@@external:%'`;
+
+  const rows = db.exec(sql, sqlParams);
+  if (!rows[0]) return [];
+
+  return rows[0].values.map((r) => ({
+    sourceId: r[0] as string,
+    targetId: r[1] as string,
+    relation: r[2] as string,
+    isCyclic: (r[3] as number) === 1,
+    sourceLine: r[4] as number,
+    sourceName: r[5] as string,
+    sourceFile: r[6] as string,
+    targetName: r[7] as string,
+    targetFile: r[8] as string,
+  }));
+}
+
+function countIndexedFiles(db: import("sql.js").Database): number {
+  const result = db.exec("SELECT COUNT(*) FROM file_index");
+  if (!result[0]) return 0;
+  return result[0].values[0][0] as number;
+}

--- a/src/mcp/tools/callgraph.ts
+++ b/src/mcp/tools/callgraph.ts
@@ -8,11 +8,11 @@
  * NO vscode imports — this module is VS Code agnostic.
  */
 
-import { CallGraphIndexer } from "@/analyzer/callgraph/CallGraphIndexer";
 import type { CallGraphEdge } from "@/analyzer/callgraph/CallGraphIndexer";
+import { CallGraphIndexer } from "@/analyzer/callgraph/CallGraphIndexer";
 import { detectCycleEdges } from "@/analyzer/callgraph/cycleUtils";
-import { fileExtToLang, GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
 import type { ExtractorConfig } from "@/analyzer/callgraph/GraphExtractor";
+import { fileExtToLang, GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
 import { SourceFileCollector } from "@/analyzer/SourceFileCollector";
 import type { RelationType } from "@/shared/callgraph-types";
 import { getLogger } from "@/shared/logger";

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -4,6 +4,9 @@ export {
     executeVerifyDependencyUsage
 } from "./analysis";
 export {
+    executeQueryCallGraph
+} from "./callgraph";
+export {
     executeGenerateCodemap
 } from "./codemap";
 export {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -12,8 +12,8 @@ import * as nodePath from "node:path";
 import { z } from "zod/v4";
 import type { Dependency } from "../analyzer/types";
 import {
-    getRelativePath as _getRelativePath,
-    normalizePathForComparison as _normalizePathForComparison,
+  getRelativePath as _getRelativePath,
+  normalizePathForComparison as _normalizePathForComparison,
 } from "../shared/path";
 
 // ============================================================================

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -105,7 +105,8 @@ export type McpToolName =
   | "analyze_breaking_changes" // NEW: Detect breaking changes
   | "get_impact_analysis" // NEW: Full impact analysis
   | "analyze_file_logic" // NEW: LSP-based intra-file call hierarchy
-  | "generate_codemap"; // NEW: Full codemap generation for a single file
+  | "generate_codemap" // NEW: Full codemap generation for a single file
+  | "query_call_graph"; // NEW: Cross-file call graph query (callers/callees via SQLite)
 
 // ============================================================================
 // Zod Schemas for Tool Parameters
@@ -475,6 +476,34 @@ export type GenerateCodemapParams = z.infer<
   typeof GenerateCodemapParamsSchema
 >;
 
+// NEW: Schema for query_call_graph (cross-file call graph query)
+export const QueryCallGraphParamsSchema = z.object({
+  filePath: FilePathSchema.describe(
+    "Absolute path to the file containing the target symbol.",
+  ),
+  symbolName: SymbolNameSchema.describe(
+    "Name of the symbol to query (function, class, method).",
+  ),
+  direction: z
+    .enum(["callers", "callees", "both"])
+    .optional()
+    .describe("Direction of traversal: 'callers', 'callees', or 'both' (default: 'both')"),
+  depth: z
+    .number()
+    .min(1)
+    .max(10)
+    .optional()
+    .describe("Maximum BFS traversal depth (default: 2, min: 1, max: 10)"),
+  relationTypes: z
+    .array(z.enum(["CALLS", "INHERITS", "IMPLEMENTS", "USES"]))
+    .optional()
+    .describe("Filter by relation types (default: all)"),
+  format: OutputFormatSchema.optional(),
+});
+export type QueryCallGraphParams = z.infer<
+  typeof QueryCallGraphParamsSchema
+>;
+
 // ============================================================================
 // Validation Utilities
 // ============================================================================
@@ -503,6 +532,7 @@ export const toolSchemas: Record<McpToolName, z.ZodType<unknown>> = {
   get_impact_analysis: GetImpactAnalysisParamsSchema,
   analyze_file_logic: AnalyzeFileLogicParamsSchema,
   generate_codemap: GenerateCodemapParamsSchema,
+  query_call_graph: QueryCallGraphParamsSchema,
 };
 
 /**

--- a/src/mcp/worker/invokeTool.ts
+++ b/src/mcp/worker/invokeTool.ts
@@ -15,6 +15,7 @@ import {
   executeGetSymbolGraph,
   executeInvalidateFiles,
   executeParseImports,
+  executeQueryCallGraph,
   executeRebuildIndex,
   executeResolveModulePath,
   executeTraceFunctionExecution,
@@ -37,6 +38,7 @@ import type {
   McpToolName,
   McpWorkerResponse,
   ParseImportsParams,
+  QueryCallGraphParams,
   ResolveModulePathParams,
   TraceFunctionExecutionParams,
   VerifyDependencyUsageParams,
@@ -197,6 +199,12 @@ export async function invokeTool(
         const p = validatedParams as GenerateCodemapParams;
         validateFilePath(p.filePath, config.rootDir);
         result = await executeGenerateCodemap(p);
+        break;
+      }
+      case "query_call_graph": {
+        const p = validatedParams as QueryCallGraphParams;
+        validateFilePath(p.filePath, config.rootDir);
+        result = await executeQueryCallGraph(p);
         break;
       }
       default:

--- a/tests/mcp/shared/state.test.ts
+++ b/tests/mcp/shared/state.test.ts
@@ -288,6 +288,8 @@ describe("WorkerState", () => {
         warmupCompleted: false,
         hasFileWatcher: false,
         pendingInvalidationCount: 0,
+        hasCallGraphIndexer: false,
+        callGraphIndexedRoot: null,
       });
     });
 
@@ -315,6 +317,8 @@ describe("WorkerState", () => {
         warmupCompleted: true,
         hasFileWatcher: true,
         pendingInvalidationCount: 1,
+        hasCallGraphIndexer: false,
+        callGraphIndexedRoot: null,
       });
 
       // Cleanup

--- a/tests/mcp/tools/callgraph.test.ts
+++ b/tests/mcp/tools/callgraph.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for the MCP call graph tool (executeQueryCallGraph).
+ *
+ * Seeds a real sql.js CallGraphIndexer with test data, injects it into
+ * workerState, then exercises the BFS query logic.
+ */
+
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+    CallGraphIndexer,
+    type CallGraphEdge,
+    type CallGraphNode,
+} from "../../../src/analyzer/callgraph/CallGraphIndexer";
+import { workerState } from "../../../src/mcp/shared/state";
+import { executeQueryCallGraph } from "../../../src/mcp/tools/callgraph";
+import type { SupportedLang } from "../../../src/shared/callgraph-types";
+
+// ---------------------------------------------------------------------------
+// sql.js WASM path (real WASM from node_modules)
+// ---------------------------------------------------------------------------
+
+const SQL_WASM_PATH = path.join(
+  process.cwd(),
+  "node_modules",
+  "sql.js",
+  "dist",
+  "sql-wasm.wasm",
+);
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const FILE_A = "/workspace/src/a.ts";
+const FILE_B = "/workspace/src/b.ts";
+
+function node(
+  filePath: string,
+  name: string,
+  line: number,
+  overrides: Partial<CallGraphNode> = {},
+): CallGraphNode {
+  return {
+    id: `${filePath}:${name}:${line}`,
+    name,
+    type: "function",
+    lang: "typescript" as SupportedLang,
+    path: filePath,
+    folder: path.dirname(filePath),
+    startLine: line,
+    endLine: line + 5,
+    startCol: 0,
+    isExported: true,
+    ...overrides,
+  };
+}
+
+function edge(
+  source: CallGraphNode,
+  target: CallGraphNode,
+  relation: string = "CALLS",
+): CallGraphEdge {
+  return {
+    sourceId: source.id,
+    targetId: target.id,
+    typeRelation: relation,
+    sourceLine: source.startLine,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("executeQueryCallGraph", () => {
+  let indexer: CallGraphIndexer;
+
+  // Shared test symbols
+  const fnMain = node(FILE_A, "main", 1);
+  const fnHelper = node(FILE_A, "helper", 10);
+  const fnProcess = node(FILE_B, "process", 1);
+  const fnFormat = node(FILE_B, "format", 20);
+
+  beforeEach(async () => {
+    indexer = new CallGraphIndexer(SQL_WASM_PATH);
+    await indexer.init();
+
+    // Seed: main → helper, main → process, process → format
+    const nodesA = [fnMain, fnHelper];
+    const edgesA: CallGraphEdge[] = [
+      edge(fnMain, fnHelper),
+      edge(fnMain, fnProcess),
+    ];
+    indexer.indexFile(nodesA, edgesA, FILE_A, "typescript", Date.now());
+
+    const nodesB = [fnProcess, fnFormat];
+    const edgesB: CallGraphEdge[] = [edge(fnProcess, fnFormat)];
+    indexer.indexFile(nodesB, edgesB, FILE_B, "typescript", Date.now());
+
+    // Inject into workerState
+    workerState.callGraphIndexer = indexer;
+    workerState.callGraphIndexedRoot = "/workspace";
+    workerState.config = {
+      rootDir: "/workspace",
+      excludeNodeModules: true,
+      maxDepth: 10,
+    };
+    workerState.isReady = true;
+  });
+
+  afterEach(() => {
+    workerState.reset();
+  });
+
+  // -------------------------------------------------------------------------
+  // Symbol lookup
+  // -------------------------------------------------------------------------
+
+  it("returns null symbol when not found", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_A,
+      symbolName: "nonExistent",
+    });
+
+    expect(result.symbol).toBeNull();
+    expect(result.callers).toHaveLength(0);
+    expect(result.callees).toHaveLength(0);
+    expect(result.indexedFiles).toBeGreaterThanOrEqual(0);
+  });
+
+  it("finds a symbol by filePath + symbolName", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_A,
+      symbolName: "main",
+    });
+
+    expect(result.symbol).not.toBeNull();
+    expect(result.symbol?.name).toBe("main");
+    expect(result.symbol?.filePath).toBe(FILE_A);
+  });
+
+  // -------------------------------------------------------------------------
+  // Direction: callees
+  // -------------------------------------------------------------------------
+
+  it("returns callees at depth 1", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_A,
+      symbolName: "main",
+      direction: "callees",
+      depth: 1,
+    });
+
+    expect(result.callees.length).toBeGreaterThanOrEqual(1);
+    const targetNames = result.callees.map((c) => c.targetName);
+    expect(targetNames).toContain("helper");
+    expect(result.callers).toHaveLength(0); // only callees requested
+  });
+
+  it("returns deeper callees at depth 2", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_A,
+      symbolName: "main",
+      direction: "callees",
+      depth: 2,
+    });
+
+    const targetNames = result.callees.map((c) => c.targetName);
+    // depth 2: main → helper + process (depth 1) → format (depth 2)
+    expect(targetNames).toContain("format");
+  });
+
+  // -------------------------------------------------------------------------
+  // Direction: callers
+  // -------------------------------------------------------------------------
+
+  it("returns callers of helper", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_A,
+      symbolName: "helper",
+      direction: "callers",
+      depth: 1,
+    });
+
+    expect(result.callers.length).toBeGreaterThanOrEqual(1);
+    const sourceNames = result.callers.map((c) => c.sourceName);
+    expect(sourceNames).toContain("main");
+    expect(result.callees).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Direction: both
+  // -------------------------------------------------------------------------
+
+  it("returns both callers and callees", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_B,
+      symbolName: "process",
+      direction: "both",
+      depth: 1,
+    });
+
+    // process is called by main, and calls format
+    const callerNames = result.callers.map((c) => c.sourceName);
+    const calleeNames = result.callees.map((c) => c.targetName);
+    expect(callerNames).toContain("main");
+    expect(calleeNames).toContain("format");
+  });
+
+  // -------------------------------------------------------------------------
+  // Defaults
+  // -------------------------------------------------------------------------
+
+  it("defaults to direction='both' and depth=2", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_A,
+      symbolName: "main",
+    });
+
+    expect(result.direction).toBe("both");
+    expect(result.depth).toBe(2);
+    // Should have callees (helper, process, format at depth 2)
+    expect(result.callees.length).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Relation type filter
+  // -------------------------------------------------------------------------
+
+  it("filters by relation type", async () => {
+    // Add an INHERITS edge: fnFormat INHERITS fnHelper
+    const db = indexer.getDb();
+    db.run(
+      "INSERT INTO edges (source_id, target_id, type_relation, source_line, is_cyclic, indexed_at) VALUES (?, ?, ?, ?, 0, ?)",
+      [fnFormat.id, fnHelper.id, "INHERITS", 20, Date.now()],
+    );
+
+    // Query only INHERITS
+    const result = await executeQueryCallGraph({
+      filePath: FILE_B,
+      symbolName: "format",
+      direction: "callees",
+      depth: 1,
+      relationTypes: ["INHERITS"],
+    });
+
+    expect(result.callees.length).toBeGreaterThanOrEqual(1);
+    for (const edge of result.callees) {
+      expect(edge.relation).toBe("INHERITS");
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Metadata
+  // -------------------------------------------------------------------------
+
+  it("returns indexedFiles and indexTimeMs", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_A,
+      symbolName: "main",
+    });
+
+    expect(result.indexedFiles).toBeGreaterThanOrEqual(2);
+    expect(result.indexTimeMs).toBeDefined();
+    expect(typeof result.indexTimeMs).toBe("number");
+  });
+
+  it("returns totalCallers and totalCallees counts matching arrays", async () => {
+    const result = await executeQueryCallGraph({
+      filePath: FILE_B,
+      symbolName: "process",
+      direction: "both",
+      depth: 1,
+    });
+
+    expect(result.totalCallers).toBe(result.callers.length);
+    expect(result.totalCallees).toBe(result.callees.length);
+  });
+});

--- a/tests/mcp/types.test.ts
+++ b/tests/mcp/types.test.ts
@@ -30,6 +30,7 @@ import {
   MCP_TOOL_VERSION,
   normalizePathForComparison,
   ParseImportsParamsSchema,
+  QueryCallGraphParamsSchema,
   RebuildIndexParamsSchema,
   ResolveModulePathParamsSchema,
   sanitizeString,
@@ -760,6 +761,117 @@ describe('GenerateCodemapParamsSchema', () => {
   });
 });
 
+describe('QueryCallGraphParamsSchema', () => {
+  it('validates minimal parameters', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/service.ts',
+      symbolName: 'processData',
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.filePath).toBe('/project/src/service.ts');
+      expect(result.data.symbolName).toBe('processData');
+      expect(result.data.direction).toBeUndefined();
+      expect(result.data.depth).toBeUndefined();
+      expect(result.data.relationTypes).toBeUndefined();
+    }
+  });
+
+  it('validates with all optional parameters', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/service.ts',
+      symbolName: 'processData',
+      direction: 'callers',
+      depth: 5,
+      relationTypes: ['CALLS', 'INHERITS'],
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.direction).toBe('callers');
+      expect(result.data.depth).toBe(5);
+      expect(result.data.relationTypes).toEqual(['CALLS', 'INHERITS']);
+    }
+  });
+
+  it('accepts all direction values', () => {
+    for (const direction of ['callers', 'callees', 'both'] as const) {
+      const result = QueryCallGraphParamsSchema.safeParse({
+        filePath: '/project/src/file.ts',
+        symbolName: 'fn',
+        direction,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects invalid direction', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/file.ts',
+      symbolName: 'fn',
+      direction: 'sideways',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('enforces depth min/max bounds', () => {
+    const tooLow = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/file.ts',
+      symbolName: 'fn',
+      depth: 0,
+    });
+    expect(tooLow.success).toBe(false);
+
+    const tooHigh = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/file.ts',
+      symbolName: 'fn',
+      depth: 11,
+    });
+    expect(tooHigh.success).toBe(false);
+  });
+
+  it('accepts all valid relation types', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/file.ts',
+      symbolName: 'fn',
+      relationTypes: ['CALLS', 'INHERITS', 'IMPLEMENTS', 'USES'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid relation type', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/file.ts',
+      symbolName: 'fn',
+      relationTypes: ['CALLS', 'EXTENDS'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing filePath', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      symbolName: 'fn',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing symbolName', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/file.ts',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects null bytes in path', () => {
+    const result = QueryCallGraphParamsSchema.safeParse({
+      filePath: '/project/src/\0evil.ts',
+      symbolName: 'fn',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 // ============================================================================
 // McpWorkerResponse Type Tests
 // ============================================================================
@@ -818,7 +930,7 @@ describe('McpWorkerResponse type', () => {
 
 describe('validateToolParams', () => {
   it('validates correct analyze_dependencies params', () => {
-    const result = validateToolParams('analyze_dependencies', {
+    const result = validateToolParams<{ filePath: string }>('analyze_dependencies', {
       filePath: '/project/src/index.ts',
     });
 
@@ -829,7 +941,7 @@ describe('validateToolParams', () => {
   });
 
   it('validates crawl_dependency_graph params with options', () => {
-    const result = validateToolParams('crawl_dependency_graph', {
+    const result = validateToolParams<{ entryFile: string; maxDepth: number; limit: number }>('crawl_dependency_graph', {
       entryFile: '/project/src/main.ts',
       maxDepth: 5,
       limit: 100,
@@ -847,7 +959,9 @@ describe('validateToolParams', () => {
     const result = validateToolParams('analyze_dependencies', {});
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('filePath');
+    if (!result.success) {
+      expect(result.error).toContain('filePath');
+    }
   });
 
   it('returns error for wrong field types', () => {
@@ -857,7 +971,9 @@ describe('validateToolParams', () => {
     });
 
     expect(result.success).toBe(false);
-    expect(result.error).toContain('maxDepth');
+    if (!result.success) {
+      expect(result.error).toContain('maxDepth');
+    }
   });
 
   it('validates get_index_status with empty params', () => {
@@ -867,7 +983,7 @@ describe('validateToolParams', () => {
   });
 
   it('validates find_referencing_files params', () => {
-    const result = validateToolParams('find_referencing_files', {
+    const result = validateToolParams<{ targetPath: string }>('find_referencing_files', {
       targetPath: '/project/src/utils.ts',
     });
 
@@ -886,7 +1002,7 @@ describe('validateToolParams', () => {
   });
 
   it('validates trace_function_execution params', () => {
-    const result = validateToolParams('trace_function_execution', {
+    const result = validateToolParams<{ filePath: string; symbolName: string; maxDepth: number }>('trace_function_execution', {
       filePath: '/project/src/service.ts',
       symbolName: 'processData',
       maxDepth: 10,


### PR DESCRIPTION
Implement simultaneous call graph pre-indexing alongside reverse indexing for improved performance. Introduce the `graphitlive_query_call_graph` tool for querying cross-file callers and callees, enhancing the MCP server's capabilities. Update documentation and tests accordingly.