### PR TITLE
Add native VS Code Language Model Tools integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ All three layers are also exposed to AI via a **20-tool MCP server**, so your as
 
 ## 🤖 Supercharge Your AI Assistant
 
-Stop pasting file paths and explaining your project structure. Graph-It-Live exposes **21 powerful dependency analysis tools** directly to your AI assistant via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io).
+Stop pasting file paths and explaining your project structure. Graph-It-Live exposes **21 powerful dependency analysis tools** directly to your AI assistant via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), and **20 native LM Tools** directly in Copilot Agent mode (no MCP setup required).
 
 **Works with:** GitHub Copilot, Claude (Desktop & Code), Cursor, Windsurf, Antigravity, and any MCP-compatible client.
 
@@ -351,7 +351,7 @@ Graph-It-Live includes an optional **MCP server** that exposes its full analysis
 
 ### Available Tools
 
-The MCP server exposes **21 tools** for AI/LLM consumption:
+The MCP server exposes **21 tools** for AI/LLM consumption. All tools except `set_workspace` are also available as **native LM Tools** (`#graphResolve`, `#graphBreaking`, `#graphCallGraph`, etc.) directly in Copilot Agent mode — no MCP server required for those.
 
 | Tool | Description |
 | :--- | :---------- |
@@ -398,6 +398,35 @@ All tools support an optional `format` parameter to reduce token consumption:
 | `markdown` | JSON wrapped in markdown code blocks | — |
 
 See [TOON Format Documentation](./docs/TOON_FORMAT.md) for full specifications.
+
+### Native LM Tools (Copilot Agent Mode)
+
+All 20 analysis tools are also available **natively in GitHub Copilot** — no MCP server required. Reference them with `#` in Agent mode:
+
+| Reference | Tool | Description |
+|---|---|---|
+| `#graphFindRefs` | `find_referencing_files` | All files that import a given file |
+| `#graphDeps` | `analyze_dependencies` | Direct imports and exports of a file |
+| `#graphCrawl` | `crawl_dependency_graph` | Full dependency tree from an entry file |
+| `#graphSymbols` | `get_symbol_graph` | Symbol-level dependencies within a file |
+| `#graphUnused` | `find_unused_symbols` | Dead code detection |
+| `#graphCallers` | `get_symbol_callers` | All callers of a symbol |
+| `#graphImpact` | `get_impact_analysis` | Full impact analysis |
+| `#graphIndexStatus` | `get_index_status` | Current state of the dependency index |
+| `#graphImports` | `parse_imports` | Raw import statements |
+| `#graphCodemap` | `generate_codemap` | Comprehensive file structural overview |
+| `#graphExpand` | `expand_node` | Incremental dependency exploration |
+| `#graphVerifyUsage` | `verify_dependency_usage` | Is an import actually used? |
+| `#graphInvalidate` | `invalidate_files` | Flush cache for specific files |
+| `#graphRebuildIndex` | `rebuild_index` | Full index rebuild |
+| `#graphDependents` | `get_symbol_dependents` | All symbols depending on a given symbol |
+| `#graphTrace` | `trace_function_execution` | Full recursive call chain |
+| `#graphFileLogic` | `analyze_file_logic` | Intra-file call hierarchy |
+| `#graphResolve` | `resolve_module_path` | Resolve a module specifier to its absolute path |
+| `#graphBreaking` | `analyze_breaking_changes` | Detect breaking changes between two file versions |
+| `#graphCallGraph` | `query_call_graph` | BFS callers/callees via the SQLite call graph index |
+
+> **Note:** `#graphCallGraph` requires the Call Graph panel (`graph-it-live.showCallGraph`) to be opened at least once to build the index.
 
 ### Manual MCP Server Configuration
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v1.8.0
+
+### Enhancements
+
+- **Native LM Tools — 10 → 20 tools, full MCP parity**: The native VS Code Language Model Tools surface now covers all 20 analysis tools (vs 21 MCP tools — only `set_workspace` is MCP-only). All support `#` reference in Copilot Agent mode. Added in two batches:
+  - *Batch 1 (7 tools):* `#graphExpand`, `#graphVerifyUsage`, `#graphInvalidate`, `#graphRebuildIndex`, `#graphDependents`, `#graphTrace`, `#graphFileLogic`
+  - *Batch 2 (3 tools):* `#graphResolve` (resolve module specifier → absolute path), `#graphBreaking` (breaking change detection between old/new file content), `#graphCallGraph` (BFS callers/callees via the SQLite call graph index)
+
+### Bug Fixes
+
+- **Extension logger — object serialization**: Fixed `formatArgs()` producing the meaningless `[object Object]` string when a non-serialisable object was passed as a log argument (e.g. a circular-reference object that throws in `JSON.stringify`). The fallback now uses `Object.prototype.toString.call(arg)` which returns a descriptive tag like `[object Array]`, `[object Map]`, `[object MyClass]`, etc. without any type assertions.
+
 ## v1.7.5
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -287,6 +287,612 @@
         }
       ]
     },
