### PR TITLE
Feat/cli deadcode finder

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -89,6 +89,7 @@ package-lock.json
 codemaps/**
 specs/**
 docs/**
+!docs/CLI.md
 scripts/**
 _bmad/**
 _bmad-output/**

--- a/README.md
+++ b/README.md
@@ -398,7 +398,9 @@ graph-it summary <file>         # Per-file codemap (exports, internals, deps, ca
 graph-it trace <file#Symbol>    # Trace execution flow from an entry symbol
 graph-it explain <file>         # File logic analysis — intra-file call hierarchy
 graph-it path <file>            # Full dependency graph from a file
-graph-it check <file>           # Detect unused exported symbols (dead code)
+graph-it check                  # Scan whole workspace for dead code (unused exports)
+graph-it check <dir>            # Scan a subdirectory for dead code
+graph-it check <file>           # Detect unused exported symbols in a single file
 graph-it serve                  # Launch MCP stdio server (for AI clients)
 graph-it tool --list            # List all 21 MCP tools
 graph-it tool <mcp-tool> [args] # Run any MCP tool directly from the terminal
@@ -502,6 +504,7 @@ The MCP server exposes **21 tools** for AI/LLM consumption. All tools except `se
 | `graphitlive_analyze_file_logic` | Analyze symbol-level call hierarchy and code flow within a file |
 | `graphitlive_generate_codemap` | Generate a comprehensive structured overview of any source file |
 | `graphitlive_query_call_graph` | Query cross-file callers/callees via BFS on the call graph SQLite database |
+| `graphitlive_scan_dead_code` | Scan the entire workspace (or a directory) for unused exported symbols in one call |
 
 ### TOON Format (Token-Optimized Output)
 
@@ -527,7 +530,7 @@ See [TOON Format Documentation](./docs/architecture/TOON_FORMAT.md) for full spe
 
 ### Native LM Tools (Copilot Agent Mode)
 
-All 20 analysis tools are also available **natively in GitHub Copilot** — no MCP server required. Reference them with `#` in Agent mode:
+All 21 analysis tools are also available **natively in GitHub Copilot** — no MCP server required. Reference them with `#` in Agent mode:
 
 | Reference | Tool | Description |
 |---|---|---|
@@ -551,6 +554,7 @@ All 20 analysis tools are also available **natively in GitHub Copilot** — no M
 | `#graphResolve` | `resolve_module_path` | Resolve a module specifier to its absolute path |
 | `#graphBreaking` | `analyze_breaking_changes` | Detect breaking changes between two file versions |
 | `#graphCallGraph` | `query_call_graph` | BFS callers/callees via the SQLite call graph index |
+| `#graphDeadCode` | `scan_dead_code` | Workspace-wide dead code scan — all unused exported symbols |
 
 > **Note:** `#graphCallGraph` requires the Call Graph panel (`graph-it-live.showCallGraph`) to be opened at least once to build the index.
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ All three layers are also exposed to AI via a **21-tool MCP server**, so your as
 
 ## 🤖 Supercharge Your AI Assistant
 
-Stop pasting file paths and explaining your project structure. Graph-It-Live exposes **21 powerful dependency analysis tools** directly to your AI assistant via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), and **20 native LM Tools** directly in Copilot Agent mode (no MCP setup required).
+Stop pasting file paths and explaining your project structure. Graph-It-Live exposes **22 powerful dependency analysis tools** directly to your AI assistant via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), and **21 native LM Tools** directly in Copilot Agent mode (no MCP setup required).
 
 **Works with:** GitHub Copilot, Claude (Desktop & Code), Cursor, Windsurf, Antigravity, and any MCP-compatible client.
 
@@ -439,6 +439,8 @@ This output can be pasted directly into any Markdown renderer (GitHub, Notion, V
 
 **Use as MCP server (no VS Code):** Run `graph-it serve` and point your AI client at it — see [Manual MCP Server Configuration](#manual-mcp-server-configuration).
 
+**Full CLI reference:** See **[docs/CLI.md](docs/CLI.md)** for complete documentation on every command, all options, output format examples, advanced workflows, and the full MCP tools reference.
+
 ---
 
 ## Agent Skill
@@ -729,7 +731,7 @@ Graph-It-Live/
 │   │   └── callgraph/         # Live Call Graph engine
 │   ├── extension/             # VS Code extension host
 │   │   └── services/          # Service layer (graph, symbol, call graph, indexing)
-│   ├── mcp/                   # MCP server (20 AI tools)
+│   ├── mcp/                   # MCP server (22 AI tools)
 │   ├── shared/                # Types, protocols, utilities
 │   └── webview/               # React UI (ReactFlow + Cytoscape.js)
 │       ├── callgraph/         # Call graph panel entry point

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,1172 @@
+# Graph-It-Live CLI Reference
+
+The `graph-it` CLI gives you full access to the dependency analysis engine of Graph-It-Live — **no VS Code required**. Run it in CI pipelines, pre-commit hooks, shell scripts, or in any terminal.
+
+---
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Global Options](#global-options)
+- [Output Formats](#output-formats)
+- [Commands](#commands)
+  - [scan](#scan)
+  - [summary](#summary)
+  - [explain](#explain)
+  - [path](#path)
+  - [check](#check)
+  - [trace](#trace)
+  - [tool](#tool)
+  - [serve](#serve)
+  - [install](#install)
+  - [update](#update)
+- [MCP Tools Reference (via `graph-it tool`)](#mcp-tools-reference-via-graph-it-tool)
+- [Advanced Analysis Workflows](#advanced-analysis-workflows)
+  - [Pre-Refactor Safety Check](#pre-refactor-safety-check)
+  - [Dead Code Audit](#dead-code-audit)
+  - [Architecture Documentation](#architecture-documentation)
+  - [CI Integration](#ci-integration)
+  - [Piping & Scripting](#piping--scripting)
+- [Tool Count: CLI vs MCP](#tool-count-cli-vs-mcp)
+
+---
+
+## Installation
+
+**Global install (recommended):**
+
+```bash
+npm install -g @magic5644/graph-it-live
+```
+
+After installation, `graph-it` is available system-wide:
+
+```bash
+graph-it --version
+graph-it --help
+```
+
+**Without installing globally (via npx):**
+
+```bash
+npx @magic5644/graph-it-live scan
+npx @magic5644/graph-it-live serve
+```
+
+**From VS Code extension:**
+
+If you have the VS Code extension installed, you can expose the bundled binary to your PATH with:
+
+```bash
+graph-it install     # adds graph-it to your system PATH
+```
+
+---
+
+## Quick Start
+
+```bash
+# 1. Go to your project root
+cd /path/to/your/project
+
+# 2. Index the workspace
+graph-it scan
+
+# 3. Get a workspace overview
+graph-it summary
+
+# 4. Analyze a specific file
+graph-it summary src/main.ts
+
+# 5. Find what depends on a file
+graph-it tool find_referencing_files --filePath=$(pwd)/src/utils.ts
+
+# 6. Scan for dead code
+graph-it check
+```
+
+---
+
+## Global Options
+
+These options are available for every command:
+
+| Option | Shorthand | Default | Description |
+|--------|-----------|---------|-------------|
+| `--workspace <path>` | `-w` | auto-detected from `cwd` | Root directory of the project to analyze |
+| `--format <format>` | `-f` | `text` | Output format: `text`, `json`, `toon`, `markdown`, `mermaid` |
+| `--help` | `-h` | — | Show help for the current command |
+| `--version` | `-v` | — | Print the installed version |
+
+**Workspace auto-detection:** If `--workspace` is omitted, `graph-it` looks for a `package.json`, `tsconfig.json`, `pyproject.toml`, or `Cargo.toml` in the current directory and its ancestors.
+
+```bash
+# Explicit workspace
+graph-it scan --workspace /abs/path/to/project
+
+# Let it auto-detect from cwd
+cd /path/to/project && graph-it scan
+```
+
+---
+
+## Output Formats
+
+All analysis commands support multiple output formats via `--format`:
+
+| Format | Description | Best for |
+|--------|-------------|----------|
+| `text` *(default)* | Human-readable structured text | Terminal inspection |
+| `json` | Standard JSON | Scripting, piping to `jq` |
+| `toon` | Compact Token-Oriented Object Notation | AI consumption (30–60% token savings) |
+| `markdown` | Data wrapped in a Markdown code block | Reports, documentation |
+| `mermaid` | Mermaid flowchart diagram syntax | Architecture docs, README, Notion |
+
+**Format availability per command:**
+
+| Format | scan | summary | explain | path | check | trace | tool |
+|--------|:----:|:-------:|:-------:|:----:|:-----:|:-----:|:----:|
+| `text` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `json` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `toon` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `markdown` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `mermaid` | — | — | — | ✓ | — | ✓ | — |
+
+**Examples:**
+
+```bash
+graph-it summary src/app.ts --format json
+graph-it path src/index.ts --format mermaid      # → paste in GitHub, Notion, VS Code Preview
+graph-it check --format markdown                  # → paste in a PR description
+graph-it summary --format toon                    # → feed to an LLM
+```
+
+---
+
+## Commands
+
+### scan
+
+Index (or re-index) the workspace. Must be run before other analysis commands on first use; subsequent commands index automatically if needed.
+
+```
+graph-it scan [options]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root to index |
+| `--format, -f` | `text` | Output format |
+
+**What it does:**
+
+1. Walks the workspace and parses every source file
+2. Builds a dependency graph in memory (import/export edges)
+3. Constructs a reverse index for O(1) "who imports this?" lookups
+4. Prints index statistics: files indexed, total edges, duration
+
+**Output (text):**
+
+```
+Indexed 347 files, 1 824 edges in 3.2 s
+  TypeScript: 284 files
+  JavaScript: 63 files
+  Cycles detected: 2
+```
+
+**Examples:**
+
+```bash
+graph-it scan
+graph-it scan --workspace /path/to/project
+graph-it scan --format json       # → { "files": 347, "edges": 1824, ... }
+```
+
+> **Tip:** In CI, run `graph-it scan` as a warm-up step before chaining other commands.
+
+---
+
+### summary
+
+Print a workspace overview: index statistics plus (optionally) a codemap for a specific file.
+
+```
+graph-it summary [file] [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `file` *(optional)* | Source file to generate a codemap for |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root |
+| `--format, -f` | `text` | Output format |
+
+**What it does (no file argument):**
+
+Prints overall statistics: files indexed, edges, cycles, index freshness.
+
+**What it does (with file argument):**
+
+Returns index statistics **plus** a structured codemap for the file:
+- Exported symbols
+- Internal symbols
+- Direct dependencies (files imported)
+- Dependents (files that import this one)
+- Call flow (intra-file symbol call order)
+- Cycle indicators
+
+**Output (text, with file):**
+
+```
+=== Index Status ===
+Files: 347   Edges: 1824   Cycles: 2
+
+=== Codemap: src/Spider.ts ===
+Exports:  Spider, SpiderOptions
+Internals: crawlFile, resolveImport, visitNode
+Deps:     Parser.ts, PathResolver.ts, Cache.ts
+Dependents: SpiderBuilder.ts, extension.ts
+Call flow: crawl → crawlFile → resolveImport → visitNode
+Cycles:   none
+```
+
+**Examples:**
+
+```bash
+graph-it summary
+graph-it summary src/api/router.ts
+graph-it summary src/api/router.ts --format markdown   # paste in docs
+graph-it summary src/api/router.ts --format toon       # feed to LLM
+```
+
+---
+
+### explain
+
+Analyze the internal call hierarchy of a file — which functions call which, in what order, including recursive cycles.
+
+```
+graph-it explain <file> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<file>` | Source file to analyze (absolute or relative to workspace root) |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root |
+| `--format, -f` | `text` | Output format |
+
+**What it does:**
+
+Uses AST analysis (Tree-sitter + ts-morph) to map every symbol in the file and construct a call graph:
+- Which symbols are exported vs. internal
+- Which functions/methods call each other
+- Entry points (symbols called by nobody internally)
+- Cycle detection (recursive calls)
+
+**Output (text):**
+
+```
+File: src/mcp/mcpServer.ts
+
+Entry points: initializeServer(), main()
+
+initializeServer()
+  └── registerAllTools()         [call #1]
+  └── setupFileWatcher()         [call #2]
+  └── startListening()           [call #3]
+      └── handleToolCall()
+          ├── validateWorkspace()
+          └── invokeWorker()
+
+Cycles: none
+```
+
+**Examples:**
+
+```bash
+graph-it explain src/mcp/mcpServer.ts
+graph-it explain src/analyzer/Spider.ts --format json
+graph-it explain src/extension/GraphProvider.ts --format markdown
+```
+
+> **Use case:** Understand how data flows through a complex file before refactoring — without reading every line.
+
+---
+
+### path
+
+Crawl the full dependency graph starting from an entry file (BFS traversal) and display all reachable files with their dependency relationships.
+
+```
+graph-it path <file> [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<file>` | Entry file to start crawling from |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root |
+| `--format, -f` | `text` | Output format (`mermaid` generates a flowchart) |
+| `--maxDepth <N>` | unlimited | Maximum traversal depth |
+
+**What it does:**
+
+Starting from `<file>`, follows all import edges recursively (BFS) and returns:
+- The complete list of reachable files
+- Direct dependency edges
+- Cycle detection (circular imports highlighted)
+- Depth at which each file is reached
+
+**Output (text):**
+
+```
+src/index.ts (depth 0)
+  → src/app.ts (depth 1)
+  → src/config.ts (depth 1)
+      → src/env.ts (depth 2)
+      → src/constants.ts (depth 2)
+  → src/router.ts (depth 1)
+      → src/handlers/auth.ts (depth 2)
+      → src/handlers/users.ts (depth 2)
+          ⟲ src/app.ts [CYCLE]
+
+Total: 8 files, 2 cycles
+```
+
+**Output (mermaid):**
+
+```mermaid
+graph LR
+  src/index.ts --> src/app.ts
+  src/index.ts --> src/config.ts
+  src/config.ts --> src/env.ts
+  src/config.ts --> src/constants.ts
+  src/index.ts --> src/router.ts
+  src/router.ts --> src/handlers/auth.ts
+  src/router.ts --> src/handlers/users.ts
+  src/handlers/users.ts -.->|CYCLE| src/app.ts
+```
+
+**Examples:**
+
+```bash
+graph-it path src/index.ts
+graph-it path src/index.ts --maxDepth 3
+graph-it path src/index.ts --format mermaid > architecture.md
+graph-it path src/index.ts --format json | jq '.files | length'
+```
+
+> **Use case:** Generate an architecture diagram in seconds. Pipe `--format mermaid` output directly into your README, Notion page, or Confluence doc.
+
+---
+
+### check
+
+Find unused exported symbols (dead code) — either workspace-wide, scoped to a directory, or for a single file.
+
+```
+graph-it check [target] [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| *(none)* | Scan the entire workspace for unused exports |
+| `<directory>` | Scan a specific directory and its subdirectories |
+| `<file>` | Check a single file for unused exported symbols |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root |
+| `--format, -f` | `text` | Output format |
+
+**What it does:**
+
+Combines the dependency graph with export analysis to find symbols that are exported but never imported anywhere in the project. Reports:
+- File path of the symbol
+- Symbol name and type (function, class, variable, type alias…)
+- Whether it is completely unreferenced or only referenced within the same file
+
+**Output (text, workspace-wide):**
+
+```
+Dead code scan — 347 files analyzed
+
+src/utils/legacy.ts
+  ⚠  formatDate        [function]   — exported, never imported
+  ⚠  LegacyConfig      [interface]  — exported, never imported
+
+src/api/deprecated.ts
+  ⚠  oldHandler        [function]   — exported, never imported
+
+3 unused exports found across 2 files.
+```
+
+**Output (text, single file):**
+
+```
+Checking src/utils/helpers.ts
+
+  ✓  formatDate        used in 4 files
+  ✗  parseQueryString  not used anywhere
+  ✓  clamp             used in 2 files
+
+1 unused export found.
+```
+
+**Examples:**
+
+```bash
+# Workspace-wide dead code scan
+graph-it check
+
+# Scope to a directory
+graph-it check src/utils/
+
+# Single file check
+graph-it check src/api/handlers.ts
+
+# Output as JSON for scripting
+graph-it check --format json | jq '[.[] | select(.unusedCount > 0)]'
+
+# Output as Markdown for PR descriptions
+graph-it check --format markdown > dead-code-report.md
+```
+
+> **Use case:** Run `graph-it check` in a pre-commit hook or CI step to prevent dead code from accumulating.
+
+---
+
+### trace
+
+Trace the complete execution path from a starting symbol — following every function call recursively until leaf functions are reached.
+
+```
+graph-it trace <file>#<Symbol> [options]
+```
+
+**Arguments:**
+
+| Argument | Format | Description |
+|----------|--------|-------------|
+| `<file>#<Symbol>` | `path/to/file.ts#FunctionName` | Entry symbol (file path + `#` + symbol name) |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root |
+| `--format, -f` | `text` | Output format (`mermaid` generates a call flowchart) |
+| `--maxDepth <N>` | `10` | Maximum recursion depth |
+
+**What it does:**
+
+Starting from the specified symbol, follows every outgoing call edge recursively (DFS) and returns a tree showing the complete execution flow:
+- Each function call with its file location
+- Call ordering (numbered edges)
+- Recursive calls / cycles detected and labelled
+
+**Output (text):**
+
+```
+Trace: src/analyzer/Spider.ts#crawl
+
+crawl (Spider.ts)
+  ├─[1] ensureIndexed (runtime.ts)
+  ├─[2] crawlFile (Spider.ts)
+  │     ├─[1] parseImports (Parser.ts)
+  │     │     └─[1] tokenize (lexer.ts)
+  │     ├─[2] resolveImport (PathResolver.ts)
+  │     └─[3] visitNode (Spider.ts)
+  │           ⟲ crawlFile [CYCLE — recursive]
+  └─[3] buildGraph (GraphBuilder.ts)
+
+Depth reached: 4   Cycles: 1
+```
+
+**Output (mermaid):**
+
+```mermaid
+graph TD
+  crawl --> ensureIndexed
+  crawl --> crawlFile
+  crawlFile --> parseImports
+  parseImports --> tokenize
+  crawlFile --> resolveImport
+  crawlFile --> visitNode
+  visitNode -.->|CYCLE| crawlFile
+  crawl --> buildGraph
+```
+
+**Examples:**
+
+```bash
+graph-it trace src/index.ts#main
+graph-it trace src/api.ts#handleRequest --format mermaid
+graph-it trace src/Spider.ts#crawl --maxDepth 5
+graph-it trace src/mcp/mcpServer.ts#initializeServer --format json
+```
+
+> **Use case:** Before changing a function signature, run `trace` to see every downstream function that will be affected, all the way to leaf functions.
+
+---
+
+### tool
+
+Invoke any of the 21 MCP analysis tools directly from the terminal — full MCP parity without a running server.
+
+```
+graph-it tool <name> [--<param>=<value>...] [options]
+graph-it tool --list
+graph-it tool --args '<json>' <name>
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<name>` | MCP tool name (see `--list`) |
+| `--list` | Print all 21 available tools with one-line descriptions |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--<param>=<value>` | — | Pass individual parameters directly |
+| `--args '<json>'` | — | Pass all parameters as a JSON string |
+| `--workspace, -w` | auto-detected | Project root |
+| `--format, -f` | `text` | Output format |
+
+**List all tools:**
+
+```bash
+graph-it tool --list
+```
+
+Output:
+```
+Available MCP tools:
+
+  analyze_dependencies           Show direct imports and exports of a file
+  crawl_dependency_graph         Full dependency tree from an entry file (BFS)
+  find_referencing_files         All files that import a given file
+  expand_node                    Incrementally expand dependencies of a node
+  parse_imports                  Raw import statements parsed from a file
+  verify_dependency_usage        Check if an import is actually used in source
+  resolve_module_path            Resolve a module specifier to its absolute path
+  get_index_status               Current state of the dependency index
+  invalidate_files               Flush cache entries for specific files
+  rebuild_index                  Trigger a full index rebuild
+  get_symbol_graph               Symbol-level call graph within a file
+  find_unused_symbols            Detect dead/unused exported symbols
+  get_symbol_dependents          All symbols that depend on a given symbol
+  trace_function_execution       Full recursive call chain from a symbol
+  get_symbol_callers             All callers of a symbol across the project
+  analyze_breaking_changes       Detect breaking API changes between two versions
+  get_impact_analysis            Full impact analysis of changing a file/symbol
+  analyze_file_logic             Intra-file call hierarchy (AST-based)
+  generate_codemap               AI-friendly structural overview of a file (TOON)
+  query_call_graph               BFS callers/callees via the SQLite call graph index
+  scan_dead_code                 Workspace-wide scan for unused exported symbols
+```
+
+**Calling a tool with parameters:**
+
+```bash
+# Using --param=value syntax
+graph-it tool analyze_dependencies --filePath=/abs/path/to/file.ts
+
+# Using --args JSON syntax (useful for complex/nested params)
+graph-it tool --args '{"filePath":"/abs/path/to/file.ts"}' analyze_dependencies
+
+# With format
+graph-it tool get_symbol_callers --filePath=/abs/path/to/Spider.ts --symbolName=crawl --format json
+```
+
+**Examples per tool:**
+
+```bash
+# Index status
+graph-it tool get_index_status
+
+# Analyze direct imports/exports of a file
+graph-it tool analyze_dependencies --filePath=$(pwd)/src/app.ts
+
+# Full dependency graph from entry file (BFS)
+graph-it tool crawl_dependency_graph --entryFile=$(pwd)/src/index.ts
+
+# All files that import a given file
+graph-it tool find_referencing_files --filePath=$(pwd)/src/utils.ts
+
+# Check if an import is actually used in source code
+graph-it tool verify_dependency_usage --filePath=$(pwd)/src/app.ts --dependency=lodash
+
+# Resolve a module specifier to its absolute path
+graph-it tool resolve_module_path --filePath=$(pwd)/src/app.ts --modulePath=./utils
+
+# Symbol-level call graph within a file
+graph-it tool get_symbol_graph --filePath=$(pwd)/src/Spider.ts
+
+# Find all callers of a specific symbol across the project
+graph-it tool get_symbol_callers --filePath=$(pwd)/src/Spider.ts --symbolName=crawl
+
+# Find all symbols that depend on a specific symbol
+graph-it tool get_symbol_dependents --filePath=$(pwd)/src/Spider.ts --symbolName=Spider
+
+# Trace complete execution path from a symbol
+graph-it tool trace_function_execution --filePath=$(pwd)/src/Spider.ts --symbolName=crawl
+
+# Detect breaking API changes between two versions of a file
+graph-it tool analyze_breaking_changes --filePath=$(pwd)/src/api.ts --newFilePath=$(pwd)/src/api.new.ts
+
+# Full impact analysis of changing a file
+graph-it tool get_impact_analysis --filePath=$(pwd)/src/utils.ts
+
+# Generate AI-friendly codemap of a file
+graph-it tool generate_codemap --filePath=$(pwd)/src/Spider.ts
+
+# Intra-file call hierarchy
+graph-it tool analyze_file_logic --filePath=$(pwd)/src/mcp/mcpServer.ts
+
+# Cross-file call graph (BFS from a symbol)
+graph-it tool query_call_graph --filePath=$(pwd)/src/Spider.ts --symbolName=crawl --depth=3
+
+# Workspace-wide dead code scan
+graph-it tool scan_dead_code
+
+# Scoped dead code scan
+graph-it tool scan_dead_code --scopePath=$(pwd)/src/utils/
+
+# Detect unused exports in a single file
+graph-it tool find_unused_symbols --filePath=$(pwd)/src/api.ts
+
+# Force cache flush for a file after editing
+graph-it tool invalidate_files --filePaths='["$(pwd)/src/api.ts"]'
+
+# Full index rebuild
+graph-it tool rebuild_index
+
+# Expand a node incrementally
+graph-it tool expand_node --filePath=$(pwd)/src/app.ts --depth=2
+
+# Parse raw import statements (no path resolution)
+graph-it tool parse_imports --filePath=$(pwd)/src/app.ts
+```
+
+---
+
+### serve
+
+Start the MCP stdio server — enables any MCP-compatible AI client (Claude Desktop, Claude Code, Cursor, Windsurf, etc.) to connect to Graph-It-Live without VS Code.
+
+```
+graph-it serve [options]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root the server will analyze |
+
+**What it does:**
+
+Launches the full 22-tool MCP server process on `stdio`. The server:
+- Accepts MCP JSON-RPC messages from stdin
+- Performs dependency analysis on the workspace
+- Returns results on stdout
+- Auto-invalidates the cache when files change (via `chokidar`, debounced 300 ms)
+
+**MCP client configuration:**
+
+```bash
+# Claude Code CLI (adds to your Claude config)
+claude mcp add graph-it -- graph-it serve
+
+# VS Code / Cursor (.vscode/mcp.json or .cursor/mcp.json)
+{
+  "servers": {
+    "graph-it-live": {
+      "type": "stdio",
+      "command": "graph-it",
+      "args": ["serve"],
+      "env": { "WORKSPACE_ROOT": "${workspaceFolder}" }
+    }
+  }
+}
+
+# Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json)
+{
+  "mcpServers": {
+    "graph-it-live": {
+      "command": "graph-it",
+      "args": ["serve"],
+      "env": { "WORKSPACE_ROOT": "/path/to/your/project" }
+    }
+  }
+}
+```
+
+**Environment variables:**
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WORKSPACE_ROOT` | `cwd` | Absolute path to project root |
+| `EXCLUDE_NODE_MODULES` | `true` | Whether to skip `node_modules` |
+| `MAX_DEPTH` | `50` | Maximum dependency depth |
+
+---
+
+### install
+
+Symlink the `graph-it` binary into your system `PATH` so it can be invoked from any directory without `npx`.
+
+```
+graph-it install
+```
+
+> **Note:** This is a VS Code extension convenience command. When using the npm global install, `graph-it` is already on your PATH.
+
+---
+
+### update
+
+Check npm for a newer version of `@magic5644/graph-it-live` and install it if one is available.
+
+```
+graph-it update
+```
+
+Requires an active internet connection and `npm` in `PATH`.
+
+---
+
+## MCP Tools Reference (via `graph-it tool`)
+
+The `graph-it tool` command provides direct access to all 21 analysis tools (the MCP server exposes 22 including `set_workspace`, which is server-management only and not needed in CLI context — see [Tool Count: CLI vs MCP](#tool-count-cli-vs-mcp)).
+
+### Tool Details
+
+#### `analyze_dependencies`
+
+**What it returns:** All direct `import` / `require` statements in a file, resolved to absolute paths, plus all exported symbols with their types.
+
+```bash
+graph-it tool analyze_dependencies --filePath=/abs/path/to/file.ts
+```
+
+**Output fields:** `imports[]`, `exports[]`, `filePath`, `language`
+
+---
+
+#### `crawl_dependency_graph`
+
+**What it returns:** The full BFS dependency tree starting from an entry file — all reachable files, edges, cycle information, and depth data.
+
+```bash
+graph-it tool crawl_dependency_graph --entryFile=/abs/path/to/index.ts
+graph-it tool crawl_dependency_graph --entryFile=/abs/path/to/index.ts --maxDepth=5
+```
+
+**Output fields:** `files[]`, `edges[]`, `cycles[]`, `totalFiles`, `totalEdges`
+
+---
+
+#### `find_referencing_files`
+
+**What it returns:** All files in the project that import the given file — an O(1) reverse lookup from the pre-built reverse index.
+
+```bash
+graph-it tool find_referencing_files --filePath=/abs/path/to/utils.ts
+```
+
+**Output fields:** `referencingFiles[]`, `count`
+
+---
+
+#### `expand_node`
+
+**What it returns:** The immediate dependencies (one level) of a node, useful for incremental graph exploration without re-crawling the full tree.
+
+```bash
+graph-it tool expand_node --filePath=/abs/path/to/app.ts --depth=1
+```
+
+**Output fields:** `dependencies[]`, `filePath`
+
+---
+
+#### `parse_imports`
+
+**What it returns:** Raw import statements parsed from the source file, without path resolution. Useful for inspecting import syntax and module specifiers directly.
+
+```bash
+graph-it tool parse_imports --filePath=/abs/path/to/app.ts
+```
+
+**Output fields:** `imports[]` (with `source`, `specifiers[]`, `type`)
+
+---
+
+#### `verify_dependency_usage`
+
+**What it returns:** Whether a specific imported module is actually referenced in the source code (i.e., is it a live import or an unused one).
+
+```bash
+graph-it tool verify_dependency_usage --filePath=/abs/path/to/app.ts --dependency=lodash
+```
+
+**Output fields:** `isUsed` (boolean), `usageLocations[]`
+
+---
+
+#### `resolve_module_path`
+
+**What it returns:** The absolute filesystem path that a module specifier resolves to, applying TypeScript path aliases, Node.js resolution rules, and workspace configuration.
+
+```bash
+graph-it tool resolve_module_path --filePath=/abs/path/to/app.ts --modulePath=@/utils/helpers
+```
+
+**Output fields:** `resolvedPath`, `exists` (boolean)
+
+---
+
+#### `get_index_status`
+
+**What it returns:** Current state of the in-memory dependency index — number of indexed files, edges, index freshness, and memory usage.
+
+```bash
+graph-it tool get_index_status
+```
+
+**Output fields:** `files`, `edges`, `indexedAt`, `isStale`
+
+---
+
+#### `invalidate_files`
+
+**What it does:** Removes specific files from the in-memory cache, forcing them to be re-analyzed on next access. Use after programmatic file edits.
+
+```bash
+graph-it tool invalidate_files --filePaths='["/abs/path/to/file.ts"]'
+```
+
+---
+
+#### `rebuild_index`
+
+**What it does:** Drops and rebuilds the entire dependency index from scratch. Useful after large refactors or when the index is stale.
+
+```bash
+graph-it tool rebuild_index
+```
+
+---
+
+#### `get_symbol_graph`
+
+**What it returns:** Symbol-level dependencies within a single file — which functions, classes, and variables are defined, and which call which internally.
+
+```bash
+graph-it tool get_symbol_graph --filePath=/abs/path/to/Spider.ts
+```
+
+**Output fields:** `symbols[]`, `dependencies[]`, `file`
+
+---
+
+#### `find_unused_symbols`
+
+**What it returns:** Exported symbols in a file that are never imported or referenced elsewhere in the project.
+
+```bash
+graph-it tool find_unused_symbols --filePath=/abs/path/to/api.ts
+```
+
+**Output fields:** `unusedSymbols[]`, `totalExports`, `unusedCount`
+
+---
+
+#### `get_symbol_dependents`
+
+**What it returns:** All symbols (across the entire project) that depend on a specific symbol — the reverse of `get_symbol_graph`.
+
+```bash
+graph-it tool get_symbol_dependents --filePath=/abs/path/to/Spider.ts --symbolName=Spider
+```
+
+**Output fields:** `dependents[]` (with `file`, `symbolName`, `type`)
+
+---
+
+#### `trace_function_execution`
+
+**What it returns:** The complete recursive call chain from a starting symbol — DFS traversal following every outgoing call edge until leaf functions.
+
+```bash
+graph-it tool trace_function_execution --filePath=/abs/path/to/Spider.ts --symbolName=crawl
+graph-it tool trace_function_execution --filePath=/abs/path/to/Spider.ts --symbolName=crawl --maxDepth=5
+```
+
+**Output fields:** `callTree` (nested), `cycles[]`, `maxDepth`
+
+---
+
+#### `get_symbol_callers`
+
+**What it returns:** All callers of a specific symbol across the entire project — an O(1) lookup from the pre-built reverse symbol index.
+
+```bash
+graph-it tool get_symbol_callers --filePath=/abs/path/to/Spider.ts --symbolName=crawl
+```
+
+**Output fields:** `callers[]` (with `file`, `symbolName`, `line`)
+
+---
+
+#### `analyze_breaking_changes`
+
+**What it returns:** Whether changes to a file introduce breaking changes — altered function signatures, removed exports, changed parameter types — and which callers are affected.
+
+```bash
+graph-it tool analyze_breaking_changes --filePath=/abs/path/to/api.ts --newFilePath=/abs/path/to/api.new.ts
+```
+
+**Output fields:** `breakingChanges[]`, `affectedCallers[]`, `severity`
+
+---
+
+#### `get_impact_analysis`
+
+**What it returns:** A full impact report for changing a file — combines `find_referencing_files`, `get_symbol_callers`, and `analyze_breaking_changes` into a single structured result.
+
+```bash
+graph-it tool get_impact_analysis --filePath=/abs/path/to/utils.ts
+```
+
+**Output fields:** `referencingFiles[]`, `symbolCallers[]`, `breakingChanges[]`, `totalImpact`
+
+---
+
+#### `analyze_file_logic`
+
+**What it returns:** Intra-file call hierarchy from AST analysis — entry points, call order, internal cycles, symbol types.
+
+```bash
+graph-it tool analyze_file_logic --filePath=/abs/path/to/mcpServer.ts
+```
+
+**Output fields:** `symbols[]`, `callEdges[]`, `entryPoints[]`, `cycles[]`
+
+---
+
+#### `generate_codemap`
+
+**What it returns:** A structured, AI-friendly overview of a file in a single call: exports, internals, dependencies, dependents, call flow, and cycles.
+
+```bash
+graph-it tool generate_codemap --filePath=/abs/path/to/Spider.ts --format toon
+```
+
+**Output fields:** `exports[]`, `internals[]`, `dependencies[]`, `dependents[]`, `callFlow`, `cycles[]`
+
+> **Tip:** Use `--format toon` to reduce token consumption by 30–60% when feeding this to an LLM.
+
+---
+
+#### `query_call_graph`
+
+**What it returns:** BFS neighbourhood of callers and callees from a symbol, using the SQLite call graph index built by the Live Call Graph engine.
+
+```bash
+graph-it tool query_call_graph --filePath=/abs/path/to/Spider.ts --symbolName=crawl --depth=3
+```
+
+**Output fields:** `nodes[]`, `edges[]`, `cycles[]`
+
+> **Note:** Requires the call graph index to have been built (auto-triggered on first use or when the VS Code panel is opened).
+
+---
+
+#### `scan_dead_code`
+
+**What it returns:** All unused exported symbols found across the entire workspace (or a scoped directory), combining dependency graph analysis with export tracking.
+
+```bash
+# Entire workspace
+graph-it tool scan_dead_code
+
+# Scoped to a directory
+graph-it tool scan_dead_code --scopePath=/abs/path/to/src/utils/
+```
+
+**Output fields:** `unusedSymbols[]` (with `file`, `symbol`, `type`), `totalScanned`, `unusedCount`
+
+---
+
+## Advanced Analysis Workflows
+
+### Pre-Refactor Safety Check
+
+Before modifying a module, understand its full impact surface:
+
+```bash
+# 1. Find all files that import the module
+graph-it tool find_referencing_files --filePath=$(pwd)/src/UserService.ts
+
+# 2. Find all callers of the function you're changing
+graph-it tool get_symbol_callers --filePath=$(pwd)/src/UserService.ts --symbolName=getUser
+
+# 3. Detect if your new signature breaks anything
+graph-it tool analyze_breaking_changes \
+  --filePath=$(pwd)/src/UserService.ts \
+  --newFilePath=$(pwd)/src/UserService.proposed.ts
+
+# 4. Full combined impact report
+graph-it tool get_impact_analysis --filePath=$(pwd)/src/UserService.ts
+
+# 5. Trace the full execution tree from your entry point
+graph-it trace src/UserService.ts#getUser --format mermaid
+```
+
+---
+
+### Dead Code Audit
+
+Find and remove unreachable code safely:
+
+```bash
+# Workspace-wide scan (shows all unused exports)
+graph-it check --format json > dead-code.json
+
+# Count total unused exports
+cat dead-code.json | jq '[.[].unusedCount] | add'
+
+# Scope to a specific module
+graph-it check src/utils/ --format markdown > utils-dead-code.md
+
+# Single file audit
+graph-it check src/api/handlers.ts
+```
+
+---
+
+### Architecture Documentation
+
+Generate dependency diagrams and documentation automatically:
+
+```bash
+# Mermaid flowchart for the main entry point
+graph-it path src/index.ts --format mermaid > docs/architecture.md
+
+# Codemap for every file in a module (pipe through xargs)
+find src/analyzer -name "*.ts" | xargs -I{} graph-it summary {} --format markdown >> docs/analyzer-reference.md
+
+# AI-friendly overview of the whole project
+graph-it summary --format toon > project-overview.toon
+
+# Execution flow diagram for a critical function
+graph-it trace src/mcp/mcpServer.ts#initializeServer --format mermaid > docs/server-flow.md
+```
+
+---
+
+### CI Integration
+
+Run dependency checks in your CI pipeline:
+
+```bash
+#!/bin/bash
+# .github/scripts/dependency-check.sh
+
+set -euo pipefail
+
+echo "=== Indexing workspace ==="
+graph-it scan --workspace .
+
+echo "=== Dead code check ==="
+DEAD=$(graph-it check --format json | jq '[.[].unusedCount] | add // 0')
+echo "Unused exports: $DEAD"
+if [ "$DEAD" -gt 10 ]; then
+  echo "⚠ Too many unused exports ($DEAD). Clean up dead code before merging."
+  exit 1
+fi
+
+echo "=== Checking for circular dependencies ==="
+CYCLES=$(graph-it tool get_index_status --format json | jq '.cycles // 0')
+if [ "$CYCLES" -gt 0 ]; then
+  echo "⚠ $CYCLES circular dependency/ies detected."
+  graph-it path src/index.ts --format json | jq '.cycles[]'
+fi
+
+echo "✅ Dependency checks passed."
+```
+
+---
+
+### Piping & Scripting
+
+Because all commands support `--format json`, the output integrates naturally with `jq` and shell pipelines:
+
+```bash
+# Find the 10 most-imported files in the project
+graph-it scan --format json \
+  | jq -r '.files[] | "\(.importedBy) \(.path)"' \
+  | sort -rn | head -10
+
+# List all TypeScript files with circular dependencies
+graph-it tool crawl_dependency_graph --entryFile=$(pwd)/src/index.ts --format json \
+  | jq -r '.cycles[] | .files[]' | sort -u
+
+# Generate a report of all files that depend on a utility module
+graph-it tool find_referencing_files \
+  --filePath=$(pwd)/src/utils/format.ts \
+  --format json | jq -r '.referencingFiles[]'
+
+# Check if a specific import is unused in a file
+graph-it tool verify_dependency_usage \
+  --filePath=$(pwd)/src/app.ts \
+  --dependency=lodash \
+  --format json | jq '.isUsed'
+```
+
+---
+
+## Tool Count: CLI vs MCP
+
+The CLI exposes **21 tools** via `graph-it tool --list`, while the MCP server provides **22 tools** in total. This is by design:
+
+| Context | Tool count | Notes |
+|---------|-----------|-------|
+| `graph-it tool --list` | 21 | All analysis tools |
+| MCP server (`graph-it serve`) | 22 | Same 21 + `set_workspace` |
+
+The extra tool, `set_workspace`, is a **server management tool** — it tells a running MCP server instance which directory to analyze. In CLI context this is handled by the `--workspace` flag (or auto-detection from `cwd`), so it is intentionally excluded from the CLI tool list.
+
+**Summary:** The CLI gives you 100% parity with the MCP analysis tools. `set_workspace` is the only tool that exists in MCP but not in the CLI, and it would be redundant there.

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@ Standards and guidelines for contributors.
 
 | File | Description |
 |------|-------------|
+| [CLI.md](CLI.md) | **CLI reference** — all commands, options, output formats, tools, and advanced workflows |
 | [development/CODING_STANDARDS.md](development/CODING_STANDARDS.md) | TypeScript conventions, layer rules, React patterns |
 | [development/CROSS_PLATFORM_TESTING.md](development/CROSS_PLATFORM_TESTING.md) | Cross-platform path handling and test guidelines |
 | [development/ADR-001-package-manager-choice.md](development/ADR-001-package-manager-choice.md) | ADR: npm vs Yarn decision |

--- a/docs/specs/2026-04-21-dead-code-scan.md
+++ b/docs/specs/2026-04-21-dead-code-scan.md
@@ -1,0 +1,192 @@
+# Spec: Workspace-Wide Dead Code Scan
+
+**Date:** 2026-04-21  
+**Status:** Approved  
+**Author:** Engineering
+
+---
+
+## 1. Problem Statement
+
+`graphitlive_find_unused_symbols` analyses one file at a time.  
+To scan a whole workspace an LLM must emit N sequential calls, each with
+per-file latency and context overhead.  
+There is no CLI shortcut for a full-workspace sweep either.
+
+---
+
+## 2. Goal
+
+Provide a single, efficient mechanism to discover all unused exported symbols
+across the entire workspace (or a scoped directory) in one call.
+
+---
+
+## 3. Out of Scope
+
+- IDE inline decorations for unused symbols  
+- Auto-removal / codemods  
+- Languages not yet supported by the AST analyzer (GraphQL, C#, Go, Java)
+
+---
+
+## 4. User-Facing APIs
+
+### 4.1 MCP Tool — `graphitlive_scan_dead_code`
+
+| Attribute | Value |
+|-----------|-------|
+| Tool ID | `graphitlive_scan_dead_code` |
+| Transport | stdio MCP |
+| Internal name | `scan_dead_code` |
+
+**Parameters**
+
+| Name | Type | Default | Description |
+|------|------|---------|-------------|
+| `scopePath` | `string?` | workspace root | Absolute path to a directory to scope the scan. Must be inside the workspace. |
+| `maxFiles` | `number?` | 500 | Hard cap on files analysed. Avoids accidental OOM on huge monorepos. |
+| `response_format` | `'json'\|'markdown'\|'toon'` | `'toon'` | Output format. |
+
+**Returns** `ScanDeadCodeResult`
+
+```ts
+interface DeadCodeFileEntry {
+  filePath: string;
+  relativePath: string;
+  unusedCount: number;
+  unusedSymbols: SymbolInfo[];
+}
+
+interface ScanDeadCodeResult {
+  rootDir: string;
+  scopePath: string;
+  scannedFiles: number;
+  filesWithDeadCode: number;
+  totalUnusedSymbols: number;
+  entries: DeadCodeFileEntry[];
+  skippedFiles: number;    // unsupported language, parse error, etc.
+  analysisTimeMs: number;
+}
+```
+
+### 4.2 CLI extension
+
+```
+graph-it check                 # scan whole workspace
+graph-it check ./src           # scan a subdirectory  
+graph-it check ./src/foo.ts    # per-file (existing behaviour)
+```
+
+`graph-it check` with no argument is equivalent to:
+`graph-it check <workspaceRoot>`.
+
+### 4.3 LM Tool — `graph-it-live_scan_dead_code`
+
+Same parameters as the MCP tool (minus `response_format`).  
+Registered via `LmToolsService.registerScanDeadCode()`.
+
+---
+
+## 5. Architecture
+
+### 5.1 Layers
+
+```
+CLI check.ts / LmToolsService        ← consumer
+        │
+        ▼
+src/mcp/tools/deadcode.ts            ← executeScanDeadCode()
+        │
+        ▼
+Spider.scanDeadCode()                ← façade on Spider.ts
+        │
+        ▼
+SpiderSymbolService.scanDeadCode()   ← core batching loop
+        │  uses
+        ├─ SourceFileCollector.collectAllSourceFiles()
+        └─ SpiderSymbolService.findUnusedSymbols()  (existing, per-file)
+```
+
+### 5.2 Batching strategy
+
+- Collect all source files under `scopePath` via `SourceFileCollector`.
+- Filter to files supported by the AST analyzer
+  (`SUPPORTED_SYMBOL_ANALYSIS_EXTENSIONS`).
+- Apply `maxFiles` cap.
+- Process files **sequentially** (reuses symbol cache; avoids memory spikes).
+- Accumulate entries where `unusedCount > 0`.
+
+### 5.3 Guards
+
+| Condition | Behaviour |
+|-----------|-----------|
+| Reverse index not ready | Throw `INDEX_NOT_READY` — never silent O(n²) fallback |
+| `scopePath` outside workspace | Throw `SECURITY_ERROR` (path traversal) |
+| File parse error | Increment `skippedFiles`, continue |
+| `scannedFiles === 0` | Return empty result with `skippedFiles > 0` |
+
+---
+
+## 6. Security
+
+`validateScopePath(scopePath, rootDir)` in `src/mcp/shared/helpers.ts`:
+
+```
+resolvedScope = path.resolve(scopePath)
+assert resolvedScope.startsWith(path.resolve(rootDir))
+assert no null bytes
+```
+
+Called before any `fs` access.
+
+---
+
+## 7. Types (additions to `src/mcp/types.ts`)
+
+```ts
+export type McpToolName = ... | "scan_dead_code";
+
+export interface DeadCodeFileEntry { ... }
+export interface ScanDeadCodeResult { ... }
+
+export const ScanDeadCodeParamsSchema = z.object({
+  scopePath: FilePathSchema.optional(),
+  maxFiles: z.number().int().min(1).max(10_000).default(500).optional(),
+  response_format: ResponseFormatSchema.optional(),
+});
+export type ScanDeadCodeParams = z.infer<typeof ScanDeadCodeParamsSchema>;
+```
+
+---
+
+## 8. Tests
+
+| File | Coverage |
+|------|----------|
+| `tests/analyzer/SpiderDeadCodeScan.test.ts` | `SpiderSymbolService.scanDeadCode` — happy path, empty workspace, all-used, maxFiles cap |
+| `tests/mcp/tools/deadcode.test.ts` | `executeScanDeadCode` — calls spider, maps result, security validation |
+| `tests/cli/deadcode.test.ts` | CLI `check` with no arg, dir arg, file arg |
+| `tests/vscode-e2e/suite/lmTools.test.ts` | Updated `EXPECTED_TOOLS` count (20 → 21) |
+
+---
+
+## 9. File Change Summary
+
+| File | Change |
+|------|--------|
+| `src/mcp/types.ts` | Add `"scan_dead_code"` to `McpToolName`; add schemas + interfaces |
+| `src/analyzer/spider/SpiderSymbolService.ts` | Add `scanDeadCode()` |
+| `src/analyzer/Spider.ts` | Add `scanDeadCode()` façade |
+| `src/mcp/shared/helpers.ts` | Add `validateScopePath()` |
+| `src/mcp/tools/deadcode.ts` | New: `executeScanDeadCode()` |
+| `src/mcp/tools/index.ts` | Export `executeScanDeadCode` |
+| `src/mcp/worker/invokeTool.ts` | Add `case "scan_dead_code"` |
+| `src/mcp/mcpServer.ts` | Register `graphitlive_scan_dead_code` |
+| `src/cli/commands/check.ts` | Make arg optional; handle dir/workspace |
+| `src/cli/commands/tool.ts` | Add `scan_dead_code` to `TOOL_NAMES` + `TOOL_DESCRIPTIONS` |
+| `src/extension/services/LmToolsService.ts` | Add `registerScanDeadCode()` |
+| `tests/vscode-e2e/suite/lmTools.test.ts` | Add tool to `EXPECTED_TOOLS` |
+| `tests/analyzer/SpiderDeadCodeScan.test.ts` | New: analyzer unit tests |
+| `tests/mcp/tools/deadcode.test.ts` | New: tool unit tests |
+| `tests/cli/deadcode.test.ts` | New: CLI integration tests |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import eslint from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
 
-export default tseslint.config(
+export default [
   {
     ignores: [
       "dist/**",
@@ -35,8 +35,9 @@ export default tseslint.config(
         ...globals.es2020,
       },
       parserOptions: {
-        // Main source tsconfigs only - tests are excluded from linting
-        project: ["./tsconfig.json", "./tsconfig.webview.json"],
+        // tsconfig.eslint.json extends tsconfig.json but has no "references",
+        // so parserOptions.project can resolve files directly without issues.
+        project: ["./tsconfig.eslint.json", "./tsconfig.webview.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -57,4 +58,4 @@ export default tseslint.config(
       "no-console": "off",
     },
   },
-);
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,8 +34,8 @@
         "@types/react-dom": "^19.2.3",
         "@types/sql.js": "^1.4.11",
         "@types/vscode": "^1.96.0",
-        "@vitest/coverage-v8": "^4.1.4",
-        "@vitest/ui": "^4.1.4",
+        "@vitest/coverage-v8": "^4.1.5",
+        "@vitest/ui": "^4.1.5",
         "@vscode/test-electron": "^2.5.2",
         "@vscode/vsce": "^3.9.1",
         "esbuild": "^0.27.7",
@@ -46,8 +46,8 @@
         "globals": "^17.5.0",
         "mocha": "^11.7.5",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.58.2",
-        "vitest": "^4.1.4"
+        "typescript-eslint": "^8.59.0",
+        "vitest": "^4.1.5"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -1148,9 +1148,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1205,9 +1205,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.126.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
+      "integrity": "sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1335,9 +1335,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rhY3k7Bsae9qQfOtph2Pm2jZEA+s8Gmjoz4hhmx70K9iMQ/ddeae+xhRQcM5IuVx5ry1+bGfkvMn7D6MJggVSA==",
       "cpu": [
         "arm64"
       ],
@@ -1352,9 +1352,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rNz0yK078yrNn3DrdgN+PKiMOW8HfQ92jQiXxwX8yW899ayV00MLVdaCNeVBhG/TbH3ouYVObo8/yrkiectkcQ==",
       "cpu": [
         "arm64"
       ],
@@ -1369,9 +1369,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-r/OmdR00HmD4i79Z//xO06uEPOq5hRXdhw7nzkxQxwSavs3PSHa1ijntdpOiZ2mzOQ3fVVu8C1M19FoNM+dMUQ==",
       "cpu": [
         "x64"
       ],
@@ -1386,9 +1386,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-KcRE5w8h0OnjUatG8pldyD14/CQ5Phs1oxfR+3pKDjboHRo9+MkqQaiIZlZRpsxC15paeXme/I127tUa9TXJ6g==",
       "cpu": [
         "x64"
       ],
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.16.tgz",
+      "integrity": "sha512-bT0guA1bpxEJ/ZhTRniQf7rNF8ybvXOuWbNIeLABaV5NGjx4EtOWBTSRGWFU9ZWVkPOZ+HNFP8RMcBokBiZ0Kg==",
       "cpu": [
         "arm"
       ],
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-+tHktCHWV8BDQSjemUqm/Jl/TPk3QObCTIjmdDy/nlupcujZghmKK2962LYrqFpWu+ai01AN/REOH3NEpqvYQg==",
       "cpu": [
         "arm64"
       ],
@@ -1440,9 +1440,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==",
       "cpu": [
         "arm64"
       ],
@@ -1460,9 +1460,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1480,9 +1480,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==",
       "cpu": [
         "s390x"
       ],
@@ -1500,9 +1500,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.16.tgz",
+      "integrity": "sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==",
       "cpu": [
         "x64"
       ],
@@ -1520,9 +1520,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.16.tgz",
+      "integrity": "sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==",
       "cpu": [
         "x64"
       ],
@@ -1540,9 +1540,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.16.tgz",
+      "integrity": "sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==",
       "cpu": [
         "arm64"
       ],
@@ -1557,9 +1557,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.16.tgz",
+      "integrity": "sha512-3Q2KQxnC8IJOLqXmUMoYwyIPZU9hzRbnHaoV3Euz+VVnjZKcY8ktnNP8T9R4/GGQtb27C/UYKABxesKWb8lsvQ==",
       "cpu": [
         "wasm32"
       ],
@@ -1569,16 +1569,16 @@
       "dependencies": {
         "@emnapi/core": "1.9.2",
         "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-tj7XRemQcOcFwv7qhpUxMTBbI5mWMlE4c1Omhg5+h8GuLXzyj8HviYgR+bB2DMDgRqUE+jiDleqSCRjx4aYk/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1593,9 +1593,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.16.tgz",
+      "integrity": "sha512-PH5DRZT+F4f2PTXRXR8uJxnBq2po/xFtddyabTJVJs/ZYVHqXPEgNIr35IHTEa6bpa0Q8Awg+ymkTaGnKITw4g==",
       "cpu": [
         "x64"
       ],
@@ -1610,9 +1610,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.16.tgz",
+      "integrity": "sha512-45+YtqxLYKDWQouLKCrpIZhke+nXxhsw+qAHVzHDVwttyBlHNBVs2K25rDXrZzhpTp9w1FlAlvweV1H++fdZoA==",
       "dev": true,
       "license": "MIT"
     },
@@ -2291,17 +2291,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.2.tgz",
-      "integrity": "sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/type-utils": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2314,7 +2314,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.2",
+        "@typescript-eslint/parser": "^8.59.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2330,16 +2330,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-      "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2355,14 +2355,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
-      "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.2",
-        "@typescript-eslint/types": "^8.58.2",
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2377,14 +2377,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
-      "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2"
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2395,9 +2395,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
-      "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2412,15 +2412,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.2.tgz",
-      "integrity": "sha512-Z7EloNR/B389FvabdGeTo2XMs4W9TjtPiO9DAsmT0yom0bwlPyRjkJ1uCdW1DvrrrYP50AJZ9Xc3sByZA9+dcg==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2437,9 +2437,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
-      "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2451,16 +2451,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
-      "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.2",
-        "@typescript-eslint/tsconfig-utils": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/visitor-keys": "8.58.2",
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2479,16 +2479,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-      "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.2",
-        "@typescript-eslint/types": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2"
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2503,13 +2503,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
-      "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2536,14 +2536,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.4.tgz",
-      "integrity": "sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -2557,8 +2557,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.4",
-        "vitest": "4.1.4"
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -2567,16 +2567,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2585,13 +2585,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -2612,9 +2612,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2625,13 +2625,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2639,14 +2639,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2665,13 +2665,13 @@
       }
     },
     "node_modules/@vitest/ui": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.4.tgz",
-      "integrity": "sha512-EgFR7nlj5iTDYZYCvavjFokNYwr3c3ry0sFiCg+N7B233Nwp+NNx7eoF/XvMWDCKY71xXAG3kFkt97ZHBJVL8A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+      "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
         "flatted": "^3.4.2",
         "pathe": "^2.0.3",
@@ -2683,17 +2683,17 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "vitest": "4.1.4"
+        "vitest": "4.1.5"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -7300,9 +7300,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -7721,14 +7721,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.16",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.16.tgz",
+      "integrity": "sha512-rzi5WqKzEZw3SooTt7cgm4eqIoujPIyGcJNGFL7iPEuajQw7vxMHUkXylu4/vhCkJGXsgRmxqMKXUpT6FEgl0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.126.0",
+        "@rolldown/pluginutils": "1.0.0-rc.16"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -7737,21 +7737,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.16",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.16",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.16",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.16",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.16",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.16",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.16"
       }
     },
     "node_modules/router": {
@@ -8582,13 +8582,13 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -8779,16 +8779,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.2.tgz",
-      "integrity": "sha512-V8iSng9mRbdZjl54VJ9NKr6ZB+dW0J3TzRXRGcSbLIej9jV86ZRtlYeTKDR/QLxXykocJ5icNzbsl2+5TzIvcQ==",
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
+      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.2",
-        "@typescript-eslint/parser": "8.58.2",
-        "@typescript-eslint/typescript-estree": "8.58.2",
-        "@typescript-eslint/utils": "8.58.2"
+        "@typescript-eslint/eslint-plugin": "8.59.0",
+        "@typescript-eslint/parser": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8942,17 +8942,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.9",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.9.tgz",
+      "integrity": "sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.16",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -9020,19 +9020,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -9060,12 +9060,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1135,8 +1135,8 @@
     "@types/react-dom": "^19.2.3",
     "@types/sql.js": "^1.4.11",
     "@types/vscode": "^1.96.0",
-    "@vitest/coverage-v8": "^4.1.4",
-    "@vitest/ui": "^4.1.4",
+    "@vitest/coverage-v8": "^4.1.5",
+    "@vitest/ui": "^4.1.5",
     "@vscode/test-electron": "^2.5.2",
     "@vscode/vsce": "^3.9.1",
     "esbuild": "^0.27.7",
@@ -1147,8 +1147,8 @@
     "globals": "^17.5.0",
     "mocha": "^11.7.5",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.58.2",
-    "vitest": "^4.1.4"
+    "typescript-eslint": "^8.59.0",
+    "vitest": "^4.1.5"
   },
   "overrides": {
     "picomatch": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1057,6 +1057,12 @@
   "bin": {
     "graph-it": "./bin/graph-it"
   },
+  "files": [
+    "bin/",
+    "dist/graph-it.js",
+    "dist/wasm/",
+    "dist/queries/"
+  ],
   "scripts": {
     "vscode:prepublish": "npm run build -- --production",
     "build": "node esbuild.js",
@@ -1074,6 +1080,7 @@
     "test:all": "npm run test:unit",
     "test:bench": "node scripts/run-benchmarks.mjs",
     "test:mcp": "node scripts/test-mcp.js",
+    "test:cli:e2e": "bash scripts/test-cli-e2e.sh",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "check:types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -894,6 +894,33 @@
             "symbolName"
           ]
         }
+      },
+      {
+        "name": "graph-it-live_scan_dead_code",
+        "canBeReferencedInPrompt": true,
+        "toolReferenceName": "graphDeadCode",
+        "tags": [
+          "graph-it-live",
+          "symbols",
+          "dead-code"
+        ],
+        "displayName": "Graph-It-Live: Scan Dead Code",
+        "icon": "$(trash)",
+        "userDescription": "Workspace-wide scan for unused exported symbols (dead code) across the entire project or a scoped directory",
+        "modelDescription": "WHEN: you need a workspace-wide scan for all unused exported symbols (dead code), not just a single file. WHY: detecting dead code across an entire project requires building and querying a full reverse symbol index — impossible to do by reading files individually. WHAT: returns a list of unused exported symbols with their file paths, symbol names, and kinds. Supports optional scopePath to restrict the scan to a subdirectory and maxFiles to cap processing.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "scopePath": {
+              "type": "string",
+              "description": "Optional absolute path to a directory to restrict the scan scope (defaults to entire workspace)"
+            },
+            "maxFiles": {
+              "type": "number",
+              "description": "Optional maximum number of files to process (defaults to no limit)"
+            }
+          }
+        }
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -1057,12 +1057,6 @@
   "bin": {
     "graph-it": "./bin/graph-it"
   },
-  "files": [
-    "bin/",
-    "dist/graph-it.js",
-    "dist/wasm/",
-    "dist/queries/"
-  ],
   "scripts": {
     "vscode:prepublish": "npm run build -- --production",
     "build": "node esbuild.js",

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -81,7 +81,7 @@ node -e "
 const fs = require('fs');
 const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 p.name = '@magic5644/graph-it-live';
-p.files = ['bin/', 'dist/graph-it.js', 'dist/astWorker.js', 'dist/mcpServer.mjs', 'dist/mcpWorker.js', 'dist/indexerWorker.js', 'dist/wasm/', 'dist/queries/', 'README.md', 'LICENSE'];
+p.files = ['bin/', 'dist/graph-it.js', 'dist/astWorker.js', 'dist/mcpServer.mjs', 'dist/mcpWorker.js', 'dist/indexerWorker.js', 'dist/wasm/', 'dist/queries/', 'README.md', 'LICENSE', 'docs/CLI.md'];
 fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
 "
 echo "  ✓ name  → @magic5644/graph-it-live"

--- a/scripts/test-cli-e2e.sh
+++ b/scripts/test-cli-e2e.sh
@@ -29,7 +29,8 @@ echo "  Packed: $TGZ"
 
 # ── 2. Install ───────────────────────────────────────────────────────────────
 section "Install from tgz"
-npm install -g "./$TGZ"
+npm uninstall -g graph-it-live 2>/dev/null || true
+npm install -g --force "./$TGZ"
 BINARY=$(which graph-it || echo "")
 [[ -n "$BINARY" ]] && pass "graph-it found at $BINARY" || fail "graph-it not in PATH"
 
@@ -79,7 +80,13 @@ graph-it "$W" tool analyze_breaking_changes --args "{\"filePath\":\"$SAMPLE_FILE
 section "Call graph"
 graph-it "$W" tool query_call_graph        "--filePath=$SAMPLE_FILE" "--symbolName=$SYMBOL"        && pass "query_call_graph"        || fail "query_call_graph"
 
-# ── 9. High-level CLI commands (no -w: auto-detected from CWD = workspace) ───
+# ── 9. Dead code scan ─────────────────────────────────────────────────────────
+section "Dead code scan (tool)"
+graph-it "$W" tool scan_dead_code                              && pass "scan_dead_code"              || fail "scan_dead_code"
+graph-it "$W" tool scan_dead_code "--scopePath=$WORKSPACE/src" && pass "scan_dead_code --scopePath" || fail "scan_dead_code --scopePath"
+graph-it "$W" tool scan_dead_code "--maxFiles=5"               && pass "scan_dead_code --maxFiles"   || fail "scan_dead_code --maxFiles"
+
+# ── 10. High-level CLI commands (no -w: auto-detected from CWD = workspace) ──
 # Note: global flags with a space-separated value (-w VAL) end up in rawCommandArgs
 # and get misinterpreted as the file pos-arg.  Omit -w; rely on CWD detection.
 section "CLI commands"
@@ -91,7 +98,7 @@ graph-it path "$ENTRY_FILE_REL"            && pass "path"            || fail "pa
 graph-it check "$SAMPLE_FILE_REL"          && pass "check"           || fail "check"
 graph-it trace "$SAMPLE_FILE_REL#$SYMBOL"  && pass "trace"           || fail "trace"
 
-# ── 10. Uninstall ─────────────────────────────────────────────────────────────
+# ── 11. Uninstall ─────────────────────────────────────────────────────────────
 section "Cleanup"
 npm uninstall -g graph-it-live && pass "uninstalled" || fail "uninstall"
 rm -f "$TGZ" && pass "tgz removed"

--- a/scripts/test-mcp.js
+++ b/scripts/test-mcp.js
@@ -871,6 +871,72 @@ export function add(a: number, b: number): number {
   await new Promise(r => setTimeout(r, 500));
 
   // =========================================================================
+  // 37. graphitlive_scan_dead_code — full workspace scan
+  // =========================================================================
+  log('\n📤 [graphitlive_scan_dead_code] Scanning full workspace for dead exports...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_scan_dead_code',
+      arguments: {}
+    }
+  });
+  await new Promise(r => setTimeout(r, 2000)); // index may need warming
+
+  // =========================================================================
+  // 38. graphitlive_scan_dead_code — scoped to fixtures/sample-project/src
+  // =========================================================================
+  log('\n📤 [graphitlive_scan_dead_code] Scanning scoped to fixtures/sample-project/src...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_scan_dead_code',
+      arguments: {
+        scopePath: fixturesPath
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 1000));
+
+  // =========================================================================
+  // 39. graphitlive_scan_dead_code — with maxFiles cap
+  // =========================================================================
+  log('\n📤 [graphitlive_scan_dead_code] Scanning with maxFiles=3 cap...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_scan_dead_code',
+      arguments: {
+        maxFiles: 3
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 500));
+
+  // =========================================================================
+  // 40. graphitlive_scan_dead_code — error case: scopePath outside workspace
+  // =========================================================================
+  log('\n📤 [graphitlive_scan_dead_code] Error case: scopePath outside workspace...');
+  send({
+    jsonrpc: '2.0',
+    id: ++id,
+    method: 'tools/call',
+    params: {
+      name: 'graphitlive_scan_dead_code',
+      arguments: {
+        scopePath: '/tmp/outside-workspace'
+      }
+    }
+  });
+  await new Promise(r => setTimeout(r, 500));
+
+  // =========================================================================
   // BENCHMARK: JSON vs TOON Format Comparison
   // =========================================================================
   log('\n📊 ============================================');

--- a/src/analyzer/Spider.ts
+++ b/src/analyzer/Spider.ts
@@ -556,6 +556,17 @@ export class Spider {
     return this.symbolService.findUnusedSymbols(filePath);
   }
 
+  async scanDeadCode(
+    scopePath?: string,
+    options?: { maxFiles?: number }
+  ): Promise<{ entries: Array<{ filePath: string; unusedSymbols: import('./types').SymbolInfo[] }>; scannedFiles: number; skippedFiles: number }> {
+    const resolvedScope = scopePath ?? this.config.rootDir;
+    return this.symbolService.scanDeadCode(resolvedScope, {
+      maxFiles: options?.maxFiles,
+      hasReverseIndex: this.hasReverseIndex(),
+    });
+  }
+
   async verifyDependencyUsage(sourceFile: string, targetFile: string): Promise<boolean> {
     return this.symbolService.verifyDependencyUsage(sourceFile, targetFile);
   }

--- a/src/analyzer/spider/SpiderSymbolService.ts
+++ b/src/analyzer/spider/SpiderSymbolService.ts
@@ -1,12 +1,14 @@
 import path from 'node:path';
+import { SUPPORTED_SYMBOL_ANALYSIS_EXTENSIONS } from '../../shared/constants';
 import { getLogger } from '../../shared/logger';
 import { AstWorkerHost } from '../ast/AstWorkerHost';
 import { Cache } from '../Cache';
 import { FileReader } from '../FileReader';
 import { LanguageService } from '../LanguageService';
+import { SourceFileCollector } from '../SourceFileCollector';
 import { SymbolDependencyHelper } from '../SymbolDependencyHelper';
 import type { Dependency, SpiderConfig, SymbolDependency, SymbolInfo } from '../types';
-import { SpiderError, normalizePath } from '../types';
+import { SpiderError, SpiderErrorCode, normalizePath } from '../types';
 import { isInIgnoredDirectory } from '../utils/PathPredicates';
 import { PathResolver } from '../utils/PathResolver';
 
@@ -444,5 +446,70 @@ export class SpiderSymbolService {
       filePath.endsWith('.go') ||
       filePath.endsWith('.java')
     );
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Workspace-wide dead code scan
+  // ──────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Scan all files under `scopePath` for unused exported symbols.
+   *
+   * @param scopePath - Absolute path to a directory (or file) to scope the
+   *   scan.  Must be inside the workspace root (caller is responsible for
+   *   validating this).
+   * @param options.maxFiles - Hard cap on files analysed (default: 500).
+   * @param options.hasReverseIndex - Whether the reverse index is available.
+   *   If false, throws INDEX_NOT_READY — we never fall back to O(n²) lookups.
+   * @returns Array of { filePath, unusedSymbols } entries (only files that
+   *   have at least one unused export are included).
+   */
+  async scanDeadCode(
+    scopePath: string,
+    options: { maxFiles?: number; hasReverseIndex: boolean }
+  ): Promise<{ entries: Array<{ filePath: string; unusedSymbols: SymbolInfo[] }>; scannedFiles: number; skippedFiles: number }> {
+    const { maxFiles = 500, hasReverseIndex } = options;
+
+    if (!hasReverseIndex) {
+      throw new SpiderError(
+        'Dead code scan requires the reverse index. Wait for indexing to complete or call rebuild_index first.',
+        SpiderErrorCode.INDEX_NOT_READY,
+      );
+    }
+
+    const config = this.getConfig();
+    const collector = new SourceFileCollector({ excludeNodeModules: config.excludeNodeModules });
+
+    // Collect all source files under scopePath
+    const allFiles = await collector.collectAllSourceFiles(scopePath);
+
+    // Filter to files supported by the symbol analyser
+    const SUPPORTED_EXTENSIONS_SET = new Set(SUPPORTED_SYMBOL_ANALYSIS_EXTENSIONS as readonly string[]);
+    const analysableFiles = allFiles.filter((f) => {
+      const ext = path.extname(f).toLowerCase();
+      return SUPPORTED_EXTENSIONS_SET.has(ext);
+    });
+
+    // Apply hard cap
+    const filesToScan = analysableFiles.slice(0, maxFiles);
+
+    const entries: Array<{ filePath: string; unusedSymbols: SymbolInfo[] }> = [];
+    let skippedFiles = 0;
+
+    for (const filePath of filesToScan) {
+      try {
+        const unusedSymbols = await this.findUnusedSymbols(filePath);
+        if (unusedSymbols.length > 0) {
+          entries.push({ filePath, unusedSymbols });
+        }
+      } catch (error) {
+        // Per-file errors are silently skipped so the batch continues.
+        const spiderError = SpiderError.fromError(error, filePath);
+        log.warn('scanDeadCode: skipping file due to error:', filePath, spiderError.message);
+        skippedFiles++;
+      }
+    }
+
+    return { entries, scannedFiles: filesToScan.length, skippedFiles };
   }
 }

