### PR TITLE
Fix memory leaks in Call Graph listeners

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v1.7.5
+
+### Bug Fixes
+
+- **Memory leak in Call Graph live-refresh listener**: Each invocation of "Show Call Graph" was pushing the save listener (`onDidSaveTextDocument`) into `context.subscriptions` without ever removing the previous entry. After repeated use, the subscriptions array accumulated stale disposed references. The listener is now managed exclusively through its own `dispose()` call — no accumulation occurs between sessions.
+- **Memory leak in sidebar message listener**: The `IDisposable` returned by `webviewView.webview.onDidReceiveMessage()` was discarded instead of being tracked. It is now captured and explicitly disposed when the webview is closed, preventing a dangling listener if the sidebar panel is closed and reopened.
+
 ## v1.7.4
 
 ### Bug Fixes

--- a/src/extension/GraphProvider.ts
+++ b/src/extension/GraphProvider.ts
@@ -821,7 +821,7 @@ export class GraphProvider implements vscode.WebviewViewProvider {
     webviewView.webview.options = this.webviewManager.getWebviewOptions();
     webviewView.webview.html = this.webviewManager.getHtmlForWebview(webviewView.webview);
 
-    webviewView.webview.onDidReceiveMessage(
+    const messageListener = webviewView.webview.onDidReceiveMessage(
       async (message: WebviewToExtensionMessage) => {
         await this._messageDispatcher.handle(message);
       },
@@ -829,6 +829,7 @@ export class GraphProvider implements vscode.WebviewViewProvider {
 
     // Clean up timer and worker when view is disposed
     webviewView.onDidDispose(() => {
+      messageListener.dispose();
       this.indexingManager?.cancelScheduledIndexing();
       this.sourceFileWatcher?.dispose();
       this._fileChangeScheduler?.dispose();

--- a/src/extension/services/CallGraphViewService.ts
+++ b/src/extension/services/CallGraphViewService.ts
@@ -887,7 +887,8 @@ export class CallGraphViewService implements vscode.Disposable, ICallGraphQueryS
   // ---------------------------------------------------------------------------
 
   private registerSaveListener(workspaceRoot: string): void {
-    // Only one listener at a time
+    // Only one listener at a time — dispose() already handles cleanup of this.saveListener;
+    // do NOT push to context.subscriptions here or it accumulates a dead entry per show() call.
     this.saveListener?.dispose();
     this.saveListener = vscode.workspace.onDidSaveTextDocument((doc) => {
       const savedPath = normalizePath(doc.uri.fsPath);
@@ -895,7 +896,6 @@ export class CallGraphViewService implements vscode.Disposable, ICallGraphQueryS
         this.scheduleRefresh(savedPath, doc.languageId, workspaceRoot);
       }
     });
-    this.context.subscriptions.push(this.saveListener);
   }
 
   private scheduleRefresh(filePath: string, languageId: string, workspaceRoot: string): void {


### PR DESCRIPTION
Address memory leaks by properly managing message listeners in the GraphProvider and adjusting save listener management in the CallGraphViewService. Document these fixes in the changelog for clarity.