+    "languageModelTools": [
+      {
+        "name": "graph-it-live_find_referencing_files",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphFindRefs",
+        "tags": [
+          "graph-it-live",
+          "dependencies",
+          "references"
+        ],
+        "displayName": "Graph-It-Live: Find Files Referencing",
+        "icon": "$(references)",
+        "userDescription": "Find all files that import or depend on a specific file",
+        "modelDescription": "WHEN: you need to know which files import or depend on a specific file. WHY: you cannot determine reverse dependencies without analyzing the full project dependency index. WHAT: returns a list of file paths that import or reference the target file, with line numbers and import module details.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "targetPath": {
+              "type": "string",
+              "description": "The absolute path to the file to find references for"
+            }
+          },
+          "required": [
+            "targetPath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_analyze_dependencies",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphDeps",
+        "tags": [
+          "graph-it-live",
+          "dependencies",
+          "imports"
+        ],
+        "displayName": "Graph-It-Live: Analyze Dependencies",
+        "icon": "$(package)",
+        "userDescription": "List all dependencies and imports of a file, with resolved paths and metadata",
+        "modelDescription": "WHEN: you need to know what a file imports or depends on. WHY: you need resolved absolute paths and structured metadata for all imports in a file, which you cannot get from just reading the source. WHAT: returns all resolved dependencies of the given file with their module names, resolved paths, import types, and line numbers.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file to analyze"
+            }
+          },
+          "required": [
+            "filePath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_crawl_dependency_graph",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphCrawl",
+        "tags": [
+          "graph-it-live",
+          "dependencies",
+          "graph"
+        ],
+        "displayName": "Graph-It-Live: Crawl Dependency Graph",
+        "icon": "$(type-hierarchy)",
+        "userDescription": "Traverse the full transitive dependency graph from an entry file",
+        "modelDescription": "WHEN: you need to explore the full transitive dependency graph starting from an entry file. WHY: you cannot determine multi-hop dependencies by reading files individually — this traverses the full graph. WHAT: returns all reachable nodes (files) and directed edges (import relationships) in the graph.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "entryFile": {
+              "type": "string",
+              "description": "The absolute path to the entry file from which to start crawling"
+            },
+            "maxDepth": {
+              "type": "number",
+              "description": "Maximum depth to crawl (optional, defaults to the configured maxDepth setting)"
+            }
+          },
+          "required": [
+            "entryFile"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_get_symbol_graph",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphSymbols",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "ast"
+        ],
+        "displayName": "Graph-It-Live: Get Symbol Graph",
+        "icon": "$(symbol-structure)",
+        "userDescription": "Get all symbols (functions, classes, variables) defined in a file and their relationships",
+        "modelDescription": "WHEN: you need to understand the symbol-level structure of a file — which functions, classes, and variables it defines and how they relate. WHY: you cannot determine symbol-to-symbol dependency relationships from source text alone without AST analysis. WHAT: returns all symbols (functions, classes, variables) defined in the file with their kinds, export status, and cross-file dependency edges.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file to inspect"
+            }
+          },
+          "required": [
+            "filePath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_find_unused_symbols",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphUnused",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "dead-code"
+        ],
+        "displayName": "Graph-It-Live: Find Unused Exported Symbols",
+        "icon": "$(trash)",
+        "userDescription": "Find exported symbols that are not used anywhere in the project (dead code)",
+        "modelDescription": "WHEN: you want to identify dead code or unused exports in a file. WHY: determining which exports are unused requires checking every file in the project that could import them — something impossible to do with simple text search. WHAT: returns a list of exported symbols that are not referenced anywhere in the project, with an unused percentage.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file to check for unused exports"
+            }
+          },
+          "required": [
+            "filePath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_get_symbol_callers",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphCallers",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "references"
+        ],
+        "displayName": "Graph-It-Live: Get Symbol Callers",
+        "icon": "$(call-incoming)",
+        "userDescription": "Find all symbols across the project that call or use a given exported symbol",
+        "modelDescription": "WHEN: you need to know which symbols (functions, classes) use or call a specific exported symbol. WHY: finding all callers of a symbol across the project requires a reverse symbol index that cannot be built by reading individual files. WHAT: returns all symbols across the project that reference the given symbol, with file paths and symbol IDs.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file containing the symbol"
+            },
+            "symbolName": {
+              "type": "string",
+              "description": "The name of the symbol to find callers for (e.g. 'MyClass', 'handleRequest')"
+            }
+          },
+          "required": [
+            "filePath",
+            "symbolName"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_get_impact_analysis",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphImpact",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "refactoring"
+        ],
+        "displayName": "Graph-It-Live: Get Impact Analysis",
+        "icon": "$(report)",
+        "userDescription": "Analyze the scope and risk of changing a symbol — shows affected files and symbols",
+        "modelDescription": "WHEN: you are about to modify a symbol and want to understand the risk and scope of the change. WHY: determining transitive impact across the project requires traversing the full reverse dependency graph, which is impossible to do manually. WHAT: returns an impact level (high/medium/low), count of affected files and symbols, and the list of impacted items with their usage types (runtime vs type-only).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file containing the symbol"
+            },
+            "symbolName": {
+              "type": "string",
+              "description": "The name of the symbol to analyze impact for"
+            },
+            "includeTransitive": {
+              "type": "boolean",
+              "description": "Whether to include transitive (indirect) dependents (default: false)"
+            },
+            "maxDepth": {
+              "type": "number",
+              "description": "Maximum transitive depth to traverse when includeTransitive is true (default: 3)"
+            }
+          },
+          "required": [
+            "filePath",
+            "symbolName"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_get_index_status",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphIndexStatus",
+        "tags": [
+          "graph-it-live",
+          "index",
+          "status"
+        ],
+        "displayName": "Graph-It-Live: Get Index Status",
+        "icon": "$(pulse)",
+        "userDescription": "Check if the dependency index is ready and get cache statistics",
+        "modelDescription": "WHEN: you need to check whether the dependency index is ready before calling other analysis tools. WHY: other tools may return incomplete results if the index is still being built. WHAT: returns the current indexing state (idle/indexing/complete/error), cache statistics, and reverse index availability.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "graph-it-live_parse_imports",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphImports",
+        "tags": [
+          "graph-it-live",
+          "imports",
+          "parsing"
+        ],
+        "displayName": "Graph-It-Live: Parse Imports",
+        "icon": "$(list-tree)",
+        "userDescription": "Parse and list all import statements in a file with resolved paths",
+        "modelDescription": "WHEN: you need a lightweight list of import statements from a file without full graph traversal. WHY: this uses the full language-aware parser pipeline to extract and resolve imports more accurately than regex-based text parsing. WHAT: returns each import with its module specifier, import type (import/require/export/dynamic), and source line number.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file to parse imports from"
+            }
+          },
+          "required": [
+            "filePath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_generate_codemap",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphCodemap",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "codemap"
+        ],
+        "displayName": "Graph-It-Live: Generate Code Map",
+        "icon": "$(file-code)",
+        "userDescription": "Generate an AI-friendly code map summarizing a file's structure, symbols, and call flow",
+        "modelDescription": "WHEN: you need a rich, AI-friendly summary of a file's structure, relationships, and internal call flow. WHY: understanding a file requires combining symbol analysis, import resolution, reverse dependencies, and intra-file call hierarchy — none of which can be inferred from reading the source alone. WHAT: returns exported/internal symbols, file-level dependencies and dependents, intra-file call flow edges, cycle detection, and timing metadata.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file to generate a code map for"
+            }
+          },
+          "required": [
+            "filePath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_expand_node",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphExpand",
+        "tags": [
+          "graph-it-live",
+          "dependencies",
+          "graph"
+        ],
+        "displayName": "Graph-It-Live: Expand Node Dependencies",
+        "icon": "$(expand-all)",
+        "userDescription": "Discover new dependencies from a file, excluding an already-known set (incremental graph exploration)",
+        "modelDescription": "WHEN: you need to incrementally explore the dependency graph from a specific node, discovering new files not already in your known set. WHY: this efficiently finds only the files you do not already know about, avoiding re-analysis of the entire graph. WHAT: returns newly discovered nodes (file paths) and edges (import relationships) that were not in the provided known set.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file to expand from"
+            },
+            "knownPaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of file paths already known — newly discovered nodes will exclude these"
+            }
+          },
+          "required": [
+            "filePath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_verify_dependency_usage",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphVerifyUsage",
+        "tags": [
+          "graph-it-live",
+          "dependencies",
+          "dead-code"
+        ],
+        "displayName": "Graph-It-Live: Verify Dependency Usage",
+        "icon": "$(check)",
+        "userDescription": "Check if an import between two files is actually used or is a dead import",
+        "modelDescription": "WHEN: you want to check if a dependency between two files is real or dead code (an unused import). WHY: raw imports do not tell the whole story — a file might import something but never use it; AST analysis is required to verify actual symbol usage. WHAT: returns a boolean indicating whether the sourceFile actually uses any symbol from targetFile.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sourceFile": {
+              "type": "string",
+              "description": "The absolute path to the file that imports the target"
+            },
+            "targetFile": {
+              "type": "string",
+              "description": "The absolute path to the imported file"
+            }
+          },
+          "required": [
+            "sourceFile",
+            "targetFile"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_invalidate_files",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphInvalidate",
+        "tags": [
+          "graph-it-live",
+          "index",
+          "cache"
+        ],
+        "displayName": "Graph-It-Live: Invalidate File Cache",
+        "icon": "$(discard)",
+        "userDescription": "Flush cached dependency data for specific files so the next analysis re-reads them",
+        "modelDescription": "WHEN: you have modified files and need to refresh the dependency analysis cache. WHY: the dependency analyzer caches file analysis; when imports/exports change the cache becomes stale. WHAT: clears the cache for the given file paths, returns how many were invalidated.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePaths": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Absolute paths of the files to invalidate from the cache"
+            }
+          },
+          "required": [
+            "filePaths"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_rebuild_index",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphRebuildIndex",
+        "tags": [
+          "graph-it-live",
+          "index",
+          "cache"
+        ],
+        "displayName": "Graph-It-Live: Rebuild Full Index",
+        "icon": "$(sync)",
+        "userDescription": "Clear all cached dependency data and rebuild the full project index from scratch",
+        "modelDescription": "WHEN: the dependency index seems out of sync (after major refactoring, branch switches, or many file changes). WHY: clears ALL cached data and re-indexes the entire workspace, ensuring the dependency graph is accurate. WHAT: returns the rebuild time and new cache size. Note: can take several seconds for large workspaces.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "graph-it-live_get_symbol_dependents",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphDependents",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "references"
+        ],
+        "displayName": "Graph-It-Live: Get Symbol Dependents",
+        "icon": "$(call-outgoing)",
+        "userDescription": "Find all symbols across the codebase that directly depend on (use) a specific symbol",
+        "modelDescription": "WHEN: you need to know every file and symbol that calls or uses a given exported symbol — essential for surgical refactoring. WHY: symbol-level impact requires a reverse symbol index that cannot be built by reading individual files. WHAT: returns a list of all symbol dependencies that use the target symbol, with file paths and symbol IDs.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file containing the symbol"
+            },
+            "symbolName": {
+              "type": "string",
+              "description": "The name of the symbol to find dependents for"
+            }
+          },
+          "required": [
+            "filePath",
+            "symbolName"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_trace_function_execution",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphTrace",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "execution"
+        ],
+        "displayName": "Graph-It-Live: Trace Function Execution",
+        "icon": "$(type-hierarchy-sub)",
+        "userDescription": "Trace the full recursive call chain starting from a function or method",
+        "modelDescription": "WHEN: you need to trace the full, deep call chain from a root symbol through multiple files. WHY: provides a complete picture of what a function calls, recursively following the call chain across files until it reaches external modules or the depth limit. WHAT: returns the root symbol, the full call chain with depth information, all visited symbols, and whether the max depth was reached.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file containing the function"
+            },
+            "symbolName": {
+              "type": "string",
+              "description": "The name of the function or method to trace"
+            },
+            "maxDepth": {
+              "type": "number",
+              "description": "Maximum call chain depth to follow (default: 10)"
+            }
+          },
+          "required": [
+            "filePath",
+            "symbolName"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_analyze_file_logic",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphFileLogic",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "ast"
+        ],
+        "displayName": "Graph-It-Live: Analyze File Logic",
+        "icon": "$(code)",
+        "userDescription": "Analyze the intra-file call hierarchy — which functions call which within a single file",
+        "modelDescription": "WHEN: you need to understand the internal call relationships between functions and methods within a single file. WHY: without AST analysis you cannot see actual call relationships between functions in a file. WHAT: returns an intra-file call graph with nodes (symbols with type, export status, line range), edges (caller→callee with line number), cycle detection, and timing.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "The absolute path to the file to analyze"
+            }
+          },
+          "required": [
+            "filePath"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_resolve_module_path",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphResolve",
+        "tags": [
+          "graph-it-live",
+          "imports",
+          "resolution"
+        ],
+        "displayName": "Graph-It-Live: Resolve Module Path",
+        "icon": "$(link)",
+        "userDescription": "Resolve a module specifier (e.g. './utils', '@/components/Button') to its absolute file path",
+        "modelDescription": "WHEN: you need to know which physical file a TypeScript/JavaScript import resolves to, especially for path aliases, barrel files, or relative imports. WHY: without the project's tsconfig path mappings you cannot reliably resolve aliases like '@/' or complex relative paths. WHAT: returns the resolved absolute path, a workspace-relative path, and a boolean indicating whether resolution succeeded.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "fromFile": {
+              "type": "string",
+              "description": "Absolute path of the file containing the import statement"
+            },
+            "moduleSpecifier": {
+              "type": "string",
+              "description": "The module specifier to resolve (e.g. './utils', '@/components/Button', 'lodash')"
+            }
+          },
+          "required": [
+            "fromFile",
+            "moduleSpecifier"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_analyze_breaking_changes",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphBreaking",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "refactoring"
+        ],
+        "displayName": "Graph-It-Live: Analyze Breaking Changes",
+        "icon": "$(warning)",
+        "userDescription": "Detect breaking changes when modifying function signatures, interface members, or type aliases",
+        "modelDescription": "WHEN: you are about to modify a function signature, interface, or type alias and want to know if callers will break. WHY: static analysis requires parsing both the old and new AST to compare signatures — you cannot reliably do this from text diffs alone. WHAT: returns a list of breaking changes (parameter removed, type changed, visibility reduced, member removed, optional→required), non-breaking changes, and per-symbol severity (error/warning).",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "Absolute path to the file being modified"
+            },
+            "oldContent": {
+              "type": "string",
+              "description": "The previous file content to compare against"
+            },
+            "symbolName": {
+              "type": "string",
+              "description": "Optional: restrict analysis to a specific symbol name"
+            },
+            "newContent": {
+              "type": "string",
+              "description": "The new file content (if omitted, reads the current file from disk)"
+            }
+          },
+          "required": [
+            "filePath",
+            "oldContent"
+          ]
+        }
+      },
+      {
+        "name": "graph-it-live_query_call_graph",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphCallGraph",
+        "tags": [
+          "graph-it-live",
+          "callgraph",
+          "symbols"
+        ],
+        "displayName": "Graph-It-Live: Query Call Graph",
+        "icon": "$(type-hierarchy)",
+        "userDescription": "Query cross-file callers and callees of a symbol via BFS traversal on the indexed call graph database",
+        "modelDescription": "WHEN: you need to understand which functions call a given symbol across multiple files, or what a function calls transitively (beyond a single file). WHY: cross-file call relationships are not visible from reading a single file — they require a pre-built graph index. WHAT: returns the target symbol's metadata plus lists of callers/callees with file paths, relation types (CALLS/INHERITS/IMPLEMENTS/USES), and cycle flags. Requires the Call Graph panel to have been opened at least once to build the index.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "filePath": {
+              "type": "string",
+              "description": "Absolute path to the file containing the target symbol"
+            },
+            "symbolName": {
+              "type": "string",
+              "description": "Name of the symbol to query (function, class, method)"
+            },
+            "direction": {
+              "type": "string",
+              "enum": [
+                "callers",
+                "callees",
+                "both"
+              ],
+              "description": "Traversal direction: 'callers' (who calls this), 'callees' (what it calls), or 'both' (default)"
+            },
+            "depth": {
+              "type": "number",
+              "description": "Maximum BFS traversal depth (default: 2, max: 10)"
+            },
+            "relationTypes": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "CALLS",
+                  "INHERITS",
+                  "IMPLEMENTS",
+                  "USES"
+                ]
+              },
+              "description": "Filter by relation types (default: all types included)"
+            }
+          },
+          "required": [
+            "filePath",
+            "symbolName"
+          ]
+        }
+      }
+    ],
     "configuration": {
       "title": "Graph-It-Live",
       "properties": {

--- a/src/extension/GraphProvider.ts
+++ b/src/extension/GraphProvider.ts
@@ -104,6 +104,18 @@ export class GraphProvider implements vscode.WebviewViewProvider {
       : undefined;
   }
 
+  /**
+   * Expose the Spider instance for use by LmToolsService.
+   * Returns undefined when no workspace folder is open.
+   */
+  public getSpiderForLmTools(): Spider | undefined {
+    return this.spider;
+  }
+
+  public getCallGraphViewServiceForLmTools(): import('./services/CallGraphViewService').CallGraphViewService | null {
+    return this._callGraphViewService;
+  }
+
   private get webviewManager(): WebviewManager {
     return this._container.get(graphProviderServiceTokens.webviewManager);
   }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -12,6 +12,7 @@ import { CallGraphViewService } from './services/CallGraphViewService';
 import { CommandCoordinator } from './services/CommandCoordinator';
 import { CommandRegistrationService } from './services/CommandRegistrationService';
 import { EditorEventsService } from './services/EditorEventsService';
+import { LmToolsService } from './services/LmToolsService';
 
 // Keep track of MCP server provider for cleanup
 let mcpServerProvider: McpServerProvider | null = null;
@@ -47,6 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
         commandCoordinator,
         logger: log,
     });