--- a/src/analyzer/types.ts
+++ b/src/analyzer/types.ts
@@ -20,6 +20,8 @@ export enum SpiderErrorCode {
   CIRCULAR_DEPENDENCY = "CIRCULAR_DEPENDENCY",
   /** Unknown or unclassified error */
   UNKNOWN = "UNKNOWN",
+  /** Reverse index not ready (dead code scan guard) */
+  INDEX_NOT_READY = "INDEX_NOT_READY",
 }
 
 /**

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -6,8 +6,8 @@
  * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
  */
 
-import { executeFindUnusedSymbols } from "../../mcp/tools";
-import { CliError, ExitCode } from "../errors";
+import fs from "node:fs/promises";
+import { executeFindUnusedSymbols, executeScanDeadCode } from "../../mcp/tools";
 import type { CliOutputFormat } from "../formatter";
 import { formatOutput } from "../formatter";
 import type { CliRuntime } from "../runtime";
@@ -18,15 +18,29 @@ export async function run(
   runtime: CliRuntime,
   format: CliOutputFormat,
 ): Promise<string> {
-  if (args.length === 0) {
-    throw new CliError(
-      "Usage: graph-it check <file>",
-      ExitCode.GENERAL_ERROR,
-    );
-  }
-
   await runtime.ensureIndexed();
 
+  // No argument → full workspace scan for dead code
+  if (args.length === 0) {
+    const result = await executeScanDeadCode({});
+    return formatOutput(result, format, "check");
+  }
+
+  // Check if the argument is a directory → scoped dead code scan
+  let isDirectory = false;
+  try {
+    const stat = await fs.stat(args[0]);
+    isDirectory = stat.isDirectory();
+  } catch {
+    // Not found or not accessible — treat as file reference below
+  }
+
+  if (isDirectory) {
+    const result = await executeScanDeadCode({ scopePath: args[0] });
+    return formatOutput(result, format, "check");
+  }
+
+  // File argument → existing per-file unused symbol check
   const ref = parseSymbolRef(args[0], runtime.workspaceRoot);
 
   const result = await executeFindUnusedSymbols({

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -58,6 +58,7 @@ const TOOL_NAMES: McpToolName[] = [
   "analyze_file_logic",
   "generate_codemap",
   "query_call_graph",
+  "scan_dead_code",
 ];
 
 /** One-line descriptions for `graph-it tool --list` */
@@ -82,6 +83,7 @@ const TOOL_DESCRIPTIONS: Record<string, string> = {
   analyze_file_logic: "Intra-file call hierarchy (AST-based)",
   generate_codemap: "AI-friendly structural overview of a file (TOON)",
   query_call_graph: "BFS callers/callees via the SQLite call graph index",
+  scan_dead_code: "Workspace-wide scan for unused exported symbols (dead code)",
 };
 
 export async function run(

--- a/src/extension/services/LmToolsService.ts
+++ b/src/extension/services/LmToolsService.ts
@@ -112,6 +112,11 @@ interface QueryCallGraphInput {
   relationTypes?: string[];
 }
 
+interface ScanDeadCodeInput {
+  scopePath?: string;
+  maxFiles?: number;
+}
+
 // ─── Service options ──────────────────────────────────────────────────────────
 
 interface LmToolsServiceOptions {
@@ -176,6 +181,7 @@ export class LmToolsService {
       this.registerResolveModulePath(),
       this.registerAnalyzeBreakingChanges(),
       this.registerQueryCallGraph(),
+      this.registerScanDeadCode(),
     ];
   }
 
@@ -1283,5 +1289,30 @@ export class LmToolsService {
       const nextId = (dir === 'callers' ? r[0] : r[1]) as string;
       if (!visited.has(nextId)) next.add(nextId);
     }
+  }
+
+  // ─── Tool: scan_dead_code ─────────────────────────────────────────────────
+
+  private registerScanDeadCode(): vscode.Disposable {
+    return vscode.lm.registerTool<ScanDeadCodeInput>(
+      'graph-it-live_scan_dead_code',
+      {
+        invoke: async (
+          options: vscode.LanguageModelToolInvocationOptions<ScanDeadCodeInput>,
+          _token: vscode.CancellationToken,
+        ): Promise<vscode.LanguageModelToolResult> => {
+          const { scopePath, maxFiles } = options.input;
+          try {
+            const { executeScanDeadCode } = await import('../../mcp/tools/deadcode.js');
+            const result = await executeScanDeadCode({ scopePath, maxFiles });
+            return new vscode.LanguageModelToolResult([
+              new vscode.LanguageModelTextPart(JSON.stringify(result)),
+            ]);
+          } catch (error) {
+            return this.errorResult(error instanceof Error ? error.message : String(error));
+          }
+        },
+      },
+    );
   }
 }

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -141,6 +141,7 @@ import {
   type RebuildIndexResult,
   ResolveModulePathParamsSchema,
   type ResolveModulePathResult,
+  ScanDeadCodeParamsSchema,
   // Import all parameter schemas with payload limits
   SetWorkspaceParamsSchema,
   type SetWorkspaceResult,
@@ -1767,6 +1768,65 @@ RETURNS:
     const response = await invokeToolWithResponse(
       "query_call_graph",
       { filePath, symbolName, direction, depth, relationTypes },
+    );
+
+    return formatToolResponse(response, responseFormat);
+  },
+);
+
+// Tool: graphitlive_scan_dead_code
+server.registerTool(
+  "graphitlive_scan_dead_code",
+  {
+    title: "Scan Workspace for Dead Code",
+    description: `CRITICAL: USE THIS TOOL WHEN the user wants to find unused exported symbols across a workspace or directory.
+
+WHEN TO USE:
+- User asks "Find dead code in this project"
+- User asks "What symbols are exported but never used?"
+- User wants to clean up unused exports before a refactor
+- User wants to identify code that can be safely deleted
+- User is performing a code quality audit
+
+EXAMPLES:
+- "Scan the whole project for dead code"
+- "Find unused exports in src/utils"
+- "Which functions are never called anywhere?"
+
+WHY YOU NEED THIS:
+This tool combines the reverse dependency index with per-file symbol analysis to efficiently find exported symbols that are not referenced elsewhere in the codebase.
+Without the index this would require O(n²) file scanning — this tool requires background indexing to be complete first.
+
+RETURNS:
+- rootDir: Workspace root
+- scopePath: Directory that was scanned
+- scannedFiles: Total files analysed
+- filesWithDeadCode: Number of files containing unused exports
+- totalUnusedSymbols: Sum of all unused exported symbols found
+- entries[]: Per-file list with filePath, relativePath, unusedCount, unusedSymbols[]
+- analysisTimeMs: Wall-clock time for the scan`,
+    inputSchema: ScanDeadCodeParamsSchema.extend({
+      response_format: ResponseFormatSchema.describe(
+        "Output format: 'json', 'markdown', or 'toon' (default: toon)",
+      ),
+    }),
+    outputSchema: McpToolResponseSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async ({ scopePath, maxFiles, response_format }) => {
+    const workerCheck = await ensureWorkerReady();
+    const responseFormat = response_format ?? "toon";
+    if (workerCheck.error)
+      return formatToolResponse(workerCheck.response, responseFormat);
+
+    const response = await invokeToolWithResponse(
+      "scan_dead_code",
+      { scopePath, maxFiles },
     );
 
     return formatToolResponse(response, responseFormat);

--- a/src/mcp/shared/helpers.ts
+++ b/src/mcp/shared/helpers.ts
@@ -246,6 +246,40 @@ export async function validateAnalysisInput(filePath: string): Promise<{
   return { ext: ext as typeof SUPPORTED_SYMBOL_ANALYSIS_EXTENSIONS[number], language };
 }
 
+/**
+ * Validate that a scope path is a directory inside the workspace root.
+ * Prevents path traversal attacks.
+ *
+ * @param scopePath - The scope path to validate (must be absolute)
+ * @param rootDir   - The workspace root directory
+ * @throws if scopePath is not absolute, contains null bytes, or is outside rootDir
+ */
+export function validateScopePath(scopePath: string, rootDir: string): void {
+  // Reject null bytes (common injection vector)
+  if (scopePath.includes("\0")) {
+    throw new Error(`INVALID_SCOPE_PATH: Path contains null bytes: ${scopePath}`);
+  }
+
+  if (!path.isAbsolute(scopePath)) {
+    throw new Error(`INVALID_SCOPE_PATH: Scope path must be absolute. Got: ${scopePath}`);
+  }
+
+  const resolvedScope = path.resolve(scopePath);
+  const resolvedRoot = path.resolve(rootDir);
+
+  // Ensure scope is the root itself or a subdirectory of root
+  const withinRoot =
+    resolvedScope === resolvedRoot ||
+    resolvedScope.startsWith(resolvedRoot + path.sep) ||
+    resolvedScope.startsWith(resolvedRoot + "/");
+
+  if (!withinRoot) {
+    throw new Error(
+      `INVALID_SCOPE_PATH: Scope path '${scopePath}' is outside workspace root '${rootDir}'`,
+    );
+  }
+}
+
 // ============================================================================
 // LSP Conversion Utilities (re-exported from shared/converters)
 // ============================================================================

--- a/src/mcp/tools/deadcode.ts
+++ b/src/mcp/tools/deadcode.ts
@@ -1,0 +1,78 @@
+import { getRelativePath, validateScopePath } from "../shared/helpers";
+import { workerState } from "../shared/state";
+import type {
+    DeadCodeFileEntry,
+    ScanDeadCodeParams,
+    ScanDeadCodeResult,
+    SymbolInfo,
+} from "../types";
+
+/**
+ * Categorize a symbol by its kind (mirrors symbol.ts helper)
+ */
+function categorizeSymbolKind(
+  kind: string,
+): "function" | "class" | "variable" | "interface" | "type" | "other" {
+  if (kind.includes("Function")) return "function";
+  if (kind.includes("Class")) return "class";
+  if (
+    kind.includes("Variable") ||
+    kind.includes("Const") ||
+    kind.includes("Let")
+  )
+    return "variable";
+  if (kind.includes("Interface")) return "interface";
+  if (kind.includes("Type")) return "type";
+  return "other";
+}
+
+/**
+ * Scan the workspace (or a scoped directory) for unused exported symbols.
+ *
+ * Security: scopePath is validated against the workspace root to prevent
+ * path traversal.
+ * Guard: requires the reverse index to be ready — never silent O(n²) fallback.
+ */
+export async function executeScanDeadCode(
+  params: ScanDeadCodeParams,
+): Promise<ScanDeadCodeResult> {
+  const spider = workerState.getSpider();
+  const config = workerState.getConfig();
+  const { scopePath, maxFiles } = params;
+
+  const resolvedScopePath = scopePath ?? config.rootDir;
+
+  // Path traversal prevention
+  validateScopePath(resolvedScopePath, config.rootDir);
+
+  const startTime = Date.now();
+
+  const rawResult = await spider.scanDeadCode(resolvedScopePath, { maxFiles });
+
+  const analysisTimeMs = Date.now() - startTime;
+
+  // Enrich entries
+  const entries: DeadCodeFileEntry[] = rawResult.entries.map((entry) => {
+    const categorizedSymbols: SymbolInfo[] = entry.unusedSymbols.map((s) => ({
+      ...s,
+      category: categorizeSymbolKind(s.kind),
+    }));
+    return {
+      filePath: entry.filePath,
+      relativePath: getRelativePath(entry.filePath, config.rootDir),
+      unusedCount: categorizedSymbols.length,
+      unusedSymbols: categorizedSymbols,
+    };
+  });
+
+  return {
+    rootDir: config.rootDir,
+    scopePath: resolvedScopePath,
+    scannedFiles: rawResult.scannedFiles,
+    filesWithDeadCode: entries.length,
+    totalUnusedSymbols: entries.reduce((sum, e) => sum + e.unusedCount, 0),
+    entries,
+    skippedFiles: rawResult.skippedFiles,
+    analysisTimeMs,
+  };
+}

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -10,6 +10,9 @@ export {
     executeGenerateCodemap
 } from "./codemap";
 export {
+    executeScanDeadCode
+} from "./deadcode";
+export {
     executeGetSymbolCallers,
     executeTraceFunctionExecution
 } from "./execution";

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -10,7 +10,7 @@
 
 import * as nodePath from "node:path";
 import { z } from "zod/v4";
-import type { Dependency } from "../analyzer/types";
+import type { Dependency, DependencyType } from "../analyzer/types";
 import {
   getRelativePath as _getRelativePath,
   normalizePathForComparison as _normalizePathForComparison,
@@ -106,7 +106,8 @@ export type McpToolName =
   | "get_impact_analysis" // NEW: Full impact analysis
   | "analyze_file_logic" // NEW: LSP-based intra-file call hierarchy
   | "generate_codemap" // NEW: Full codemap generation for a single file
-  | "query_call_graph"; // NEW: Cross-file call graph query (callers/callees via SQLite)
+  | "query_call_graph" // NEW: Cross-file call graph query (callers/callees via SQLite)
+  | "scan_dead_code"; // NEW: Workspace-wide dead code scan
 
 // ============================================================================
 // Zod Schemas for Tool Parameters
@@ -504,6 +505,25 @@ export type QueryCallGraphParams = z.infer<
   typeof QueryCallGraphParamsSchema
 >;
 
+// NEW: Schema for scan_dead_code (workspace-wide dead code scan)
+export const ScanDeadCodeParamsSchema = z.object({
+  scopePath: FilePathSchema.optional().describe(
+    "Absolute path to a directory to scope the scan (default: workspace root). Must be inside the workspace.",
+  ),
+  maxFiles: z
+    .number()
+    .int()
+    .min(1)
+    .max(10_000)
+    .default(500)
+    .optional()
+    .describe(
+      "Maximum number of files to analyse (default: 500). Prevents OOM on very large monorepos.",
+    ),
+  format: OutputFormatSchema.optional(),
+});
+export type ScanDeadCodeParams = z.infer<typeof ScanDeadCodeParamsSchema>;
+
 // ============================================================================
 // Validation Utilities
 // ============================================================================
@@ -533,6 +553,7 @@ export const toolSchemas: Record<McpToolName, z.ZodType<unknown>> = {
   analyze_file_logic: AnalyzeFileLogicParamsSchema,
   generate_codemap: GenerateCodemapParamsSchema,
   query_call_graph: QueryCallGraphParamsSchema,
+  scan_dead_code: ScanDeadCodeParamsSchema,
 };
 
 /**
@@ -734,9 +755,9 @@ export interface McpToolResponse<T> {
 // ============================================================================
 
 /**
- * Type of import statement
+ * Type of import statement (alias for DependencyType from analyzer)
  */
-export type ImportType = "import" | "require" | "export" | "dynamic";
+export type ImportType = DependencyType;
 
 /**
  * Result of analyze_dependencies tool
@@ -1382,6 +1403,46 @@ export function createErrorResponse<T>(
       workspaceRoot,
     },
   };
+}
+
+// ============================================================================
+// NEW: Scan Dead Code Result
+// ============================================================================
+
+/**
+ * Per-file entry in the dead code scan result
+ */
+export interface DeadCodeFileEntry {
+  /** Absolute path to the file */
+  filePath: string;
+  /** Relative path from workspace root */
+  relativePath: string;
+  /** Number of unused exported symbols found */
+  unusedCount: number;
+  /** Unused exported symbols */
+  unusedSymbols: SymbolInfo[];
+}
+
+/**
+ * Result of scan_dead_code tool
+ */
+export interface ScanDeadCodeResult {
+  /** Workspace root directory */
+  rootDir: string;
+  /** Absolute path of the scanned scope */
+  scopePath: string;
+  /** Number of files that were analysed */
+  scannedFiles: number;
+  /** Number of files containing at least one unused exported symbol */
+  filesWithDeadCode: number;
+  /** Total unused exported symbols across all files */
+  totalUnusedSymbols: number;
+  /** Per-file entries (only files with dead code are included) */
+  entries: DeadCodeFileEntry[];
+  /** Number of files skipped (unsupported language / parse error) */
+  skippedFiles: number;
+  /** Total analysis time in milliseconds */
+  analysisTimeMs: number;
 }
 
 /**

--- a/src/mcp/worker/invokeTool.ts
+++ b/src/mcp/worker/invokeTool.ts
@@ -18,6 +18,7 @@ import {
   executeQueryCallGraph,
   executeRebuildIndex,
   executeResolveModulePath,
+  executeScanDeadCode,
   executeTraceFunctionExecution,
   executeVerifyDependencyUsage,
 } from "../tools";
@@ -40,6 +41,7 @@ import type {
   ParseImportsParams,
   QueryCallGraphParams,
   ResolveModulePathParams,
+  ScanDeadCodeParams,
   TraceFunctionExecutionParams,
   VerifyDependencyUsageParams,
 } from "../types";
@@ -205,6 +207,11 @@ export async function invokeTool(
         const p = validatedParams as QueryCallGraphParams;
         validateFilePath(p.filePath, config.rootDir);
         result = await executeQueryCallGraph(p);
+        break;
+      }
+      case "scan_dead_code": {
+        const p = validatedParams as ScanDeadCodeParams;
+        result = await executeScanDeadCode(p);
         break;
       }
       default:

--- a/tests/analyzer/SpiderDeadCodeScan.test.ts
+++ b/tests/analyzer/SpiderDeadCodeScan.test.ts
@@ -1,0 +1,87 @@
+import * as path from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { Spider } from '../../src/analyzer/Spider';
+import { SpiderBuilder } from '../../src/analyzer/SpiderBuilder';
+import { SpiderErrorCode } from '../../src/analyzer/types';
+
+describe('Spider - scanDeadCode', () => {
+  const fixturesDir = path.resolve(process.cwd(), 'tests/fixtures/symbols');
+  const utilsPath = path.join(fixturesDir, 'utils.ts');
+
+  let spider: Spider;
+
+  beforeAll(async () => {
+    spider = new SpiderBuilder()
+      .withRootDir(fixturesDir)
+      .withReverseIndex(true)
+      .build();
+
+    await spider.buildFullIndex();
+  });
+
+  it('should return the correct shape: { entries, scannedFiles, skippedFiles }', async () => {
+    const result = await spider.scanDeadCode();
+
+    expect(result).toHaveProperty('entries');
+    expect(result).toHaveProperty('scannedFiles');
+    expect(result).toHaveProperty('skippedFiles');
+    expect(Array.isArray(result.entries)).toBe(true);
+    expect(typeof result.scannedFiles).toBe('number');
+    expect(typeof result.skippedFiles).toBe('number');
+  });
+
+  it('should find unused symbols in utils.ts', async () => {
+    const result = await spider.scanDeadCode();
+
+    const utilsEntry = result.entries.find((e) => e.filePath === utilsPath);
+    expect(utilsEntry).toBeDefined();
+
+    const symbolNames = utilsEntry?.unusedSymbols.map((s) => s.name) ?? [];
+    expect(symbolNames).toContain('unusedFunc');
+    expect(symbolNames).toContain('UnusedType');
+  });
+
+  it('should count scannedFiles >= entries.length (total ≥ files with dead code)', async () => {
+    const result = await spider.scanDeadCode();
+
+    expect(result.scannedFiles).toBeGreaterThanOrEqual(result.entries.length);
+  });
+
+  it('should return 0 skippedFiles when all files parse successfully', async () => {
+    const result = await spider.scanDeadCode();
+
+    expect(result.skippedFiles).toBe(0);
+  });
+
+  it('should scope results when scopePath is a subdirectory', async () => {
+    // Passing the exact fixturesDir should still work as a valid scope
+    const result = await spider.scanDeadCode(fixturesDir);
+
+    expect(result).toHaveProperty('entries');
+    expect(result.scannedFiles).toBeGreaterThan(0);
+  });
+
+  it('should throw INDEX_NOT_READY when reverse index is absent', async () => {
+    const spiderWithoutIndex = new SpiderBuilder()
+      .withRootDir(fixturesDir)
+      .withReverseIndex(false)
+      .build();
+
+    await expect(spiderWithoutIndex.scanDeadCode()).rejects.toMatchObject({
+      code: SpiderErrorCode.INDEX_NOT_READY,
+    });
+  });
+
+  it('should throw INDEX_NOT_READY after reset (index cleared)', async () => {
+    // A fresh spider with reverse index enabled but NOT yet indexed
+    const freshSpider = new SpiderBuilder()
+      .withRootDir(fixturesDir)
+      .withReverseIndex(true)
+      .build();
+
+    // Do NOT call buildFullIndex — index is empty
+    await expect(freshSpider.scanDeadCode()).rejects.toMatchObject({
+      code: SpiderErrorCode.INDEX_NOT_READY,
+    });
+  });
+});

--- a/tests/benchmarks/deadCodeScan.bench.ts
+++ b/tests/benchmarks/deadCodeScan.bench.ts
@@ -1,0 +1,62 @@
+import * as path from 'node:path';
+import { beforeAll, bench, describe } from 'vitest';
+import { Spider } from '../../src/analyzer/Spider';
+
+const BENCH_OPTIONS = {
+  time: 10,
+  warmupTime: 0,
+  warmupIterations: 0,
+  iterations: 1,
+} as const;
+
+/**
+ * Benchmark tests for workspace-wide dead code scan performance
+ *
+ * These benchmarks measure:
+ * 1. Full workspace scan (bench-permanent, ~20 TS files, reverse index pre-built)
+ * 2. Scoped scan (single src/ directory)
+ * 3. Scan with maxFiles cap (maxFiles = 5)
+ *
+ * Run with: npm run test:bench
+ *
+ * IMPORTANT: Uses permanent fixtures in tests/fixtures/bench-permanent
+ */
+
+const BENCH_PERMANENT_PATH = path.resolve(process.cwd(), 'tests/fixtures/bench-permanent');
+const SRC_PATH = path.join(BENCH_PERMANENT_PATH, 'src');
+
+let _spider: Spider | null = null;
+
+async function getSpider(): Promise<Spider> {
+  if (!_spider) {
+    _spider = new Spider({
+      rootDir: BENCH_PERMANENT_PATH,
+      enableReverseIndex: true,
+      indexingConcurrency: 4,
+    });
+    await _spider.buildFullIndex();
+  }
+  return _spider;
+}
+
+describe('Dead Code Scan Benchmarks', () => {
+  beforeAll(async () => {
+    // Pre-warm: build the full reverse index once before any benchmark runs
+    await getSpider();
+  });
+
+  bench('scanDeadCode – full workspace (~20 files)', async () => {
+    const spider = await getSpider();
+    await spider.scanDeadCode(BENCH_PERMANENT_PATH);
+  }, BENCH_OPTIONS);
+
+  bench('scanDeadCode – scoped to src/ directory', async () => {
+    const spider = await getSpider();
+    await spider.scanDeadCode(SRC_PATH);
+  }, BENCH_OPTIONS);
+
+  bench('scanDeadCode – maxFiles cap = 5', async () => {
+    const spider = await getSpider();
+    await spider.scanDeadCode(BENCH_PERMANENT_PATH, { maxFiles: 5 });
+  }, BENCH_OPTIONS);
+});

--- a/tests/cli/commands.test.ts
+++ b/tests/cli/commands.test.ts
@@ -26,7 +26,7 @@ function createFixtureProject(): string {
 // ---------------------------------------------------------------------------
 
 describe("tool command", () => {
-  it("--list returns all 20 MCP tool names", async () => {
+  it("--list returns all 21 MCP tool names", async () => {
     const { run } = await import("../../src/cli/commands/tool.js");
 
     // Provide a minimal runtime stub — --list doesn't touch spider
@@ -56,6 +56,7 @@ describe("tool command", () => {
     expect(output).toContain("analyze_file_logic");
     expect(output).toContain("generate_codemap");
     expect(output).toContain("query_call_graph");
+    expect(output).toContain("scan_dead_code");
     // Verify descriptions are included
     expect(output).toContain("Show direct imports and exports");
   });

--- a/tests/cli/deadcode.test.ts
+++ b/tests/cli/deadcode.test.ts
@@ -1,0 +1,191 @@
+/**
+ * CLI integration tests for the `check` command with dead-code scan feature.
+ *
+ * Three modes are tested:
+ *   1. `check` with no args   → full workspace dead-code scan
+ *   2. `check ./src`          → scoped scan of a directory
+ *   3. `check ./src/foo.ts`   → per-file unused-symbol check (existing behaviour)
+ *
+ * Spider and MCP tool functions are mocked so no WASM / AST is loaded.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { workerState } from "../../src/mcp/shared/state";
+
+// ---------------------------------------------------------------------------
+// Helper: tiny fixture project
+// ---------------------------------------------------------------------------
+
+function createFixtureProject(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "graph-it-check-"));
+  fs.mkdirSync(path.join(root, "src"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "src", "index.ts"),
+    `export const x = 1;\n`,
+  );
+  fs.writeFileSync(
+    path.join(root, "src", "utils.ts"),
+    `export function helper(): void {}\n`,
+  );
+  return root;
+}
+
+// ---------------------------------------------------------------------------
+// Shared mock state
+// ---------------------------------------------------------------------------
+
+const scanDeadCodeMock = vi.fn();
+const findUnusedSymbolsMock = vi.fn();
+
+vi.mock("../../src/mcp/tools", () => ({
+  executeScanDeadCode: (...args: unknown[]) => scanDeadCodeMock(...args),
+  executeFindUnusedSymbols: (...args: unknown[]) => findUnusedSymbolsMock(...args),
+}));
+
+vi.mock("../../src/cli/formatter", () => ({
+  formatOutput: (result: unknown) => JSON.stringify(result),
+}));
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("CLI check command", () => {
+  let tmpDir: string;
+
+  const runtimeStub = {
+    ensureIndexed: vi.fn(),
+    workspaceRoot: "",
+  };
+
+  beforeEach(() => {
+    tmpDir = createFixtureProject();
+    runtimeStub.workspaceRoot = tmpDir;
+    runtimeStub.ensureIndexed.mockResolvedValue(undefined);
+
+    // Default mock returns for each mode
+    scanDeadCodeMock.mockResolvedValue({
+      rootDir: tmpDir,
+      scopePath: tmpDir,
+      scannedFiles: 2,
+      filesWithDeadCode: 1,
+      totalUnusedSymbols: 1,
+      entries: [
+        {
+          filePath: path.join(tmpDir, "src", "utils.ts"),
+          relativePath: "src/utils.ts",
+          unusedCount: 1,
+          unusedSymbols: [{ id: "s:helper", name: "helper", kind: "FunctionDeclaration", line: 1, isExported: true }],
+        },
+      ],
+      skippedFiles: 0,
+      analysisTimeMs: 42,
+    });
+
+    findUnusedSymbolsMock.mockResolvedValue({
+      filePath: path.join(tmpDir, "src", "utils.ts"),
+      unusedSymbols: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    workerState.reset();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // ── Mode 1: no args ────────────────────────────────────────────────────────
+
+  describe("no arguments → workspace scan", () => {
+    it("calls executeScanDeadCode with no args", async () => {
+      const { run } = await import("../../src/cli/commands/check.js");
+      await run([], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(scanDeadCodeMock).toHaveBeenCalledOnce();
+      expect(scanDeadCodeMock).toHaveBeenCalledWith({});
+    });
+
+    it("does NOT call executeFindUnusedSymbols", async () => {
+      const { run } = await import("../../src/cli/commands/check.js");
+      await run([], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(findUnusedSymbolsMock).not.toHaveBeenCalled();
+    });
+
+    it("calls ensureIndexed before scanning", async () => {
+      const { run } = await import("../../src/cli/commands/check.js");
+      await run([], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(runtimeStub.ensureIndexed).toHaveBeenCalledOnce();
+    });
+
+    it("returns formatted output string", async () => {
+      const { run } = await import("../../src/cli/commands/check.js");
+      const output = await run([], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(typeof output).toBe("string");
+      expect(output.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Mode 2: directory arg ──────────────────────────────────────────────────
+
+  describe("directory argument → scoped scan", () => {
+    it("calls executeScanDeadCode with the directory as scopePath", async () => {
+      const srcDir = path.join(tmpDir, "src");
+      const { run } = await import("../../src/cli/commands/check.js");
+      await run([srcDir], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(scanDeadCodeMock).toHaveBeenCalledOnce();
+      expect(scanDeadCodeMock).toHaveBeenCalledWith({ scopePath: srcDir });
+    });
+
+    it("does NOT call executeFindUnusedSymbols", async () => {
+      const srcDir = path.join(tmpDir, "src");
+      const { run } = await import("../../src/cli/commands/check.js");
+      await run([srcDir], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(findUnusedSymbolsMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Mode 3: file arg ───────────────────────────────────────────────────────
+
+  describe("file argument → per-file unused-symbol check", () => {
+    it("calls executeFindUnusedSymbols with the file path", async () => {
+      const filePath = path.join(tmpDir, "src", "utils.ts");
+      const { run } = await import("../../src/cli/commands/check.js");
+      await run([filePath], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(findUnusedSymbolsMock).toHaveBeenCalledOnce();
+      expect(findUnusedSymbolsMock).toHaveBeenCalledWith(
+        expect.objectContaining({ filePath }),
+      );
+    });
+
+    it("does NOT call executeScanDeadCode", async () => {
+      const filePath = path.join(tmpDir, "src", "utils.ts");
+      const { run } = await import("../../src/cli/commands/check.js");
+      await run([filePath], runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime, "text");
+
+      expect(scanDeadCodeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── scan_dead_code in tool --list ──────────────────────────────────────────
+
+  describe("tool --list includes scan_dead_code", () => {
+    it("lists scan_dead_code in --list output", async () => {
+      const { run: toolRun } = await import("../../src/cli/commands/tool.js");
+      const output = await toolRun(
+        ["--list"],
+        runtimeStub as unknown as import("../../src/cli/runtime").CliRuntime,
+        "text",
+      );
+      expect(output).toContain("scan_dead_code");
+    });
+  });
+});

--- a/tests/extension/services/LmToolsService.test.ts
+++ b/tests/extension/services/LmToolsService.test.ts
@@ -145,13 +145,13 @@ describe('LmToolsService', () => {
   // ─── registerAll ──────────────────────────────────────────────────────────
 
   describe('registerAll', () => {
-    it('registers 20 tools and returns 20 disposables', () => {
+    it('registers 21 tools and returns 21 disposables', () => {
       const provider = createProvider();
       const service = new LmToolsService({ provider, logger });
       const disposables = service.registerAll();
 
-      expect(disposables).toHaveLength(20);
-      expect(registerToolFn).toHaveBeenCalledTimes(20);
+      expect(disposables).toHaveLength(21);
+      expect(registerToolFn).toHaveBeenCalledTimes(21);
     });
 
     it('returns empty array when vscode.lm.registerTool is unavailable', () => {
@@ -189,6 +189,13 @@ describe('LmToolsService', () => {
       const service = new LmToolsService({ provider, logger });
       service.registerAll();
       expect(registeredTools.has('graph-it-live_query_call_graph')).toBe(true);
+    });
+
+    it('registers graph-it-live_scan_dead_code', () => {
+      const provider = createProvider();
+      const service = new LmToolsService({ provider, logger });
+      service.registerAll();
+      expect(registeredTools.has('graph-it-live_scan_dead_code')).toBe(true);
     });
   });
 

--- a/tests/mcp/McpWorkerScanDeadCode.test.ts
+++ b/tests/mcp/McpWorkerScanDeadCode.test.ts
@@ -1,0 +1,189 @@
+/**
+ * MCP Worker integration tests for scan_dead_code
+ *
+ * Tests the full invocation path:
+ *   invokeTool(requestId, "scan_dead_code", params, postMessage)
+ *     → executeScanDeadCode() → spider.scanDeadCode()
+ *
+ * Mirrors the pattern used in McpWorker.test.ts (real Spider, tmp workspace).
+ */
+
+import * as fs from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Spider } from "../../src/analyzer/Spider";
+import { SpiderBuilder } from "../../src/analyzer/SpiderBuilder";
+import { workerState } from "../../src/mcp/shared/state";
+import type { McpWorkerResponse, ScanDeadCodeResult } from "../../src/mcp/types";
+import { invokeTool } from "../../src/mcp/worker/invokeTool";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal workspace: one file with an exported but never-imported function. */
+async function createDeadCodeWorkspace(root: string) {
+  const src = path.join(root, "src");
+  await fs.mkdir(src, { recursive: true });
+
+  // index.ts imports usedHelper — this creates a reverse-index entry for utils.ts
+  // BUT does NOT import unusedHelper or anotherUnused → those remain dead code
+  await fs.writeFile(
+    path.join(src, "index.ts"),
+    `import { usedHelper } from "./utils";\n` +
+      `export const main = (): void => { usedHelper(); };\n`,
+  );
+
+  await fs.writeFile(
+    path.join(src, "utils.ts"),
+    `export function usedHelper(): void { console.log("used"); }\n` +
+      `export function unusedHelper(): number { return 42; }\n` +
+      `export function anotherUnused(): string { return "x"; }\n`,
+  );
+
+  await fs.writeFile(
+    path.join(root, "package.json"),
+    JSON.stringify({ name: "test-workspace", version: "1.0.0" }),
+  );
+}
+
+/**
+ * Wrap invokeTool into a Promise that resolves/rejects from the postMessage callback.
+ */
+async function callTool(tool: string, params: unknown): Promise<McpWorkerResponse> {
+  return new Promise((resolve) => {
+    invokeTool(
+      "test-request-id",
+      tool as Parameters<typeof invokeTool>[1],
+      params,
+      (msg: McpWorkerResponse) => resolve(msg),
+    ).catch((err: unknown) => {
+      resolve({ type: "error", requestId: "test-request-id", error: err instanceof Error ? err.message : "unknown", code: "EXECUTION_ERROR" });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("MCP invokeTool – scan_dead_code", () => {
+  let tempDir: string;
+  let spider: Spider;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(tmpdir(), "mcp-scan-dead-code-"));
+    await createDeadCodeWorkspace(tempDir);
+
+    spider = new SpiderBuilder()
+      .withRootDir(tempDir)
+      .withMaxDepth(10)
+      .withReverseIndex(true)
+      .withExcludeNodeModules(true)
+      .withExtensionPath(process.cwd())
+      .build();
+
+    // Seed reverse index so scanDeadCode can work
+    await spider.buildFullIndex();
+
+    workerState.spider = spider as unknown as typeof workerState.spider;
+    workerState.parser = {} as unknown as typeof workerState.parser;
+    workerState.resolver = {} as unknown as typeof workerState.resolver;
+    workerState.config = {
+      rootDir: tempDir,
+      excludeNodeModules: true,
+      maxDepth: 10,
+    };
+    workerState.isReady = true;
+  });
+
+  afterEach(async () => {
+    workerState.reset();
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  });
+
+  it("returns a successful ScanDeadCodeResult via invokeTool", async () => {
+    const response = await callTool("scan_dead_code", {});
+
+    expect(response.type).toBe("result");
+    if (response.type !== "result") return;
+    const result = response.data as ScanDeadCodeResult;
+
+    expect(result.rootDir).toBe(tempDir);
+    expect(result.scopePath).toBe(tempDir);
+    expect(result.scannedFiles).toBeGreaterThanOrEqual(1);
+    expect(result.filesWithDeadCode).toBeGreaterThanOrEqual(0);
+    expect(result.skippedFiles).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(result.entries)).toBe(true);
+    expect(typeof result.analysisTimeMs).toBe("number");
+    expect(result.analysisTimeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("detects unused exported symbols in the workspace", async () => {
+    const response = await callTool("scan_dead_code", {});
+
+    expect(response.type).toBe("result");
+    if (response.type !== "result") return;
+    const result = response.data as ScanDeadCodeResult;
+
+    // utils.ts has two exported functions never referenced anywhere
+    const utilsEntry = result.entries.find((e) =>
+      e.filePath.endsWith("utils.ts"),
+    );
+    expect(utilsEntry).toBeDefined();
+    if (utilsEntry) {
+      expect(utilsEntry.unusedCount).toBeGreaterThanOrEqual(1);
+      expect(utilsEntry.unusedSymbols.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("respects scopePath parameter — limits scan to a subdirectory", async () => {
+    const srcDir = path.join(tempDir, "src");
+    const response = await callTool("scan_dead_code", { scopePath: srcDir });
+
+    expect(response.type).toBe("result");
+    if (response.type !== "result") return;
+    const result = response.data as ScanDeadCodeResult;
+
+    expect(result.scopePath).toBe(srcDir);
+    // All returned file paths are inside src/
+    for (const entry of result.entries) {
+      expect(entry.filePath.startsWith(srcDir)).toBe(true);
+    }
+  });
+
+  it("respects maxFiles parameter", async () => {
+    const response = await callTool("scan_dead_code", { maxFiles: 1 });
+
+    expect(response.type).toBe("result");
+    if (response.type !== "result") return;
+    const result = response.data as ScanDeadCodeResult;
+
+    // At most 1 file was analysed
+    expect(result.scannedFiles).toBeLessThanOrEqual(1);
+  });
+
+  it("returns error for scopePath outside workspace", async () => {
+    const response = await callTool("scan_dead_code", {
+      scopePath: "/tmp/some-other-totally-unrelated-path",
+    });
+
+    // Should propagate as an error (security or path validation)
+    expect(response.type).toBe("error");
+  });
+
+  it("result entries include relativePath field", async () => {
+    const response = await callTool("scan_dead_code", {});
+
+    expect(response.type).toBe("result");
+    if (response.type !== "result") return;
+    const result = response.data as ScanDeadCodeResult;
+
+    for (const entry of result.entries) {
+      expect(typeof entry.relativePath).toBe("string");
+      // relativePath must be shorter than the absolute filePath
+      expect(entry.relativePath.length).toBeLessThan(entry.filePath.length);
+    }
+  });
+});

--- a/tests/mcp/shared/helpers.test.ts
+++ b/tests/mcp/shared/helpers.test.ts
@@ -18,6 +18,7 @@ import {
   updateNodeCounts,
   validateAnalysisInput,
   validateFileExists,
+  validateScopePath,
 } from "../../../src/mcp/shared/helpers";
 import type { EdgeInfo, NodeInfo } from "../../../src/mcp/types";
 import { normalizePath } from "../../../src/shared/path";
@@ -504,6 +505,50 @@ describe("MCP Worker Helpers", () => {
       expect(calls).toBeDefined();
       expect(calls).toHaveLength(1);
       expect(calls?.[0].to.name).toBe("MyClass.helper");
+    });
+  });
+
+  describe("validateScopePath", () => {
+    const root = "/workspace/project";
+
+    it("should pass when scopePath equals rootDir", () => {
+      expect(() => validateScopePath(root, root)).not.toThrow();
+    });
+
+    it("should pass when scopePath is a subdirectory of rootDir", () => {
+      expect(() => validateScopePath(`${root}/src`, root)).not.toThrow();
+      expect(() => validateScopePath(`${root}/src/utils`, root)).not.toThrow();
+    });
+
+    it("should throw when scopePath contains null bytes", () => {
+      expect(() => validateScopePath(`${root}/\0evil`, root)).toThrow(
+        "INVALID_SCOPE_PATH: Path contains null bytes",
+      );
+    });
+
+    it("should throw when scopePath is not absolute", () => {
+      expect(() => validateScopePath("relative/path", root)).toThrow(
+        "INVALID_SCOPE_PATH: Scope path must be absolute",
+      );
+    });
+
+    it("should throw when scopePath is outside rootDir (traversal attempt)", () => {
+      expect(() => validateScopePath("/workspace/other", root)).toThrow(
+        "INVALID_SCOPE_PATH: Scope path",
+      );
+    });
+
+    it("should throw for path traversal via .. segments", () => {
+      expect(() => validateScopePath(`${root}/../outside`, root)).toThrow(
+        "INVALID_SCOPE_PATH:",
+      );
+    });
+
+    it("should reject paths that share a prefix but are not subdirectories", () => {
+      // /workspace/project-evil should NOT be accepted as subdirectory of /workspace/project
+      expect(() => validateScopePath(`${root}-evil`, root)).toThrow(
+        "INVALID_SCOPE_PATH:",
+      );
     });
   });
 });

--- a/tests/mcp/tools/deadcode.test.ts
+++ b/tests/mcp/tools/deadcode.test.ts
@@ -1,0 +1,199 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { workerState } from "../../../src/mcp/shared/state";
+import { executeScanDeadCode } from "../../../src/mcp/tools/deadcode";
+
+describe("deadcode tools", () => {
+  let tempDir: string;
+
+  const makeSymbol = (name: string, kind = "FunctionDeclaration") => ({
+    id: `sym:${name}`,
+    name,
+    kind,
+    line: 1,
+    isExported: true,
+  });
+
+  const setupWorkerState = (spiderMock: any) => {
+    workerState.spider = spiderMock;
+    workerState.parser = {} as any;
+    workerState.resolver = {} as any;
+    workerState.config = {
+      rootDir: tempDir,
+      excludeNodeModules: false,
+      maxDepth: 3,
+    };
+    workerState.isReady = true;
+  };
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "gitl-deadcode-"));
+  });
+
+  afterEach(async () => {
+    workerState.reset();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("executeScanDeadCode", () => {
+    it("should return enriched dead code entries with correct counts", async () => {
+      const fileA = path.join(tempDir, "src", "utils.ts");
+      const fileB = path.join(tempDir, "src", "helpers.ts");
+
+      const spiderMock = {
+        scanDeadCode: vi.fn(async () => ({
+          entries: [
+            {
+              filePath: fileA,
+              unusedSymbols: [makeSymbol("unusedFn"), makeSymbol("UnusedClass", "ClassDeclaration")],
+            },
+            {
+              filePath: fileB,
+              unusedSymbols: [makeSymbol("orphanVar", "VariableDeclaration")],
+            },
+          ],
+          scannedFiles: 10,
+          skippedFiles: 1,
+        })),
+      };
+
+      setupWorkerState(spiderMock);
+
+      const result = await executeScanDeadCode({});
+
+      expect(spiderMock.scanDeadCode).toHaveBeenCalledWith(tempDir, { maxFiles: undefined });
+      expect(result.rootDir).toBe(tempDir);
+      expect(result.scopePath).toBe(tempDir);
+      expect(result.scannedFiles).toBe(10);
+      expect(result.skippedFiles).toBe(1);
+      expect(result.filesWithDeadCode).toBe(2);
+      expect(result.totalUnusedSymbols).toBe(3);
+      expect(result.entries).toHaveLength(2);
+      expect(result.analysisTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should categorize symbol kinds correctly", async () => {
+      const fileA = path.join(tempDir, "index.ts");
+
+      const spiderMock = {
+        scanDeadCode: vi.fn(async () => ({
+          entries: [
+            {
+              filePath: fileA,
+              unusedSymbols: [
+                makeSymbol("myFn", "FunctionDeclaration"),
+                makeSymbol("MyClass", "ClassDeclaration"),
+                makeSymbol("myVar", "VariableDeclaration"),
+                makeSymbol("MyInterface", "InterfaceDeclaration"),
+                makeSymbol("MyType", "TypeAliasDeclaration"),
+                makeSymbol("other", "EnumDeclaration"),
+              ],
+            },
+          ],
+          scannedFiles: 1,
+          skippedFiles: 0,
+        })),
+      };
+
+      setupWorkerState(spiderMock);
+
+      const result = await executeScanDeadCode({});
+      const symbols = result.entries[0].unusedSymbols;
+
+      expect(symbols.find((s) => s.name === "myFn")?.category).toBe("function");
+      expect(symbols.find((s) => s.name === "MyClass")?.category).toBe("class");
+      expect(symbols.find((s) => s.name === "myVar")?.category).toBe("variable");
+      expect(symbols.find((s) => s.name === "MyInterface")?.category).toBe("interface");
+      expect(symbols.find((s) => s.name === "MyType")?.category).toBe("type");
+      expect(symbols.find((s) => s.name === "other")?.category).toBe("other");
+    });
+
+    it("should use provided scopePath when given", async () => {
+      const subDir = path.join(tempDir, "src");
+      await fs.mkdir(subDir, { recursive: true });
+
+      const spiderMock = {
+        scanDeadCode: vi.fn(async () => ({
+          entries: [],
+          scannedFiles: 0,
+          skippedFiles: 0,
+        })),
+      };
+
+      setupWorkerState(spiderMock);
+
+      const result = await executeScanDeadCode({ scopePath: subDir });
+
+      expect(spiderMock.scanDeadCode).toHaveBeenCalledWith(subDir, { maxFiles: undefined });
+      expect(result.scopePath).toBe(subDir);
+      expect(result.filesWithDeadCode).toBe(0);
+      expect(result.totalUnusedSymbols).toBe(0);
+    });
+
+    it("should pass maxFiles option to spider", async () => {
+      const spiderMock = {
+        scanDeadCode: vi.fn(async () => ({
+          entries: [],
+          scannedFiles: 0,
+          skippedFiles: 0,
+        })),
+      };
+
+      setupWorkerState(spiderMock);
+
+      await executeScanDeadCode({ maxFiles: 100 });
+
+      expect(spiderMock.scanDeadCode).toHaveBeenCalledWith(tempDir, { maxFiles: 100 });
+    });
+
+    it("should include relative paths in entries", async () => {
+      const fileA = path.join(tempDir, "src", "utils.ts");
+
+      const spiderMock = {
+        scanDeadCode: vi.fn(async () => ({
+          entries: [{ filePath: fileA, unusedSymbols: [makeSymbol("unusedFn")] }],
+          scannedFiles: 1,
+          skippedFiles: 0,
+        })),
+      };
+
+      setupWorkerState(spiderMock);
+
+      const result = await executeScanDeadCode({});
+
+      expect(result.entries[0].relativePath).toBe("src/utils.ts");
+      expect(result.entries[0].unusedCount).toBe(1);
+    });
+
+    it("should throw when scopePath is outside rootDir", async () => {
+      const spiderMock = { scanDeadCode: vi.fn() };
+      setupWorkerState(spiderMock);
+
+      await expect(executeScanDeadCode({ scopePath: "/outside/workspace" })).rejects.toThrow(
+        "INVALID_SCOPE_PATH",
+      );
+      expect(spiderMock.scanDeadCode).not.toHaveBeenCalled();
+    });
+
+    it("should return empty result when no dead code found", async () => {
+      const spiderMock = {
+        scanDeadCode: vi.fn(async () => ({
+          entries: [],
+          scannedFiles: 42,
+          skippedFiles: 0,
+        })),
+      };
+
+      setupWorkerState(spiderMock);
+
+      const result = await executeScanDeadCode({});
+
+      expect(result.filesWithDeadCode).toBe(0);
+      expect(result.totalUnusedSymbols).toBe(0);
+      expect(result.scannedFiles).toBe(42);
+      expect(result.entries).toHaveLength(0);
+    });
+  });
+});

--- a/tests/vscode-e2e/suite/lmTools.test.ts
+++ b/tests/vscode-e2e/suite/lmTools.test.ts
@@ -1,7 +1,7 @@
 /**
  * E2E Tests for native Language Model Tools registration.
  *
- * Verifies that after extension activation all 20 Graph-It-Live LM tools
+ * Verifies that after extension activation all 21 Graph-It-Live LM tools
  * are present in `vscode.lm.tools`.  Tests are skipped gracefully when the
  * VS Code host doesn't support `vscode.lm.tools` (pre-1.90 or non-Copilot
  * environments) so they never cause false failures on older CI agents.
@@ -10,13 +10,14 @@
  *   - graph-it-live_resolve_module_path
  *   - graph-it-live_analyze_breaking_changes
  *   - graph-it-live_query_call_graph
+ *   - graph-it-live_scan_dead_code
  */
 
 import { before } from 'mocha';
 import * as assert from 'node:assert';
 import * as vscode from 'vscode';
 
-// Minimum set of expected tool names (all 20).
+// Minimum set of expected tool names (all 21).
 const EXPECTED_TOOLS = [
   'graph-it-live_find_referencing_files',
   'graph-it-live_analyze_dependencies',
@@ -39,6 +40,7 @@ const EXPECTED_TOOLS = [
   'graph-it-live_resolve_module_path',
   'graph-it-live_analyze_breaking_changes',
   'graph-it-live_query_call_graph',
+  'graph-it-live_scan_dead_code',
 ];
 
 /** Returns true when vscode.lm.tools is supported by the current host. */

--- a/tests/vscode-e2e/suite/lmTools.test.ts
+++ b/tests/vscode-e2e/suite/lmTools.test.ts
@@ -120,7 +120,7 @@ suite('LM Tools Registration Test Suite', () => {
     assert.ok(tool, 'graph-it-live_query_call_graph should be registered');
   });
 
-  test('Total Graph-It-Live tool count is exactly 20', function () {
+  test('Total Graph-It-Live tool count is exactly 21', function () {
     if (!lmToolsSupported()) {
       this.skip();
     }
@@ -129,8 +129,8 @@ suite('LM Tools Registration Test Suite', () => {
     const graphItLiveTools = tools.filter((t) => t.name.startsWith('graph-it-live_'));
     assert.strictEqual(
       graphItLiveTools.length,
-      20,
-      `Expected 20 graph-it-live tools, found ${graphItLiveTools.length}: ${graphItLiveTools.map((t) => t.name).join(', ')}`,
+      21,
+      `Expected 21 graph-it-live tools, found ${graphItLiveTools.length}: ${graphItLiveTools.map((t) => t.name).join(', ')}`,
     );
   });
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
Introduce a new dead code scanning tool that validates scope paths to prevent path traversal attacks. The tool scans for unused exported symbols and integrates with the CLI. Enhance type definitions, add benchmarks, and update tests to ensure functionality and performance. Remove unnecessary files from package.json and update dependencies.