+    const lmToolsService = new LmToolsService({ provider, logger: log });
     
     // Watch for performance profile changes and apply preset values
     const profileWatcher = vscode.workspace.onDidChangeConfiguration(async (e) => {
@@ -105,6 +107,8 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Register commands via centralized service
       ...commandService.registerAll(),
+        // Native VS Code Language Model Tools (always active, targets Copilot Chat)
+        ...lmToolsService.registerAll(),
       // Editor/workspace event listeners
       ...editorEventsService.register(),
     ];

--- a/src/extension/extensionLogger.ts
+++ b/src/extension/extensionLogger.ts
@@ -51,6 +51,9 @@ export class VsCodeLogger implements ILogger {
       try {
         return JSON.stringify(arg);
       } catch {
+        if (typeof arg === 'object' && arg !== null) {
+          return Object.prototype.toString.call(arg);
+        }
         return String(arg);
       }
     }).join(' ');

--- a/src/extension/services/CallGraphViewService.ts
+++ b/src/extension/services/CallGraphViewService.ts
@@ -226,6 +226,8 @@ export class CallGraphViewService implements vscode.Disposable, ICallGraphQueryS
   public getCallGraphNodeCount(): number { return this.callGraphNodeCount; }
   public getCallGraphEdgeCount(): number { return this.callGraphEdgeCount; }
   public getCallGraphCycleCount(): number { return this.callGraphCycleCount; }
+  /** Expose the indexer for LM Tools (query_call_graph). Returns null if not yet initialized. */
+  public getCallGraphIndexerForLmTools(): CallGraphIndexer | null { return this.indexer; }
   // ---------------------------------------------------------------------------
   // Public API
   // ---------------------------------------------------------------------------

--- a/src/extension/services/LmToolsService.ts
+++ b/src/extension/services/LmToolsService.ts
@@ -1,0 +1,1287 @@
+/**
+ * LmToolsService — registers Graph-It-Live analyzer tools as native VS Code
+ * Language Model Tools (`vscode.lm.registerTool`).
+ *
+ * This is separate from the MCP server:
+ *   - MCP targets external clients (Claude Desktop, Cursor, …)
+ *   - LM Tools target Copilot Chat inside VS Code directly
+ *
+ * Architecture rule: this file IS in the extension layer and MAY import vscode.
+ */
+
+import { LspCallHierarchyAnalyzer } from '@/analyzer/LspCallHierarchyAnalyzer';
+import type { Dependency } from '@/analyzer/types';
+import { convertSpiderToLspFormat } from '@/shared/converters';
+import { detectLanguageFromExtension } from '@/shared/utils/languageDetection';
+import * as fs from 'node:fs/promises';
+import * as nodePath from 'node:path';
+import * as vscode from 'vscode';
+import type { GraphProvider } from '../GraphProvider';
+import type { VsCodeLogger } from '../extensionLogger';
+
+// ─── Input types for each tool ────────────────────────────────────────────────
+
+interface FindReferencingFilesInput {
+  targetPath: string;
+}
+
+interface AnalyzeDependenciesInput {
+  filePath: string;
+}
+
+interface CrawlDependencyGraphInput {
+  entryFile: string;
+  maxDepth?: number;
+}
+
+interface GetSymbolGraphInput {
+  filePath: string;
+}
+
+interface FindUnusedSymbolsInput {
+  filePath: string;
+}
+
+interface GetSymbolCallersInput {
+  filePath: string;
+  symbolName: string;
+}
+
+interface GetImpactAnalysisInput {
+  filePath: string;
+  symbolName: string;
+  includeTransitive?: boolean;
+  maxDepth?: number;
+}
+
+interface ParseImportsInput {
+  filePath: string;
+}
+
+interface GenerateCodemapInput {
+  filePath: string;
+}
+
+interface ExpandNodeInput {
+  filePath: string;
+  knownPaths?: string[];
+  extraDepth?: number;
+}
+
+interface VerifyDependencyUsageInput {
+  sourceFile: string;
+  targetFile: string;
+}
+
+interface InvalidateFilesInput {
+  filePaths: string[];
+}
+
+interface GetSymbolDependentsInput {
+  filePath: string;
+  symbolName: string;
+}
+
+interface TraceFunctionExecutionInput {
+  filePath: string;
+  symbolName: string;
+  maxDepth?: number;
+}
+
+interface AnalyzeFileLogicInput {
+  filePath: string;
+}
+
+interface ResolveModulePathInput {
+  fromFile: string;
+  moduleSpecifier: string;
+}
+
+interface AnalyzeBreakingChangesInput {
+  filePath: string;
+  oldContent: string;
+  symbolName?: string;
+  newContent?: string;
+}
+
+interface QueryCallGraphInput {
+  filePath: string;
+  symbolName: string;
+  direction?: 'callers' | 'callees' | 'both';
+  depth?: number;
+  relationTypes?: string[];
+}
+
+// ─── Service options ──────────────────────────────────────────────────────────
+
+interface LmToolsServiceOptions {
+  provider: GraphProvider;
+  logger: VsCodeLogger;
+}
+
+// ─── Local path helper (mirrors mcp/shared/helpers without importing MCP) ────
+
+function toRelativePath(absolutePath: string, workspaceRoot: string): string {
+  const rel = nodePath.relative(workspaceRoot, absolutePath);
+  if (rel.startsWith('..') || nodePath.isAbsolute(rel)) {
+    return absolutePath;
+  }
+  return rel.replaceAll('\\', '/');
+}
+
+function stripFilePrefix(symbolId: string): string {
+  const idx = symbolId.lastIndexOf(':');
+  return idx >= 0 ? symbolId.slice(idx + 1) : symbolId;
+}
+
+// ─── Service ─────────────────────────────────────────────────────────────────
+
+export class LmToolsService {
+  private readonly provider: GraphProvider;
+  private readonly logger: VsCodeLogger;
+
+  constructor(options: LmToolsServiceOptions) {
+    this.provider = options.provider;
+    this.logger = options.logger;
+  }
+
+  /**
+   * Register all LM tools. Returns an array of Disposable objects.
+   * Returns an empty array if VS Code doesn't support native LM tools.
+   */
+  registerAll(): vscode.Disposable[] {
+    if (!('registerTool' in (vscode.lm as Record<string, unknown>))) {
+      this.logger.warn('vscode.lm.registerTool not available — Native LM Tools disabled.');
+      return [];
+    }
+    this.logger.info('Registering Graph-It-Live native Language Model Tools');
+    return [
+      this.registerFindReferencingFiles(),
+      this.registerAnalyzeDependencies(),
+      this.registerCrawlDependencyGraph(),
+      this.registerGetSymbolGraph(),
+      this.registerFindUnusedSymbols(),
+      this.registerGetSymbolCallers(),
+      this.registerGetImpactAnalysis(),
+      this.registerGetIndexStatus(),
+      this.registerParseImports(),
+      this.registerGenerateCodemap(),
+      this.registerExpandNode(),
+      this.registerVerifyDependencyUsage(),
+      this.registerInvalidateFiles(),
+      this.registerRebuildIndex(),
+      this.registerGetSymbolDependents(),
+      this.registerTraceFunctionExecution(),
+      this.registerAnalyzeFileLogic(),
+      this.registerResolveModulePath(),
+      this.registerAnalyzeBreakingChanges(),
+      this.registerQueryCallGraph(),
+    ];
+  }
+
+  // ─── Shared helpers ───────────────────────────────────────────────────────
+
+  private errorResult(message: string): vscode.LanguageModelToolResult {
+    return new vscode.LanguageModelToolResult([
+      new vscode.LanguageModelTextPart(JSON.stringify({ error: message })),
+    ]);
+  }
+
+  private getWorkspaceRoot(): string | undefined {
+    return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  }
+
+  // ─── Tool: find_referencing_files ─────────────────────────────────────────
+
+  private registerFindReferencingFiles(): vscode.Disposable {
+    return vscode.lm.registerTool<FindReferencingFilesInput>(
+      'graph-it-live_find_referencing_files',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<FindReferencingFilesInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { targetPath } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const references = await spider.findReferencingFiles(targetPath);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  targetPath,
+                  referencingFileCount: references.length,
+                  referencingFiles: references.map((ref) => ({
+                    path: ref.path,
+                    relativePath: rootDir ? toRelativePath(ref.path, rootDir) : ref.path,
+                    type: ref.type,
+                    line: ref.line,
+                    module: ref.module,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: analyze_dependencies ──────────────────────────────────────────
+
+  private registerAnalyzeDependencies(): vscode.Disposable {
+    return vscode.lm.registerTool<AnalyzeDependenciesInput>(
+      'graph-it-live_analyze_dependencies',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<AnalyzeDependenciesInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const dependencies = await spider.analyze(filePath);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  dependencyCount: dependencies.length,
+                  dependencies: dependencies.map((dep) => ({
+                    module: dep.module,
+                    path: dep.path,
+                    relativePath: dep.path && rootDir ? toRelativePath(dep.path, rootDir) : null,
+                    type: dep.type,
+                    line: dep.line,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: crawl_dependency_graph ────────────────────────────────────────
+
+  private registerCrawlDependencyGraph(): vscode.Disposable {
+    return vscode.lm.registerTool<CrawlDependencyGraphInput>(
+      'graph-it-live_crawl_dependency_graph',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<CrawlDependencyGraphInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { entryFile, maxDepth } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          const configuredMaxDepth = vscode.workspace
+            .getConfiguration('graph-it-live')
+            .get<number>('maxDepth', 50);
+          if (maxDepth !== undefined) {
+            spider.updateConfig({ maxDepth });
+          }
+          try {
+            const graph = await spider.crawl(entryFile);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  entryFile,
+                  nodeCount: graph.nodes.length,
+                  edgeCount: graph.edges.length,
+                  nodes: graph.nodes.map((n) => ({
+                    path: n,
+                    relativePath: rootDir ? toRelativePath(n, rootDir) : n,
+                  })),
+                  edges: graph.edges.map((e) => ({
+                    source: e.source,
+                    target: e.target,
+                    sourceRelative: rootDir ? toRelativePath(e.source, rootDir) : e.source,
+                    targetRelative: rootDir ? toRelativePath(e.target, rootDir) : e.target,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          } finally {
+            if (maxDepth !== undefined) {
+              spider.updateConfig({ maxDepth: configuredMaxDepth });
+            }
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: get_symbol_graph ───────────────────────────────────────────────
+
+  private registerGetSymbolGraph(): vscode.Disposable {
+    return vscode.lm.registerTool<GetSymbolGraphInput>(
+      'graph-it-live_get_symbol_graph',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<GetSymbolGraphInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const { symbols, dependencies } = await spider.getSymbolGraph(filePath);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  relativePath: rootDir ? toRelativePath(filePath, rootDir) : filePath,
+                  symbolCount: symbols.length,
+                  dependencyCount: dependencies.length,
+                  symbols,
+                  dependencies: dependencies.map((dep) => ({
+                    ...dep,
+                    targetRelativePath: rootDir
+                      ? toRelativePath(dep.targetFilePath, rootDir)
+                      : dep.targetFilePath,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: find_unused_symbols ───────────────────────────────────────────
+
+  private registerFindUnusedSymbols(): vscode.Disposable {
+    return vscode.lm.registerTool<FindUnusedSymbolsInput>(
+      'graph-it-live_find_unused_symbols',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<FindUnusedSymbolsInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const [unusedSymbols, { symbols }] = await Promise.all([
+              spider.findUnusedSymbols(filePath),
+              spider.getSymbolGraph(filePath),
+            ]);
+            const exportedCount = symbols.filter((s) => s.isExported).length;
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  relativePath: rootDir ? toRelativePath(filePath, rootDir) : filePath,
+                  unusedCount: unusedSymbols.length,
+                  totalExportedSymbols: exportedCount,
+                  unusedPercentage:
+                    exportedCount > 0
+                      ? Math.round((unusedSymbols.length / exportedCount) * 100)
+                      : 0,
+                  unusedSymbols,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: get_symbol_callers ─────────────────────────────────────────────
+
+  private registerGetSymbolCallers(): vscode.Disposable {
+    return vscode.lm.registerTool<GetSymbolCallersInput>(
+      'graph-it-live_get_symbol_callers',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<GetSymbolCallersInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath, symbolName } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const dependents = await spider.getSymbolDependents(filePath, symbolName);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  symbolName,
+                  callerCount: dependents.length,
+                  callers: dependents.map((dep) => ({
+                    sourceSymbolId: dep.sourceSymbolId,
+                    targetSymbolId: dep.targetSymbolId,
+                    targetFilePath: dep.targetFilePath,
+                    targetRelativePath: rootDir
+                      ? toRelativePath(dep.targetFilePath, rootDir)
+                      : dep.targetFilePath,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: get_impact_analysis ────────────────────────────────────────────
+
+  private buildImpactItem(
+    dep: { sourceSymbolId: string; targetFilePath: string; isTypeOnly?: boolean },
+    depth: number,
+    rootDir: string | undefined,
+  ): { symbolId: string; targetFilePath: string; relativePath: string; usageType: 'runtime' | 'type-only'; depth: number } {
+    return {
+      symbolId: dep.sourceSymbolId,
+      targetFilePath: dep.targetFilePath,
+      relativePath: rootDir ? toRelativePath(dep.targetFilePath, rootDir) : dep.targetFilePath,
+      usageType: dep.isTypeOnly ? 'type-only' : 'runtime',
+      depth,
+    };
+  }
+
+  private computeImpactLevel(runtimeCount: number, totalCount: number): 'high' | 'medium' | 'low' {
+    if (runtimeCount >= 10 || totalCount >= 20) return 'high';
+    if (runtimeCount >= 3 || totalCount >= 5) return 'medium';
+    return 'low';
+  }
+
+  private processTransitiveDep(
+    dep: { sourceSymbolId: string; targetFilePath: string; isTypeOnly?: boolean },
+    currentDepth: number,
+    maxDepth: number,
+    visited: Set<string>,
+    rootDir: string | undefined,
+    queue: Array<{ symbolId: string; depth: number }>,
+    result: ReturnType<LmToolsService['buildImpactItem']>[],
+  ): void {
+    if (visited.has(dep.sourceSymbolId)) return;
+    visited.add(dep.sourceSymbolId);
+    result.push(this.buildImpactItem(dep, currentDepth, rootDir));
+    if (currentDepth < maxDepth) {
+      queue.push({ symbolId: dep.sourceSymbolId, depth: currentDepth + 1 });
+    }
+  }
+
+  private async collectTransitiveDependents(
+    directDependents: Array<{ sourceSymbolId: string; targetFilePath: string; isTypeOnly?: boolean }>,
+    spider: ReturnType<GraphProvider['getSpiderForLmTools']> & object,
+    maxDepth: number,
+    rootDir: string | undefined,
+  ): Promise<ReturnType<LmToolsService['buildImpactItem']>[]> {
+    const visited = new Set<string>(directDependents.map((d) => d.sourceSymbolId));
+    const queue = directDependents.map((d) => ({ symbolId: d.sourceSymbolId, depth: 2 }));
+    const transitiveItems: ReturnType<LmToolsService['buildImpactItem']>[] = [];
+
+    while (queue.length > 0) {
+      const current = queue.shift();
+      if (!current || current.depth > maxDepth) continue;
+
+      const colonIdx = current.symbolId.lastIndexOf(':');
+      if (colonIdx <= 0) continue;
+
+      const sym = current.symbolId.slice(colonIdx + 1);
+      const fp = current.symbolId.slice(0, colonIdx);
+
+      try {
+        const deps = await spider.getSymbolDependents(fp, sym);
+        for (const dep of deps) {
+          this.processTransitiveDep(dep, current.depth, maxDepth, visited, rootDir, queue, transitiveItems);
+        }
+      } catch {
+        // skip symbols that fail to analyze
+      }
+    }
+    return transitiveItems;
+  }
+
+  private registerGetImpactAnalysis(): vscode.Disposable {
+    return vscode.lm.registerTool<GetImpactAnalysisInput>(
+      'graph-it-live_get_impact_analysis',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<GetImpactAnalysisInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath, symbolName, includeTransitive = false, maxDepth = 3 } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const directDependents = await spider.getSymbolDependents(filePath, symbolName);
+            const impactedItems = directDependents.map((dep) => this.buildImpactItem(dep, 1, rootDir));
+
+            if (includeTransitive && maxDepth > 1) {
+              const transitiveItems = await this.collectTransitiveDependents(
+                directDependents, spider, maxDepth, rootDir,
+              );
+              impactedItems.push(...transitiveItems);
+            }
+
+            const runtimeCount = impactedItems.filter((i) => i.usageType === 'runtime').length;
+            const affectedFiles = new Set(impactedItems.map((i) => i.targetFilePath));
+
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  symbolId: `${filePath}:${symbolName}`,
+                  filePath,
+                  symbolName,
+                  impactLevel: this.computeImpactLevel(runtimeCount, impactedItems.length),
+                  totalImpactCount: impactedItems.length,
+                  directCount: impactedItems.filter((i) => i.depth === 1).length,
+                  affectedFileCount: affectedFiles.size,
+                  runtimeCount,
+                  typeOnlyCount: impactedItems.filter((i) => i.usageType === 'type-only').length,
+                  impactedItems,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: get_index_status ───────────────────────────────────────────────
+
+  private registerGetIndexStatus(): vscode.Disposable {
+    return vscode.lm.registerTool<Record<string, never>>(
+      'graph-it-live_get_index_status',
+      {
+        invoke: async (
+          _options: vscode.LanguageModelToolInvocationOptions<Record<string, never>>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  state: 'uninitialized',
+                  isReady: false,
+                  message: 'No workspace open or dependency index not initialized.',
+                }),
+              ),
+            ]);
+          }
+          try {
+            const indexStatus = spider.getIndexStatus();
+            const cacheStats = await spider.getCacheStatsAsync();
+            const normalizedState =
+              indexStatus.state === 'validating' ? 'indexing' : indexStatus.state;
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  state: normalizedState,
+                  isReady:
+                    indexStatus.state === 'idle' ||
+                    indexStatus.state === 'complete',
+                  hasReverseIndex: spider.hasReverseIndex(),
+                  cacheSize: cacheStats.dependencyCache.size,
+                  reverseIndexStats: cacheStats.reverseIndexStats,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: parse_imports ──────────────────────────────────────────────────
+
+  private registerParseImports(): vscode.Disposable {
+    return vscode.lm.registerTool<ParseImportsInput>(
+      'graph-it-live_parse_imports',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<ParseImportsInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath } = options.input;
+          try {
+            // spider.analyze() runs the full parser pipeline and returns resolved imports
+            const imports = await spider.analyze(filePath);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  importCount: imports.length,
+                  imports: imports.map((imp) => ({
+                    module: imp.module,
+                    type: imp.type,
+                    line: imp.line,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: generate_codemap ───────────────────────────────────────────────
+
+  private registerGenerateCodemap(): vscode.Disposable {
+    return vscode.lm.registerTool<GenerateCodemapInput>(
+      'graph-it-live_generate_codemap',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<GenerateCodemapInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          const startTime = Date.now();
+          try {
+            const ext = nodePath.extname(filePath).toLowerCase();
+            const language = detectLanguageFromExtension(ext);
+            const relativePath = rootDir ? toRelativePath(filePath, rootDir) : filePath;
+
+            const content = await fs.readFile(filePath, 'utf-8');
+            const lineCount = content.split('\n').length;
+
+            const [{ symbols, dependencies: symbolDeps }, deps] = await Promise.all([
+              spider.getSymbolGraph(filePath),
+              spider.analyze(filePath),
+            ]);
+
+            let refs: Dependency[] = [];
+            try {
+              refs = await spider.findReferencingFiles(filePath);
+            } catch {
+              // reverse index may not be ready yet — non-fatal
+            }
+
+            let callFlow: Array<{ caller: string; callee: string; line: number }> = [];
+            let hasCycle = false;
+            let cycleSymbols: string[] = [];
+            try {
+              const lspData = convertSpiderToLspFormat(
+                { symbols, dependencies: symbolDeps },
+                filePath,
+              );
+              const analyzer = new LspCallHierarchyAnalyzer();
+              const graph = analyzer.buildIntraFileGraph(filePath, lspData);
+              callFlow = graph.edges.map((e) => ({
+                caller: stripFilePrefix(e.source),
+                callee: stripFilePrefix(e.target),
+                line: e.line,
+              }));
+              hasCycle = graph.hasCycle;
+              cycleSymbols = (graph.cycleNodes ?? []).map(stripFilePrefix);
+            } catch {
+              // call hierarchy analysis failed — non-fatal, return partial result
+            }
+
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  relativePath,
+                  language,
+                  lineCount,
+                  exports: symbols
+                    .filter((s) => s.isExported)
+                    .map((s) => ({
+                      name: s.name,
+                      kind: s.kind,
+                      line: s.line,
+                      category: s.category,
+                    })),
+                  internals: symbols
+                    .filter((s) => !s.isExported)
+                    .map((s) => ({
+                      name: s.name,
+                      kind: s.kind,
+                      line: s.line,
+                      category: s.category,
+                    })),
+                  dependencies: deps.map((d) => ({
+                    module: d.module,
+                    resolvedPath: d.path,
+                    relativePath: d.path && rootDir ? toRelativePath(d.path, rootDir) : null,
+                    type: d.type,
+                    line: d.line,
+                  })),
+                  dependents: refs.map((r) => ({
+                    path: r.path,
+                    relativePath: rootDir ? toRelativePath(r.path, rootDir) : r.path,
+                    type: r.type,
+                    line: r.line,
+                  })),
+                  callFlow,
+                  hasCycle,
+                  cycleSymbols,
+                  analysisTimeMs: Date.now() - startTime,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: expand_node ─────────────────────────────────────────────────────
+
+  private registerExpandNode(): vscode.Disposable {
+    return vscode.lm.registerTool<ExpandNodeInput>(
+      'graph-it-live_expand_node',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<ExpandNodeInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath, knownPaths = [] } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const graph = await spider.crawl(filePath);
+            const knownSet = new Set(knownPaths.map((p) => p.replaceAll('\\', '/')));
+            const newNodes = graph.nodes.filter(
+              (n) => !knownSet.has(n.replaceAll('\\', '/')),
+            );
+            const newNodeIds = new Set(newNodes);
+            const newEdges = graph.edges.filter(
+              (e) => newNodeIds.has(e.source) || newNodeIds.has(e.target),
+            );
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  newNodeCount: newNodes.length,
+                  newEdgeCount: newEdges.length,
+                  newNodes: newNodes.map((n) => ({
+                    path: n,
+                    relativePath: rootDir ? toRelativePath(n, rootDir) : n,
+                  })),
+                  newEdges: newEdges.map((e) => ({
+                    source: e.source,
+                    target: e.target,
+                    sourceRelative: rootDir ? toRelativePath(e.source, rootDir) : e.source,
+                    targetRelative: rootDir ? toRelativePath(e.target, rootDir) : e.target,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: verify_dependency_usage ─────────────────────────────────────────
+
+  private registerVerifyDependencyUsage(): vscode.Disposable {
+    return vscode.lm.registerTool<VerifyDependencyUsageInput>(
+      'graph-it-live_verify_dependency_usage',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<VerifyDependencyUsageInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { sourceFile, targetFile } = options.input;
+          try {
+            const isUsed = await spider.verifyDependencyUsage(sourceFile, targetFile);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({ sourceFile, targetFile, isUsed }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: invalidate_files ────────────────────────────────────────────────
+
+  private registerInvalidateFiles(): vscode.Disposable {
+    return vscode.lm.registerTool<InvalidateFilesInput>(
+      'graph-it-live_invalidate_files',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<InvalidateFilesInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePaths } = options.input;
+          try {
+            const invalidatedFiles: string[] = [];
+            const notFoundFiles: string[] = [];
+            for (const fp of filePaths) {
+              const wasInvalidated = spider.invalidateFile(fp);
+              if (wasInvalidated) {
+                invalidatedFiles.push(fp);
+              } else {
+                notFoundFiles.push(fp);
+              }
+            }
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  invalidatedCount: invalidatedFiles.length,
+                  invalidatedFiles,
+                  notFoundFiles,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: rebuild_index ───────────────────────────────────────────────────
+
+  private registerRebuildIndex(): vscode.Disposable {
+    return vscode.lm.registerTool<Record<string, never>>(
+      'graph-it-live_rebuild_index',
+      {
+        invoke: async (
+          _options: vscode.LanguageModelToolInvocationOptions<Record<string, never>>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          try {
+            const startTime = Date.now();
+            spider.clearCache();
+            await spider.buildFullIndex();
+            const rebuildTimeMs = Date.now() - startTime;
+            const cacheStats = await spider.getCacheStatsAsync();
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  rebuildTimeMs,
+                  newCacheSize: cacheStats.dependencyCache.size,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: get_symbol_dependents ──────────────────────────────────────────
+
+  private registerGetSymbolDependents(): vscode.Disposable {
+    return vscode.lm.registerTool<GetSymbolDependentsInput>(
+      'graph-it-live_get_symbol_dependents',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<GetSymbolDependentsInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath, symbolName } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const dependents = await spider.getSymbolDependents(filePath, symbolName);
+            const symbolId = `${filePath}:${symbolName}`;
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  symbolId,
+                  dependentCount: dependents.length,
+                  dependents: dependents.map((d) => ({
+                    symbolId: d.targetSymbolId ?? d.sourceSymbolId,
+                    filePath: d.targetFilePath,
+                    relativePath: d.targetFilePath && rootDir
+                      ? toRelativePath(d.targetFilePath, rootDir)
+                      : d.targetFilePath,
+                  })),
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: trace_function_execution ───────────────────────────────────────
+
+  private registerTraceFunctionExecution(): vscode.Disposable {
+    return vscode.lm.registerTool<TraceFunctionExecutionInput>(
+      'graph-it-live_trace_function_execution',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<TraceFunctionExecutionInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath, symbolName, maxDepth = 10 } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const result = await spider.traceFunctionExecution(filePath, symbolName, maxDepth);
+            const relativePath = rootDir ? toRelativePath(filePath, rootDir) : filePath;
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  rootSymbol: {
+                    id: result.rootSymbol.id,
+                    filePath: result.rootSymbol.filePath,
+                    relativePath,
+                    symbolName: result.rootSymbol.symbolName,
+                  },
+                  maxDepth,
+                  callCount: result.callChain.length,
+                  uniqueSymbolCount: result.visitedSymbols.length,
+                  maxDepthReached: result.maxDepthReached,
+                  callChain: result.callChain.map((entry) => ({
+                    depth: entry.depth,
+                    callerSymbolId: entry.callerSymbolId,
+                    calledSymbolId: entry.calledSymbolId,
+                    calledFilePath: entry.calledFilePath,
+                    resolvedFilePath: entry.resolvedFilePath,
+                    resolvedRelativePath: entry.resolvedFilePath && rootDir
+                      ? toRelativePath(entry.resolvedFilePath, rootDir)
+                      : null,
+                  })),
+                  visitedSymbols: result.visitedSymbols,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: analyze_file_logic ──────────────────────────────────────────────
+
+  private registerAnalyzeFileLogic(): vscode.Disposable {
+    return vscode.lm.registerTool<AnalyzeFileLogicInput>(
+      'graph-it-live_analyze_file_logic',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<AnalyzeFileLogicInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { filePath } = options.input;
+          const startTime = Date.now();
+          try {
+            const symbolGraphData = await spider.getSymbolGraph(filePath);
+            const lspData = convertSpiderToLspFormat(symbolGraphData, filePath);
+            const analyzer = new LspCallHierarchyAnalyzer();
+            const graph = analyzer.buildIntraFileGraph(filePath, lspData);
+            const analysisTimeMs = Date.now() - startTime;
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  graph: {
+                    nodes: graph.nodes,
+                    edges: graph.edges,
+                    hasCycle: graph.hasCycle,
+                    cycleNodes: graph.cycleNodes ?? [],
+                    cycleType: graph.cycleType,
+                  },
+                  analysisTimeMs,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: resolve_module_path ─────────────────────────────────────────────
+
+  private registerResolveModulePath(): vscode.Disposable {
+    return vscode.lm.registerTool<ResolveModulePathInput>(
+      'graph-it-live_resolve_module_path',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<ResolveModulePathInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const spider = this.provider.getSpiderForLmTools();
+          if (!spider) {
+            return this.errorResult('No workspace open or dependency index not initialized.');
+          }
+          const { fromFile, moduleSpecifier } = options.input;
+          const rootDir = this.getWorkspaceRoot();
+          try {
+            const resolvedPath = await spider.resolveModuleSpecifier(fromFile, moduleSpecifier);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  fromFile,
+                  moduleSpecifier,
+                  resolved: resolvedPath !== null,
+                  resolvedPath,
+                  resolvedRelativePath: resolvedPath && rootDir
+                    ? toRelativePath(resolvedPath, rootDir)
+                    : null,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: analyze_breaking_changes ───────────────────────────────────────
+
+  private registerAnalyzeBreakingChanges(): vscode.Disposable {
+    return vscode.lm.registerTool<AnalyzeBreakingChangesInput>(
+      'graph-it-live_analyze_breaking_changes',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<AnalyzeBreakingChangesInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const { filePath, oldContent, symbolName, newContent: inputNewContent } = options.input;
+          let newContent = inputNewContent;
+          if (!newContent) {
+            try {
+              newContent = await fs.readFile(filePath, 'utf-8');
+            } catch {
+              return this.errorResult(`Cannot read current file: ${filePath}`);
+            }
+          }
+          try {
+            const { SignatureAnalyzer } = await import('@/analyzer/SignatureAnalyzer');
+            const analyzer = new SignatureAnalyzer();
+            let results = analyzer.analyzeBreakingChanges(filePath, oldContent, newContent);
+            if (symbolName) {
+              results = results.filter(r => r.symbolName === symbolName);
+            }
+            const breakingChanges = results.flatMap(r => r.breakingChanges);
+            const nonBreakingChanges = results.flatMap(r => r.nonBreakingChanges);
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({
+                  filePath,
+                  symbolName: symbolName ?? null,
+                  hasBreakingChanges: breakingChanges.length > 0,
+                  breakingChangesCount: breakingChanges.length,
+                  nonBreakingChangesCount: nonBreakingChanges.length,
+                  breakingChanges,
+                  nonBreakingChanges,
+                }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  // ─── Tool: query_call_graph ────────────────────────────────────────────────
+
+  private registerQueryCallGraph(): vscode.Disposable {
+    return vscode.lm.registerTool<QueryCallGraphInput>(
+      'graph-it-live_query_call_graph',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<QueryCallGraphInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const callGraphService = this.provider.getCallGraphViewServiceForLmTools();
+          const indexer = callGraphService?.getCallGraphIndexerForLmTools();
+          if (!indexer) {
+            return this.errorResult(
+              'Call graph index not available. Open the Call Graph panel (graph-it-live.showCallGraph) first to build the index.',
+            );
+          }
+          const { filePath, symbolName, direction = 'both', depth = 2, relationTypes } = options.input;
+          try {
+            const { normalizePath } = await import('@/shared/path');
+            const db = indexer.getDb();
+            const normalizedPath = normalizePath(filePath);
+            const symbolRows = db.exec(
+              'SELECT id, name, type, lang, path, start_line, end_line, is_exported FROM nodes WHERE path = ? AND name = ?',
+              [normalizedPath, symbolName],
+            );
+            if (!symbolRows[0] || symbolRows[0].values.length === 0) {
+              return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(
+                  JSON.stringify({ symbol: null, callers: [], callees: [], totalCallers: 0, totalCallees: 0, depth, direction }),
+                ),
+              ]);
+            }
+            const row = symbolRows[0].values[0];
+            const symbolId = row[0] as string;
+            const symbol = {
+              id: symbolId, name: row[1] as string, type: row[2] as string,
+              lang: row[3] as string, filePath: row[4] as string,
+              startLine: row[5] as number, endLine: row[6] as number,
+              isExported: (row[7] as number) === 1,
+            };
+            const callers = (direction === 'callers' || direction === 'both')
+              ? this.callGraphBfs(db, symbolId, 'callers', depth, relationTypes ?? null) : [];
+            const callees = (direction === 'callees' || direction === 'both')
+              ? this.callGraphBfs(db, symbolId, 'callees', depth, relationTypes ?? null) : [];
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(
+                JSON.stringify({ symbol, callers, callees, totalCallers: callers.length, totalCallees: callees.length, depth, direction }),
+              ),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
+  }
+
+  private callGraphBfs(
+    db: import('sql.js').Database,
+    rootId: string,
+    dir: 'callers' | 'callees',
+    maxDepth: number,
+    relationFilter: string[] | null,
+  ): unknown[] {
+    const visited = new Set<string>();
+    const results: unknown[] = [];
+    let frontier = new Set<string>([rootId]);
+    for (let d = 0; d < maxDepth && frontier.size > 0; d++) {
+      const next = new Set<string>();
+      for (const nodeId of frontier) {
+        if (visited.has(nodeId)) continue;
+        visited.add(nodeId);
+        this.callGraphExpandNode(db, nodeId, dir, relationFilter, results, visited, next);
+      }
+      frontier = next;
+    }
+    return results;
+  }
+
+  private callGraphExpandNode(
+    db: import('sql.js').Database,
+    nodeId: string,
+    dir: 'callers' | 'callees',
+    relationFilter: string[] | null,
+    results: unknown[],
+    visited: Set<string>,
+    next: Set<string>,
+  ): void {
+    const joinCol = dir === 'callers' ? 'e.target_id' : 'e.source_id';
+    const otherCol = dir === 'callers' ? 'e.source_id' : 'e.target_id';
+    let sql = `SELECT e.source_id, e.target_id, e.type_relation, e.is_cyclic, e.source_line,
+      src.name, src.path, tgt.name, tgt.path
+      FROM edges e
+      JOIN nodes src ON src.id = e.source_id
+      JOIN nodes tgt ON tgt.id = e.target_id
+      WHERE ${joinCol} = ?`;
+    const params: (string | number)[] = [nodeId];
+    if (relationFilter && relationFilter.length > 0) {
+      sql += ` AND e.type_relation IN (${relationFilter.map(() => '?').join(',')})`;
+      params.push(...relationFilter);
+    }
+    sql += ` AND ${otherCol} NOT LIKE '@@external:%'`;
+    const rows = db.exec(sql, params);
+    if (!rows[0]) return;
+    for (const r of rows[0].values) {
+      results.push({
+        sourceId: r[0], targetId: r[1], relation: r[2],
+        isCyclic: (r[3] as number) === 1, sourceLine: r[4],
+        sourceName: r[5], sourceFile: r[6], targetName: r[7], targetFile: r[8],
+      });
+      const nextId = (dir === 'callers' ? r[0] : r[1]) as string;
+      if (!visited.has(nextId)) next.add(nextId);
+    }
+  }
+}

--- a/tests/extension/services/LmToolsService.test.ts
+++ b/tests/extension/services/LmToolsService.test.ts
@@ -1,0 +1,442 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GraphProvider } from '../../../src/extension/GraphProvider';
+import type { VsCodeLogger } from '../../../src/extension/extensionLogger';
+import { LmToolsService } from '../../../src/extension/services/LmToolsService';
+
+// ─── Shared mock state (vi.hoisted ensures it's accessible inside vi.mock factories) ──
+
+const { registeredTools, registerToolFn } = vi.hoisted(() => {
+  const registeredTools = new Map<string, { invoke: (...args: unknown[]) => Promise<unknown> }>();
+  const registerToolFn = vi.fn(
+    (name: string, handler: { invoke: (...args: unknown[]) => Promise<unknown> }) => {
+      registeredTools.set(name, handler);
+      return { dispose: vi.fn() };
+    },
+  );
+  return { registeredTools, registerToolFn };
+});
+
+// ─── vscode mock ──────────────────────────────────────────────────────────────
+
+vi.mock('vscode', () => {
+  class LanguageModelTextPart {
+    constructor(public readonly value: string) {}
+  }
+
+  class LanguageModelToolResult {
+    constructor(public readonly parts: LanguageModelTextPart[]) {}
+  }
+
+  return {
+    lm: {
+      registerTool: registerToolFn,
+    },
+    workspace: {
+      workspaceFolders: [{ uri: { fsPath: '/workspace' } }],
+    },
+    LanguageModelTextPart,
+    LanguageModelToolResult,
+  };
+});
+
+// ─── Dynamic-import mocks ─────────────────────────────────────────────────────
+
+vi.mock('@/analyzer/SignatureAnalyzer', () => ({
+  SignatureAnalyzer: class {
+    analyzeBreakingChanges(_file: string, _old: string, _new: string) {
+      return [
+        {
+          symbolName: 'myFn',
+          breakingChanges: [{ type: 'parameter_added', description: 'param x added' }],
+          nonBreakingChanges: [{ type: 'doc_comment', description: 'updated JSDoc' }],
+        },
+      ];
+    }
+  },
+}));
+
+vi.mock('@/shared/path', () => ({
+  normalizePath: (p: string) => p.replaceAll('\\', '/'),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+import * as vscode from 'vscode';
+import * as fsPromises from 'node:fs/promises';
+
+function createLogger(): VsCodeLogger {
+  return {
+    error: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    setLevel: vi.fn(),
+    level: 'info',
+    show: vi.fn(),
+  } as unknown as VsCodeLogger;
+}
+
+function createProvider(overrides: Partial<{
+  spider: unknown;
+  callGraphService: unknown;
+}> = {}): GraphProvider {
+  const spider = overrides.spider ?? {
+    resolveModuleSpecifier: vi.fn().mockResolvedValue(null),
+    findReferencingFiles: vi.fn().mockResolvedValue([]),
+    analyzeFileDependencies: vi.fn().mockResolvedValue({ imports: [], exports: [], language: 'typescript' }),
+    crawlDependencyGraph: vi.fn().mockResolvedValue({ nodes: [], edges: [] }),
+    getSymbolGraph: vi.fn().mockResolvedValue({ symbols: [], dependencies: [] }),
+    findUnusedSymbols: vi.fn().mockResolvedValue([]),
+    getSymbolCallers: vi.fn().mockResolvedValue([]),
+    getImpactAnalysis: vi.fn().mockResolvedValue([]),
+    getIndexStatus: vi.fn().mockResolvedValue({ totalFiles: 0, indexedFiles: 0 }),
+    parseImports: vi.fn().mockResolvedValue({ imports: [] }),
+    generateCodemap: vi.fn().mockResolvedValue(''),
+    verifyDependencyUsage: vi.fn().mockResolvedValue(false),
+    invalidateFile: vi.fn().mockReturnValue(false),
+    clearCache: vi.fn(),
+    buildFullIndex: vi.fn().mockResolvedValue(undefined),
+    getCacheStatsAsync: vi.fn().mockResolvedValue({ dependencyCache: { size: 0 } }),
+    getSymbolDependents: vi.fn().mockResolvedValue([]),
+    traceFunctionExecution: vi.fn().mockResolvedValue({ rootSymbol: { id: '', filePath: '', symbolName: '' }, callChain: [], visitedSymbols: [], maxDepthReached: false }),
+  };
+
+  return {
+    getSpiderForLmTools: vi.fn().mockReturnValue(spider),
+    getCallGraphViewServiceForLmTools: vi.fn().mockReturnValue(overrides.callGraphService ?? null),
+  } as unknown as GraphProvider;
+}
+
+function makeOptions<T>(input: T): vscode.LanguageModelToolInvocationOptions<T> {
+  return { input } as vscode.LanguageModelToolInvocationOptions<T>;
+}
+
+const fakeToken = {} as vscode.CancellationToken;
+
+function parseResult(result: unknown): unknown {
+  const parts = (result as { parts: { value: string }[] }).parts;
+  return JSON.parse(parts[0].value);
+}
+
+async function invokeTool<T>(name: string, input: T): Promise<unknown> {
+  const handler = registeredTools.get(name);
+  if (!handler) throw new Error(`Tool "${name}" not registered`);
+  return parseResult(await handler.invoke(makeOptions(input), fakeToken));
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('LmToolsService', () => {
+  let logger: VsCodeLogger;
+
+  beforeEach(() => {
+    logger = createLogger();
+    registeredTools.clear();
+    registerToolFn.mockClear();
+    vi.mocked(fsPromises.readFile).mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+    );
+  });
+
+  // ─── registerAll ──────────────────────────────────────────────────────────
+
+  describe('registerAll', () => {
+    it('registers 20 tools and returns 20 disposables', () => {
+      const provider = createProvider();
+      const service = new LmToolsService({ provider, logger });
+      const disposables = service.registerAll();
+
+      expect(disposables).toHaveLength(20);
+      expect(registerToolFn).toHaveBeenCalledTimes(20);
+    });
+
+    it('returns empty array when vscode.lm.registerTool is unavailable', () => {
+      // Remove registerTool from the lm namespace
+      const origRegisterTool = (vscode.lm as Record<string, unknown>).registerTool;
+      delete (vscode.lm as Record<string, unknown>).registerTool;
+
+      const provider = createProvider();
+      const service = new LmToolsService({ provider, logger });
+      const disposables = service.registerAll();
+
+      expect(disposables).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('not available'));
+
+      // Restore
+      (vscode.lm as Record<string, unknown>).registerTool = origRegisterTool;
+    });
+
+    it('registers graph-it-live_resolve_module_path', () => {
+      const provider = createProvider();
+      const service = new LmToolsService({ provider, logger });
+      service.registerAll();
+      expect(registeredTools.has('graph-it-live_resolve_module_path')).toBe(true);
+    });
+
+    it('registers graph-it-live_analyze_breaking_changes', () => {
+      const provider = createProvider();
+      const service = new LmToolsService({ provider, logger });
+      service.registerAll();
+      expect(registeredTools.has('graph-it-live_analyze_breaking_changes')).toBe(true);
+    });
+
+    it('registers graph-it-live_query_call_graph', () => {
+      const provider = createProvider();
+      const service = new LmToolsService({ provider, logger });
+      service.registerAll();
+      expect(registeredTools.has('graph-it-live_query_call_graph')).toBe(true);
+    });
+  });
+
+  // ─── resolve_module_path ──────────────────────────────────────────────────
+
+  describe('resolve_module_path', () => {
+    const TOOL = 'graph-it-live_resolve_module_path';
+
+    beforeEach(() => {
+      const provider = createProvider();
+      const service = new LmToolsService({ provider, logger });
+      service.registerAll();
+    });
+
+    it('returns error when spider is unavailable', async () => {
+      // Re-register with no-spider provider
+      registeredTools.clear();
+      const provider = createProvider();
+      (provider.getSpiderForLmTools as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, { fromFile: '/workspace/src/a.ts', moduleSpecifier: './b' });
+      expect(result).toMatchObject({ error: expect.stringContaining('No workspace') });
+    });
+
+    it('returns resolved: false when specifier does not resolve', async () => {
+      registeredTools.clear();
+      const spider = { resolveModuleSpecifier: vi.fn().mockResolvedValue(null) };
+      const provider = createProvider({ spider });
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, {
+        fromFile: '/workspace/src/a.ts',
+        moduleSpecifier: './nonexistent',
+      }) as Record<string, unknown>;
+
+      expect(result.resolved).toBe(false);
+      expect(result.resolvedPath).toBeNull();
+      expect(result.resolvedRelativePath).toBeNull();
+    });
+
+    it('returns resolved: true with relative path when specifier resolves', async () => {
+      registeredTools.clear();
+      const spider = {
+        resolveModuleSpecifier: vi.fn().mockResolvedValue('/workspace/src/b.ts'),
+      };
+      const provider = createProvider({ spider });
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, {
+        fromFile: '/workspace/src/a.ts',
+        moduleSpecifier: './b',
+      }) as Record<string, unknown>;
+
+      expect(result.resolved).toBe(true);
+      expect(result.resolvedPath).toBe('/workspace/src/b.ts');
+      expect(result.resolvedRelativePath).toBe('src/b.ts');
+    });
+
+    it('returns error when spider throws', async () => {
+      registeredTools.clear();
+      const spider = {
+        resolveModuleSpecifier: vi.fn().mockRejectedValue(new Error('parse error')),
+      };
+      const provider = createProvider({ spider });
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, {
+        fromFile: '/workspace/src/a.ts',
+        moduleSpecifier: './b',
+      }) as Record<string, unknown>;
+
+      expect(result).toMatchObject({ error: 'parse error' });
+    });
+  });
+
+  // ─── analyze_breaking_changes ─────────────────────────────────────────────
+
+  describe('analyze_breaking_changes', () => {
+    const TOOL = 'graph-it-live_analyze_breaking_changes';
+
+    beforeEach(() => {
+      const provider = createProvider();
+      new LmToolsService({ provider, logger }).registerAll();
+    });
+
+    it('returns breaking changes when both oldContent and newContent provided', async () => {
+      const result = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        oldContent: 'export function myFn() {}',
+        newContent: 'export function myFn(x: string) {}',
+      }) as Record<string, unknown>;
+
+      expect(result.hasBreakingChanges).toBe(true);
+      expect(result.breakingChangesCount).toBe(1);
+      expect(result.breakingChanges).toHaveLength(1);
+      expect(result.nonBreakingChanges).toHaveLength(1);
+    });
+
+    it('filters results by symbolName when provided', async () => {
+      // The mock returns results for 'myFn' only
+      const resultMatching = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        oldContent: 'export function myFn() {}',
+        newContent: 'export function myFn(x: string) {}',
+        symbolName: 'myFn',
+      }) as Record<string, unknown>;
+
+      expect(resultMatching.symbolName).toBe('myFn');
+      expect(resultMatching.breakingChangesCount).toBe(1);
+
+      const resultNonMatching = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        oldContent: 'export function other() {}',
+        newContent: 'export function other(x: string) {}',
+        symbolName: 'other',
+      }) as Record<string, unknown>;
+
+      // Mock only returns results for 'myFn', filter for 'other' yields nothing
+      expect(resultNonMatching.breakingChangesCount).toBe(0);
+      expect(resultNonMatching.hasBreakingChanges).toBe(false);
+    });
+
+    it('returns error when newContent is missing and file cannot be read', async () => {
+      vi.mocked(fsPromises.readFile).mockRejectedValue(new Error('File not found'));
+
+      const result = await invokeTool(TOOL, {
+        filePath: '/workspace/src/missing.ts',
+        oldContent: 'export function myFn() {}',
+      }) as Record<string, unknown>;
+
+      expect(result).toMatchObject({ error: expect.stringContaining('Cannot read current file') });
+    });
+
+    it('reads current file content when newContent is not provided', async () => {
+      vi.mocked(fsPromises.readFile).mockResolvedValue(
+        'export function myFn(x: string) {}' as unknown as Awaited<ReturnType<typeof fsPromises.readFile>>,
+      );
+
+      const result = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        oldContent: 'export function myFn() {}',
+      }) as Record<string, unknown>;
+
+      expect(result.hasBreakingChanges).toBe(true);
+      expect(fsPromises.readFile).toHaveBeenCalledWith('/workspace/src/a.ts', 'utf-8');
+    });
+  });
+
+  // ─── query_call_graph ─────────────────────────────────────────────────────
+
+  describe('query_call_graph', () => {
+    const TOOL = 'graph-it-live_query_call_graph';
+
+    it('returns error when call graph index is not available', async () => {
+      const provider = createProvider({ callGraphService: null });
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        symbolName: 'myFn',
+      }) as Record<string, unknown>;
+
+      expect(result).toMatchObject({ error: expect.stringContaining('Call graph index not available') });
+    });
+
+    it('returns empty result when symbol is not found in DB', async () => {
+      const mockDb = { exec: vi.fn().mockReturnValue([]) };
+      const mockIndexer = { getDb: vi.fn().mockReturnValue(mockDb) };
+      const mockCallGraphService = { getCallGraphIndexerForLmTools: vi.fn().mockReturnValue(mockIndexer) };
+
+      const provider = createProvider({ callGraphService: mockCallGraphService });
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        symbolName: 'unknownFn',
+      }) as Record<string, unknown>;
+
+      expect(result.symbol).toBeNull();
+      expect(result.callers).toEqual([]);
+      expect(result.callees).toEqual([]);
+      expect(result.totalCallers).toBe(0);
+      expect(result.totalCallees).toBe(0);
+    });
+
+    it('returns symbol info and BFS results when symbol is found', async () => {
+      const symbolRow = ['sym1', 'myFn', 'function', 'typescript', '/workspace/src/a.ts', 10, 20, 1];
+      const edgeRow = ['sym2', 'sym1', 'call', 0, 15, 'caller', '/workspace/src/b.ts', 'myFn', '/workspace/src/a.ts'];
+
+      const mockDb = {
+        exec: vi.fn()
+          // First call: SELECT symbol by path + name
+          .mockReturnValueOnce([{ values: [symbolRow] }])
+          // Second call: BFS callers (depth 1, finding sym2 → sym1)
+          .mockReturnValueOnce([{ values: [edgeRow] }])
+          // Third call: BFS callees
+          .mockReturnValueOnce([{ values: [] }])
+          // Remaining BFS iterations: no more edges
+          .mockReturnValue([{ values: [] }]),
+      };
+      const mockIndexer = { getDb: vi.fn().mockReturnValue(mockDb) };
+      const mockCallGraphService = { getCallGraphIndexerForLmTools: vi.fn().mockReturnValue(mockIndexer) };
+
+      const provider = createProvider({ callGraphService: mockCallGraphService });
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        symbolName: 'myFn',
+        direction: 'both',
+        depth: 1,
+      }) as Record<string, unknown>;
+
+      expect(result.symbol).toMatchObject({
+        id: 'sym1',
+        name: 'myFn',
+        type: 'function',
+        lang: 'typescript',
+      });
+      expect(result.totalCallers).toBe(1);
+      expect(result.totalCallees).toBe(0);
+      expect(result.direction).toBe('both');
+      expect(result.depth).toBe(1);
+    });
+
+    it('queries only callers when direction is "callers"', async () => {
+      const symbolRow = ['sym1', 'myFn', 'function', 'typescript', '/workspace/src/a.ts', 1, 5, 1];
+
+      const mockDb = {
+        exec: vi.fn()
+          .mockReturnValueOnce([{ values: [symbolRow] }]) // symbol lookup
+          .mockReturnValue([{ values: [] }]),              // BFS callers (empty)
+      };
+      const mockIndexer = { getDb: vi.fn().mockReturnValue(mockDb) };
+      const mockCallGraphService = { getCallGraphIndexerForLmTools: vi.fn().mockReturnValue(mockIndexer) };
+
+      const provider = createProvider({ callGraphService: mockCallGraphService });
+      new LmToolsService({ provider, logger }).registerAll();
+
+      const result = await invokeTool(TOOL, {
+        filePath: '/workspace/src/a.ts',
+        symbolName: 'myFn',
+        direction: 'callers',
+      }) as Record<string, unknown>;
+
+      expect(result.direction).toBe('callers');
+      expect(result.callees).toEqual([]);
+    });
+  });
+});

--- a/tests/extension/services/LmToolsService.test.ts
+++ b/tests/extension/services/LmToolsService.test.ts
@@ -65,8 +65,8 @@ vi.mock('node:fs/promises', () => ({
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-import * as vscode from 'vscode';
 import * as fsPromises from 'node:fs/promises';
+import * as vscode from 'vscode';
 
 function createLogger(): VsCodeLogger {
   return {

--- a/tests/vscode-e2e/suite/lmTools.test.ts
+++ b/tests/vscode-e2e/suite/lmTools.test.ts
@@ -1,0 +1,134 @@
+/**
+ * E2E Tests for native Language Model Tools registration.
+ *
+ * Verifies that after extension activation all 20 Graph-It-Live LM tools
+ * are present in `vscode.lm.tools`.  Tests are skipped gracefully when the
+ * VS Code host doesn't support `vscode.lm.tools` (pre-1.90 or non-Copilot
+ * environments) so they never cause false failures on older CI agents.
+ *
+ * New tools added in session (v1.8.0):
+ *   - graph-it-live_resolve_module_path
+ *   - graph-it-live_analyze_breaking_changes
+ *   - graph-it-live_query_call_graph
+ */
+
+import { before } from 'mocha';
+import * as assert from 'node:assert';
+import * as vscode from 'vscode';
+
+// Minimum set of expected tool names (all 20).
+const EXPECTED_TOOLS = [
+  'graph-it-live_find_referencing_files',
+  'graph-it-live_analyze_dependencies',
+  'graph-it-live_crawl_dependency_graph',
+  'graph-it-live_get_symbol_graph',
+  'graph-it-live_find_unused_symbols',
+  'graph-it-live_get_symbol_callers',
+  'graph-it-live_get_impact_analysis',
+  'graph-it-live_get_index_status',
+  'graph-it-live_parse_imports',
+  'graph-it-live_generate_codemap',
+  'graph-it-live_expand_node',
+  'graph-it-live_verify_dependency_usage',
+  'graph-it-live_invalidate_files',
+  'graph-it-live_rebuild_index',
+  'graph-it-live_get_symbol_dependents',
+  'graph-it-live_trace_function_execution',
+  'graph-it-live_analyze_file_logic',
+  // v1.8.0 batch 2
+  'graph-it-live_resolve_module_path',
+  'graph-it-live_analyze_breaking_changes',
+  'graph-it-live_query_call_graph',
+];
+
+/** Returns true when vscode.lm.tools is supported by the current host. */
+function lmToolsSupported(): boolean {
+  return (
+    typeof vscode.lm === 'object' &&
+    vscode.lm !== null &&
+    'tools' in vscode.lm &&
+    Array.isArray((vscode.lm as unknown as { tools: unknown }).tools)
+  );
+}
+
+/** Returns registered tools as a plain array, or [] when unsupported. */
+function getRegisteredTools(): ReadonlyArray<{ name: string }> {
+  if (!lmToolsSupported()) return [];
+  return (vscode.lm as unknown as { tools: ReadonlyArray<{ name: string }> }).tools;
+}
+
+suite('LM Tools Registration Test Suite', () => {
+  before(async function () {
+    this.timeout(30000);
+    const ext = vscode.extensions.getExtension('magic5644.graph-it-live');
+    assert.ok(ext, 'Extension should exist');
+    if (!ext.isActive) {
+      await ext.activate();
+    }
+    assert.strictEqual(ext.isActive, true, 'Extension should be active');
+  });
+
+  test('vscode.lm.registerTool is supported in this VS Code version', function () {
+    const supported = typeof (vscode.lm as Record<string, unknown>).registerTool === 'function';
+    if (!supported) {
+      this.skip();
+    }
+    assert.ok(supported, 'vscode.lm.registerTool should be a function');
+  });
+
+  test('All 20 Graph-It-Live LM tools are registered', function () {
+    if (!lmToolsSupported()) {
+      this.skip();
+    }
+
+    const registeredNames = new Set(getRegisteredTools().map((t) => t.name));
+
+    const missing = EXPECTED_TOOLS.filter((name) => !registeredNames.has(name));
+    assert.strictEqual(
+      missing.length,
+      0,
+      `Missing LM tools: ${missing.join(', ')}`,
+    );
+  });
+
+  test('resolve_module_path tool is registered with correct name', function () {
+    if (!lmToolsSupported()) {
+      this.skip();
+    }
+
+    const tool = getRegisteredTools().find((t) => t.name === 'graph-it-live_resolve_module_path');
+    assert.ok(tool, 'graph-it-live_resolve_module_path should be registered');
+  });
+
+  test('analyze_breaking_changes tool is registered with correct name', function () {
+    if (!lmToolsSupported()) {
+      this.skip();
+    }
+
+    const tool = getRegisteredTools().find((t) => t.name === 'graph-it-live_analyze_breaking_changes');
+    assert.ok(tool, 'graph-it-live_analyze_breaking_changes should be registered');
+  });
+
+  test('query_call_graph tool is registered with correct name', function () {
+    if (!lmToolsSupported()) {
+      this.skip();
+    }
+
+    const tool = getRegisteredTools().find((t) => t.name === 'graph-it-live_query_call_graph');
+    assert.ok(tool, 'graph-it-live_query_call_graph should be registered');
+  });
+
+  test('Total Graph-It-Live tool count is exactly 20', function () {
+    if (!lmToolsSupported()) {
+      this.skip();
+    }
+
+    const tools = getRegisteredTools();
+    const graphItLiveTools = tools.filter((t) => t.name.startsWith('graph-it-live_'));
+    assert.strictEqual(
+      graphItLiveTools.length,
+      20,
+      `Expected 20 graph-it-live tools, found ${graphItLiveTools.length}: ${graphItLiveTools.map((t) => t.name).join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
Introduce LmToolsService for registering Graph-It-Live analyzer tools as native LM tools. Enhance extension activation and improve logging for better object handling. Add end-to-end tests to verify the registration of all 20 tools. Reorder imports for clarity.