### PR TITLE
feat(repl): add contextual tips and recent files tracking

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v1.9.2
+
+### Features
+
+- **Interactive CLI REPL entry path**: Running `graph-it` with no arguments in a TTY now enters an interactive REPL flow.
+
+### Enhancements
+
+- **REPL guidance and interaction improvements**:
+  - Added contextual tips and persona tips in interactive flows
+  - Improved slash-command command-palette UX
+  - Added contextual follow-up prompts after command results
+- **Session state enrichment**:
+  - Added `recentFiles` (up to 5 entries)
+  - Added `tipCounter`
+- **Prompt/browser context improvements**:
+  - Added a recent files section in prompt/browser UI
+  - Added `/file` command context support
+
+### Bug Fixes
+
+- **SpiderSymbolService default option handling**: `excludeNodeModules` now defaults to `true` when the option is `undefined`.
+
+### Maintenance
+
+- **Dependency update**: Added runtime dependency `@inquirer/core`.
+- **Typecheck workflow cleanup**: `check:types` now runs the clean path (`check:types:clean`) to avoid stale `out` artifacts.
+- **TypeScript references cleanup**: Removed the `test.node` reference from project tsconfig references.
+
 ## v1.9.1
 
 ### Features

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -11,6 +11,7 @@ The `graph-it` CLI gives you full access to the dependency analysis engine of Gr
 - [Global Options](#global-options)
 - [Output Formats](#output-formats)
 - [Commands](#commands)
+  - [graph-it (no arguments)](#graph-it-no-arguments)
   - [scan](#scan)
   - [summary](#summary)
   - [explain](#explain)
@@ -145,6 +146,76 @@ graph-it summary --format toon                    # → feed to an LLM
 ---
 
 ## Commands
+
+### graph-it (no arguments)
+
+Launches interactive mode when invoked without a command in a TTY session.
+
+```
+graph-it [options]
+```
+
+**Behavior:**
+
+- If `stdin` is a TTY, starts the interactive REPL.
+- If `stdin` is not a TTY, interactive mode is not started. Use direct commands such as `graph-it summary`, `graph-it trace`, or `graph-it check`.
+- REPL session default output format is `text` unless changed with `/format`.
+
+#### REPL slash commands
+
+| Command | Description |
+|--------|-------------|
+| `/trace` | Run trace flow for a selected file and optional symbol |
+| `/path` | Set session workspace scope (directory) |
+| `/file` | Set active file context for context-aware commands |
+| `/check-dependencies` | Check incoming and outgoing dependencies |
+| `/cycles` | List confirmed dependency cycles for a file |
+| `/summary` | Summarize current file context or workspace |
+| `/architecture` | Build workspace architecture graph |
+| `/check` | Find unused exports |
+| `/format` | Set preferred output format for the session |
+| `/command` | Run a raw CLI command line inside REPL |
+| `/help` | Show REPL command help |
+| `/quit` | Exit interactive mode |
+
+#### Post-result actions
+
+After each result, the REPL supports contextual actions:
+
+- drill-down into current file/symbol context
+- export current structured result in another format
+- save current output to file
+- set default session format
+- run context-aware follow-up actions (for example dependency, cycle, trace, dead-code, or architecture follow-ups)
+
+#### Session state
+
+REPL session state is in-memory for the current invocation and tracks:
+
+- `workspaceRoot`
+- `lastFile`
+- `lastSymbol`
+- `lastResult`
+- `lastCommandLine`
+- `preferredFormat`
+- `recentFiles` (max 5, newest first)
+- `tipCounter`
+
+#### Tips
+
+The REPL tip system includes:
+
+- general rotating tips
+- command-step tips (for example trace/check-dependencies/cycles/result steps)
+- persona-tagged tips (role-oriented hints)
+
+#### Save path safety
+
+When saving from REPL:
+
+- writes are restricted to paths inside the workspace root
+- path checks are enforced using resolved/real paths
+- symlink targets are refused for overwrite
 
 ### scan
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Graph-It-Live Documentation
 
-**Last Updated:** 2026-04-24
+**Last Updated:** 2026-05-09
 
 This directory is the single source of truth for technical documentation. It is organized into three sections.
 
@@ -33,7 +33,7 @@ Standards and guidelines for contributors.
 
 | File | Description |
 |------|-------------|
-| [CLI.md](CLI.md) | **CLI reference** — all commands, options, output formats, tools, and advanced workflows |
+| [CLI.md](CLI.md) | **CLI + interactive REPL reference** — commands, options, output formats, tools, and interactive workflows |
 | [development/CODING_STANDARDS.md](development/CODING_STANDARDS.md) | TypeScript conventions, layer rules, React patterns |
 | [development/CROSS_PLATFORM_TESTING.md](development/CROSS_PLATFORM_TESTING.md) | Cross-platform path handling and test guidelines |
 | [development/ADR-001-package-manager-choice.md](development/ADR-001-package-manager-choice.md) | ADR: npm vs Yarn decision |

--- a/docs/superpowers/plans/2026-04-30-cli-repl.md
+++ b/docs/superpowers/plans/2026-04-30-cli-repl.md
@@ -1,0 +1,792 @@
+# CLI REPL Guidé — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a guided interactive REPL to `graph-it` that launches when no command is given in a TTY, orchestrating existing commands via `@inquirer/prompts`.
+
+**Architecture:** New `src/cli/repl/` sub-package (`sessionState`, `fileSearch`, `prompts`) plus `src/cli/commands/repl.ts` main loop. `src/cli/index.ts` gains a TTY check that routes the no-arg case to the REPL; all other invocations are unchanged.
+
+**Tech Stack:** `@inquirer/prompts` (select, search, confirm), `SourceFileCollector` from `src/analyzer/SourceFileCollector.ts`, Vitest for unit tests, esbuild (no changes needed — bundles `@inquirer/prompts` automatically as CJS).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `package.json` | Modify | Add `@inquirer/prompts` runtime dependency |
+| `src/cli/repl/sessionState.ts` | Create | In-memory session (workspaceRoot, lastFile, lastResult, preferredFormat) |
+| `src/cli/repl/fileSearch.ts` | Create | Substring filter on workspace file paths |
+| `src/cli/repl/prompts.ts` | Create | All `@inquirer/prompts` calls (select, search, confirm) centralised |
+| `src/cli/commands/repl.ts` | Create | Main REPL loop; delegates to existing command runners |
+| `src/cli/index.ts` | Modify | Route no-arg + TTY invocations to the REPL |
+| `tests/cli/repl.test.ts` | Create | Unit tests for `sessionState.ts` and `fileSearch.ts` |
+
+---
+
+## Task 1: Install @inquirer/prompts
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install the dependency**
+
+```bash
+cd /path/to/Graph-It-Live
+npm install @inquirer/prompts
+```
+
+Expected: `@inquirer/prompts` appears in `package.json` `dependencies`, `package-lock.json` updated, no errors.
+
+- [ ] **Step 2: Verify it can be imported in a Node.js context**
+
+```bash
+node -e "import('@inquirer/prompts').then(m => console.log(Object.keys(m).join(', ')))"
+```
+
+Expected: prints something like `input, select, confirm, search, ...`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add @inquirer/prompts dependency for REPL"
+```
+
+---
+
+## Task 2: Session State — TDD
+
+**Files:**
+- Create: `src/cli/repl/sessionState.ts`
+- Create: `tests/cli/repl.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/cli/repl.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import {
+  createSessionState,
+  type SessionState,
+} from '../../src/cli/repl/sessionState.js';
+
+describe('createSessionState', () => {
+  it('sets workspaceRoot from argument', () => {
+    const state = createSessionState('/home/user/project');
+    expect(state.workspaceRoot).toBe('/home/user/project');
+  });
+
+  it('defaults preferredFormat to text', () => {
+    const state = createSessionState('/tmp/ws');
+    expect(state.preferredFormat).toBe('text');
+  });
+
+  it('has no lastFile or lastResult initially', () => {
+    const state = createSessionState('/tmp/ws');
+    expect(state.lastFile).toBeUndefined();
+    expect(state.lastResult).toBeUndefined();
+  });
+
+  it('allows mutating lastFile on the returned object', () => {
+    const state: SessionState = createSessionState('/tmp/ws');
+    state.lastFile = '/tmp/ws/src/index.ts';
+    expect(state.lastFile).toBe('/tmp/ws/src/index.ts');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npx vitest run tests/cli/repl.test.ts
+```
+
+Expected: FAIL with "Cannot find module '../../src/cli/repl/sessionState.js'"
+
+- [ ] **Step 3: Create `src/cli/repl/sessionState.ts`**
+
+```typescript
+/**
+ * REPL Session State
+ *
+ * In-memory context shared across the REPL loop for a single invocation.
+ * No persistence — state lives only for the duration of the REPL session.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import type { CliOutputFormat } from '../formatter.js';
+
+export interface SessionState {
+  workspaceRoot: string;
+  lastFile?: string;
+  lastResult?: unknown;
+  preferredFormat: CliOutputFormat;
+}
+
+/**
+ * Create a fresh session state for the given workspace root.
+ */
+export function createSessionState(workspaceRoot: string): SessionState {
+  return {
+    workspaceRoot,
+    preferredFormat: 'text',
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npx vitest run tests/cli/repl.test.ts
+```
+
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/repl/sessionState.ts tests/cli/repl.test.ts
+git commit -m "feat(repl): add sessionState with tests"
+```
+
+---
+
+## Task 3: File Search — TDD
+
+**Files:**
+- Create: `src/cli/repl/fileSearch.ts`
+- Modify: `tests/cli/repl.test.ts`
+
+- [ ] **Step 1: Add failing tests for fileSearch**
+
+Append to `tests/cli/repl.test.ts`:
+
+```typescript
+import { filterFiles } from '../../src/cli/repl/fileSearch.js';
+
+describe('filterFiles', () => {
+  const workspaceRoot = '/home/user/project';
+  const files = [
+    '/home/user/project/src/index.ts',
+    '/home/user/project/src/utils/helpers.ts',
+    '/home/user/project/src/cli/commands/scan.ts',
+    '/home/user/project/tests/cli/repl.test.ts',
+  ];
+
+  it('returns all files when query is empty', () => {
+    const result = filterFiles(files, '', workspaceRoot);
+    expect(result).toHaveLength(4);
+  });
+
+  it('filters by substring (case-insensitive)', () => {
+    const result = filterFiles(files, 'cli', workspaceRoot);
+    expect(result).toContain('src/cli/commands/scan.ts');
+    expect(result).toContain('tests/cli/repl.test.ts');
+    expect(result).not.toContain('src/index.ts');
+  });
+
+  it('returns relative paths (not absolute)', () => {
+    const result = filterFiles(files, 'index', workspaceRoot);
+    expect(result).toContain('src/index.ts');
+    expect(result.every(r => !r.startsWith('/'))).toBe(true);
+  });
+
+  it('returns results sorted alphabetically', () => {
+    const result = filterFiles(files, '', workspaceRoot);
+    const sorted = [...result].sort();
+    expect(result).toEqual(sorted);
+  });
+
+  it('returns empty array when nothing matches', () => {
+    const result = filterFiles(files, 'zzznomatch', workspaceRoot);
+    expect(result).toHaveLength(0);
+  });
+
+  it('matches against uppercase input', () => {
+    const result = filterFiles(files, 'INDEX', workspaceRoot);
+    expect(result).toContain('src/index.ts');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run tests/cli/repl.test.ts
+```
+
+Expected: 4 passing (sessionState), 6 failing (Cannot find module fileSearch)
+
+- [ ] **Step 3: Create `src/cli/repl/fileSearch.ts`**
+
+```typescript
+/**
+ * REPL File Search
+ *
+ * Filters a list of absolute file paths by a case-insensitive substring query.
+ * Returns relative paths sorted alphabetically.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import * as path from 'node:path';
+
+/**
+ * Filter `files` (absolute paths) by `query` substring against relative paths.
+ *
+ * @param files - Absolute file paths from SourceFileCollector
+ * @param query - User-typed string (case-insensitive)
+ * @param workspaceRoot - Workspace root for computing relative paths
+ * @returns Sorted array of relative paths that match `query`
+ */
+export function filterFiles(
+  files: string[],
+  query: string,
+  workspaceRoot: string,
+): string[] {
+  const q = query.toLowerCase();
+  const matches = files
+    .map((f) => path.relative(workspaceRoot, f))
+    .filter((rel) => rel.toLowerCase().includes(q));
+  matches.sort();
+  return matches;
+}
+```
+
+- [ ] **Step 4: Run tests to verify all pass**
+
+```bash
+npx vitest run tests/cli/repl.test.ts
+```
+
+Expected: PASS (10 tests — 4 sessionState + 6 fileSearch)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/repl/fileSearch.ts tests/cli/repl.test.ts
+git commit -m "feat(repl): add fileSearch with tests"
+```
+
+---
+
+## Task 4: Create prompts.ts
+
+**Files:**
+- Create: `src/cli/repl/prompts.ts`
+
+No unit tests for this module — `@inquirer/prompts` interactive APIs require a real TTY and are tested via the REPL integration. The underlying command runners have their own tests.
+
+- [ ] **Step 1: Create `src/cli/repl/prompts.ts`**
+
+```typescript
+/**
+ * REPL Prompts
+ *
+ * All @inquirer/prompts questions used by the REPL, centralised here
+ * so each can be updated independently from the REPL loop.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import { confirm, input, search, select } from '@inquirer/prompts';
+import { filterFiles } from './fileSearch.js';
+
+// ============================================================================
+// Action types
+// ============================================================================
+
+export type MainAction = 'trace' | 'path' | 'check' | 'summary' | 'quit';
+export type PostResultAction = 'drillDown' | 'export' | 'newAnalysis' | 'quit';
+export type ExportFormat = 'json' | 'markdown' | 'mermaid';
+
+// ============================================================================
+// Prompts
+// ============================================================================
+
+/** Main menu: what would you like to do? */
+export async function selectMainAction(): Promise<MainAction> {
+  return select<MainAction>({
+    message: 'Que voulez-vous faire ?',
+    choices: [
+      { name: 'Analyser un fichier ou symbole', value: 'trace' },
+      { name: "Cartographier les dépendances d'un fichier", value: 'path' },
+      { name: 'Trouver du code mort', value: 'check' },
+      { name: 'Résumé du workspace', value: 'summary' },
+      { name: 'Quitter', value: 'quit' },
+    ],
+  });
+}
+
+/**
+ * File fuzzy-search: type to filter, pick from live list.
+ *
+ * @param allFiles - Absolute paths from SourceFileCollector
+ * @param workspaceRoot - Root for computing relative display paths
+ */
+export async function searchFile(
+  allFiles: string[],
+  workspaceRoot: string,
+): Promise<string> {
+  return search<string>({
+    message: 'Rechercher un fichier',
+    source: async (input) => {
+      const matches = filterFiles(allFiles, input ?? '', workspaceRoot);
+      return matches.slice(0, 20).map((rel) => ({ name: rel, value: rel }));
+    },
+  });
+}
+
+/**
+ * Optional symbol input after file selection.
+ * Empty answer means "analyse the whole file".
+ *
+ * @param displayPath - Relative path shown in the prompt label
+ */
+export async function inputSymbol(displayPath: string): Promise<string> {
+  return input({
+    message: `Symbole à analyser dans ${displayPath} (laisser vide = tout le fichier)`,
+    default: '',
+  });
+}
+
+/** Post-result menu. */
+export async function selectPostResultAction(): Promise<PostResultAction> {
+  return select<PostResultAction>({
+    message: 'Que faire ensuite ?',
+    choices: [
+      { name: 'Explorer un nœud de ce graphe', value: 'drillDown' },
+      { name: 'Exporter (json / markdown / mermaid)', value: 'export' },
+      { name: 'Nouvelle analyse', value: 'newAnalysis' },
+      { name: 'Quitter', value: 'quit' },
+    ],
+  });
+}
+
+/** Export format selector. */
+export async function selectExportFormat(): Promise<ExportFormat> {
+  return select<ExportFormat>({
+    message: "Format d'export",
+    choices: [
+      { name: 'JSON', value: 'json' },
+      { name: 'Markdown', value: 'markdown' },
+      { name: 'Mermaid', value: 'mermaid' },
+    ],
+  });
+}
+
+/** Offer to re-index when the workspace has no index yet. */
+export async function confirmScan(reason: string): Promise<boolean> {
+  return confirm({ message: `${reason} Scanner maintenant ?`, default: true });
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors related to `src/cli/repl/prompts.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/repl/prompts.ts
+git commit -m "feat(repl): add prompts module"
+```
+
+---
+
+## Task 5: Create commands/repl.ts — Main REPL Loop
+
+**Files:**
+- Create: `src/cli/commands/repl.ts`
+
+- [ ] **Step 1: Create `src/cli/commands/repl.ts`**
+
+```typescript
+/**
+ * CLI Command: repl
+ *
+ * Guided interactive REPL. Launched when `graph-it` is invoked with no
+ * arguments in a TTY context. Orchestrates existing CLI commands without
+ * re-implementing analysis logic.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import * as path from 'node:path';
+import { ExitPromptError } from '@inquirer/prompts';
+import { SourceFileCollector } from '../../analyzer/SourceFileCollector.js';
+import { formatOutput } from '../formatter.js';
+import type { CliRuntime } from '../runtime.js';
+import {
+  confirmScan,
+  inputSymbol,
+  searchFile,
+  selectExportFormat,
+  selectMainAction,
+  selectPostResultAction,
+} from '../repl/prompts.js';
+import { createSessionState } from '../repl/sessionState.js';
+
+const NON_TTY_MESSAGE =
+  'Mode interactif non disponible (pas de TTY).\n' +
+  'Utilise les commandes directes : graph-it --help\n';
+
+/**
+ * Entry point for the REPL.
+ *
+ * `runtime` is already constructed but NOT yet `init()`ed — this function
+ * handles init itself so it can offer a guided scan on first use.
+ */
+export async function run(runtime: CliRuntime): Promise<void> {
+  if (!process.stdin.isTTY) {
+    process.stdout.write(NON_TTY_MESSAGE);
+    return;
+  }
+
+  // ── Initialise workspace ────────────────────────────────────────────────
+  try {
+    await runtime.init();
+  } catch {
+    process.stderr.write('Workspace introuvable ou inaccessible.\n');
+    return;
+  }
+
+  // ── Lazy index: offer to scan if not yet indexed ─────────────────────────
+  try {
+    await runtime.ensureIndexed();
+  } catch {
+    const doScan = await confirmScan('L\'index est absent ou périmé.').catch(() => false);
+    if (!doScan) {
+      process.stdout.write('Au revoir !\n');
+      return;
+    }
+    try {
+      await runtime.ensureIndexed();
+    } catch (err) {
+      process.stderr.write(
+        `Erreur lors du scan : ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return;
+    }
+  }
+
+  // ── Collect all source files for fuzzy search ────────────────────────────
+  const collector = new SourceFileCollector({ excludeNodeModules: true });
+  const allFiles = await collector.collectAllSourceFiles(runtime.workspaceRoot);
+
+  const state = createSessionState(runtime.workspaceRoot);
+
+  process.stdout.write('\n  Graph-It-Live — mode interactif  (Ctrl+C pour quitter)\n\n');
+
+  // ── Main loop ────────────────────────────────────────────────────────────
+  let quit = false;
+  while (!quit) {
+    let action: Awaited<ReturnType<typeof selectMainAction>>;
+    try {
+      action = await selectMainAction();
+    } catch (err) {
+      if (err instanceof ExitPromptError) break; // Ctrl+C at main menu → exit
+      process.stderr.write(`Erreur inattendue : ${err instanceof Error ? err.message : String(err)}\n`);
+      break;
+    }
+
+    if (action === 'quit') break;
+
+    try {
+      const output = await runAction(action, runtime, state, allFiles);
+
+      if (output) {
+        state.lastResult = output;
+        process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
+      }
+
+      // ── Post-result menu ─────────────────────────────────────────────────
+      let postAction: Awaited<ReturnType<typeof selectPostResultAction>>;
+      try {
+        postAction = await selectPostResultAction();
+      } catch (err) {
+        if (err instanceof ExitPromptError) { quit = true; break; }
+        throw err;
+      }
+
+      if (postAction === 'quit') {
+        quit = true;
+      } else if (postAction === 'export' && output) {
+        await handleExport(output, action);
+      } else if (postAction === 'drillDown' && state.lastFile) {
+        await handleDrillDown(state.lastFile, runtime, state, allFiles);
+      }
+      // 'newAnalysis' → loop continues naturally
+
+    } catch (err) {
+      if (err instanceof ExitPromptError) { quit = true; break; }
+      process.stderr.write(
+        `Erreur : ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      // Continue loop — non-fatal
+    }
+  }
+
+  process.stdout.write('\nAu revoir !\n');
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+async function runAction(
+  action: 'trace' | 'path' | 'check' | 'summary',
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  allFiles: string[],
+): Promise<string | undefined> {
+  if (action === 'summary') {
+    const { run } = await import('./summary.js');
+    return run([], runtime, state.preferredFormat);
+  }
+
+  if (action === 'check') {
+    const { run } = await import('./check.js');
+    return run([], runtime, state.preferredFormat);
+  }
+
+  // 'trace' and 'path' both need a file picker
+  const rel = await searchFile(allFiles, runtime.workspaceRoot);
+  const absoluteFile = path.join(runtime.workspaceRoot, rel);
+  state.lastFile = absoluteFile;
+
+  if (action === 'path') {
+    const { run } = await import('./path.js');
+    return run([absoluteFile], runtime, state.preferredFormat);
+  }
+
+  // 'trace' — optionally pick a symbol
+  const symbolName = await inputSymbol(rel);
+  if (symbolName.trim()) {
+    const { run } = await import('./trace.js');
+    return run([`${absoluteFile}#${symbolName.trim()}`], runtime, state.preferredFormat);
+  }
+
+  // No symbol entered → explain (intra-file analysis)
+  const { run } = await import('./explain.js');
+  return run([absoluteFile], runtime, state.preferredFormat);
+}
+
+async function handleExport(output: string, command: string): Promise<void> {
+  try {
+    const fmt = await selectExportFormat();
+    const data: unknown = (() => {
+      try { return JSON.parse(output); } catch { return output; }
+    })();
+    const exported = formatOutput(data, fmt, command);
+    process.stdout.write(exported.endsWith('\n') ? exported : `${exported}\n`);
+  } catch (err) {
+    if (err instanceof ExitPromptError) return;
+    process.stderr.write(
+      `Erreur d'export : ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+async function handleDrillDown(
+  filePath: string,
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  allFiles: string[],
+): Promise<void> {
+  // Re-run trace/explain on the same file, optionally picking a different symbol
+  const rel = path.relative(runtime.workspaceRoot, filePath);
+  const symbolName = await inputSymbol(rel).catch(() => '');
+  try {
+    if (symbolName.trim()) {
+      const { run } = await import('./trace.js');
+      const output = await run(
+        [`${filePath}#${symbolName.trim()}`],
+        runtime,
+        state.preferredFormat,
+      );
+      state.lastResult = output;
+      process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
+    } else {
+      const { run } = await import('./explain.js');
+      const output = await run([filePath], runtime, state.preferredFormat);
+      state.lastResult = output;
+      process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
+    }
+  } catch (err) {
+    if (!(err instanceof ExitPromptError)) {
+      process.stderr.write(
+        `Erreur : ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors in `src/cli/commands/repl.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/cli/commands/repl.ts
+git commit -m "feat(repl): add main REPL loop"
+```
+
+---
+
+## Task 6: Wire REPL into index.ts
+
+**Files:**
+- Modify: `src/cli/index.ts`
+
+The current `if (!command)` branch unconditionally prints help and exits. We change it to route to the REPL when `process.stdin.isTTY` is true. The `runtime` is already constructed at that point.
+
+- [ ] **Step 1: Locate the exact lines to change**
+
+In `src/cli/index.ts`, find the block:
+
+```typescript
+  if (!command) {
+    process.stdout.write(HELP);
+    process.exit(ExitCode.SUCCESS);
+  }
+```
+
+- [ ] **Step 2: Replace that block**
+
+Replace:
+
+```typescript
+  if (!command) {
+    process.stdout.write(HELP);
+    process.exit(ExitCode.SUCCESS);
+  }
+```
+
+With:
+
+```typescript
+  if (!command) {
+    if (process.stdin.isTTY) {
+      const { run } = await import('./commands/repl.js');
+      await run(runtime);
+      await runtime.dispose().catch(() => {/* best-effort */});
+      process.exit(ExitCode.SUCCESS);
+    }
+    process.stdout.write(HELP);
+    process.exit(ExitCode.SUCCESS);
+  }
+```
+
+> Note: the existing `finally { await runtime.dispose() }` only runs for commands that reach the `dispatch()` call. Because we `process.exit()` before reaching the `try` block's `dispatch`, we call `runtime.dispose()` explicitly here.
+
+- [ ] **Step 3: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Run existing CLI tests to confirm no regression**
+
+```bash
+npx vitest run tests/cli/
+```
+
+Expected: all existing CLI tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli/index.ts
+git commit -m "feat(repl): route no-arg TTY invocations to REPL"
+```
+
+---
+
+## Task 7: Build and Smoke Test
+
+**Files:** (none changed — verification only)
+
+- [ ] **Step 1: Build the CLI bundle**
+
+```bash
+npm run build -- --cli-only
+```
+
+Expected: `dist/graph-it.js` rebuilt, no esbuild errors.
+
+- [ ] **Step 2: Run full unit test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass (including the 10 new tests in `tests/cli/repl.test.ts`).
+
+- [ ] **Step 3: Smoke-test the non-TTY guard (pipe)**
+
+```bash
+echo "" | node dist/graph-it.js
+```
+
+Expected output:
+```
+Mode interactif non disponible (pas de TTY).
+Utilise les commandes directes : graph-it --help
+```
+
+Exit code: 0
+
+- [ ] **Step 4: Smoke-test that existing commands are unaffected**
+
+```bash
+node dist/graph-it.js --help
+node dist/graph-it.js scan --help
+```
+
+Expected: normal help text, no REPL interaction.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: verify REPL build and smoke tests"
+```
+
+---
+
+## Self-Review Checklist (reference only — already applied)
+
+| Spec requirement | Task |
+|-----------------|------|
+| No-arg + TTY → REPL | Task 6 |
+| Non-TTY guard + message | Task 5 (guard in `run()`) |
+| Fuzzy file search | Task 3 + 4 |
+| Session state (workspaceRoot, lastFile, lastResult, preferredFormat) | Task 2 |
+| Analyse fichier → trace + explain fallback | Task 5 |
+| Cartographier dépendances → path | Task 5 |
+| Code mort → check | Task 5 |
+| Résumé workspace → summary | Task 5 |
+| Post-result: drillDown / export / newAnalysis / quit | Task 5 |
+| Export: json / markdown / mermaid | Task 5 |
+| Ctrl+C at main menu → quit | Task 5 (ExitPromptError) |
+| Ctrl+C during prompt → back to menu | Task 5 (caught per-prompt) |
+| Index absent → offer to scan | Task 5 |
+| Workspace introuvable → message + return | Task 5 |
+| Unit tests for sessionState + fileSearch | Tasks 2–3 |
+| @inquirer/prompts only new dep | Task 1 |

--- a/docs/superpowers/specs/2026-04-30-cli-repl-design.md
+++ b/docs/superpowers/specs/2026-04-30-cli-repl-design.md
@@ -124,7 +124,7 @@ Le REPL intercepte les erreurs au lieu de terminer le process :
 
 ### Non-TTY / CI
 
-Si `process.stdin.isTTY === false`, le REPL refuse de démarrer et affiche :
+Si `!process.stdin.isTTY` (valeur `false` ou `undefined`), le REPL refuse de démarrer et affiche :
 ```
 Mode interactif non disponible (pas de TTY).
 Utilise les commandes directes : graph-it --help

--- a/docs/superpowers/specs/2026-04-30-cli-repl-design.md
+++ b/docs/superpowers/specs/2026-04-30-cli-repl-design.md
@@ -1,0 +1,163 @@
+# CLI REPL Guidé — Design Spec
+
+**Date:** 2026-04-30  
+**Statut:** Approuvé  
+**Scope:** Phase 1 MVP — mode interactif pour `graph-it`
+
+---
+
+## Contexte et motivation
+
+Le CLI `graph-it` compte ~659 téléchargements/mois sur npm, ce qui témoigne d'une audience réelle qui choisit le CLI plutôt que l'extension VS Code. Cette audience souffre de trois frictions :
+
+1. **Découverte** — l'utilisateur ne sait pas quelle commande utiliser ni comment formuler son analyse
+2. **Navigation dans les résultats** — les outputs en texte brut sont difficiles à explorer
+3. **Enchaînement** — plusieurs commandes successives pour une analyse complète, sans contexte partagé
+
+La solution retenue est un **REPL guidé** (`graph-it` sans argument) qui orchestre les commandes existantes via une interface de prompts interactifs, sans réimplémenter la logique d'analyse.
+
+---
+
+## Approche retenue
+
+**REPL guidé avec `@inquirer/prompts`** — façade interactive sur les commandes existantes.
+
+Deux autres approches ont été évaluées et écartées :
+- **UI locale navigateur** (`graph-it ui`) : plus riche mais 3-4 semaines d'effort ; validé comme Phase 2 une fois l'audience CLI confirmée
+- **TUI (Terminal UI)** avec `blessed`/`ink` : les graphes de dépendances sont visuels par nature, les forcer en ASCII plafonne l'UX rapidement
+
+---
+
+## Architecture
+
+### Nouveaux fichiers
+
+```
+src/cli/
+├── commands/repl.ts        ← point d'entrée du mode interactif, boucle principale
+├── repl/
+│   ├── prompts.ts          ← toutes les questions @inquirer/prompts
+│   ├── fileSearch.ts       ← fuzzy search sur les fichiers du workspace
+│   └── sessionState.ts     ← contexte de session (fichier courant, historique)
+```
+
+### Déclenchement
+
+Dans `src/cli/index.ts` : si `process.argv.length === 2` (aucun argument) **et** `process.stdin.isTTY === true`, router vers `commands/repl.ts`. Comportement inchangé pour toutes les commandes existantes.
+
+```bash
+graph-it            # → lance le REPL
+graph-it scan       # → mode non-interactif (inchangé)
+graph-it --help     # → aide (inchangée)
+```
+
+### Dépendance ajoutée
+
+`@inquirer/prompts` uniquement — ~40KB, zéro dépendance transitive, maintenu par l'équipe npm, support Windows natif.
+
+---
+
+## Flux UX
+
+```
+graph-it (sans arg, TTY)
+  └─ Menu principal
+       ├─ Analyser un fichier ou symbole
+       │    ├─ Fuzzy search fichier (Spider.getAllFiles())
+       │    ├─ Sélection symbole optionnelle (filtrée)
+       │    └─ → runTrace() → affichage résultat
+       ├─ Cartographier les dépendances d'un fichier
+       │    ├─ Fuzzy search fichier
+       │    └─ → runPath() → affichage résultat
+       ├─ Trouver du code mort
+       │    └─ → runCheck() → affichage résultat
+       ├─ Résumé du workspace
+       │    └─ → runSummary() → affichage résultat
+       └─ Quitter
+
+  Après chaque résultat :
+       ├─ Explorer un nœud de ce graphe  (re-appelle trace avec un symbole du résultat)
+       ├─ Exporter  (json / markdown / mermaid)
+       ├─ Nouvelle analyse  (retour menu principal)
+       └─ Quitter
+```
+
+---
+
+## Composants
+
+### `commands/repl.ts`
+Boucle principale `while (!quit)`. Appelle `prompts.ts` pour obtenir l'intention de l'utilisateur, puis délègue aux fonctions des commandes existantes. Capture toutes les erreurs et les présente inline au lieu de `process.exit()`.
+
+### `repl/sessionState.ts`
+Objet en mémoire (pas de persistence disque) :
+```typescript
+interface SessionState {
+  workspaceRoot: string;
+  lastFile?: string;
+  lastResult?: AnalysisResult;
+  preferredFormat: OutputFormat;  // défaut: 'text'
+}
+```
+Évite de re-saisir le workspace et le fichier courant à chaque étape.
+
+### `repl/fileSearch.ts`
+Fuzzy search sur la liste de fichiers retournée par `Spider.getAllFiles()`. Filtre en temps réel pendant la saisie via `@inquirer/prompts` autocomplete. Utilise une correspondance simple par sous-chaîne sur le chemin relatif (pas de dépendance fuzzy externe).
+
+### `repl/prompts.ts`
+Toutes les questions inquirer centralisées. Séparées de la logique REPL pour faciliter les tests et l'évolution indépendante.
+
+---
+
+## Gestion des erreurs
+
+Le REPL intercepte les erreurs au lieu de terminer le process :
+
+| Situation | Comportement REPL |
+|---|---|
+| Workspace introuvable | "Aucun workspace détecté. Scanner maintenant ? (o/n)" |
+| Index absent ou périmé | "L'index est vieux ou absent. Scanner maintenant ? (o/n)" |
+| Symbole ambigu | Liste de choix proposée directement dans le prompt de sélection |
+| Erreur d'analyse | Message d'erreur + "Retour au menu" |
+| `Ctrl+C` au menu principal | Quitte proprement |
+| `Ctrl+C` pendant un prompt | Retour au menu (pas de quit) |
+
+### Non-TTY / CI
+
+Si `process.stdin.isTTY === false`, le REPL refuse de démarrer et affiche :
+```
+Mode interactif non disponible (pas de TTY).
+Utilise les commandes directes : graph-it --help
+```
+Le comportement CLI classique reste intact pour les scripts, pipes, et CI.
+
+---
+
+## Tests
+
+Aucune nouvelle infrastructure — Vitest est déjà en place.
+
+**Ajouts dans `tests/cli/` :**
+- `repl.test.ts` — tests unitaires de `sessionState.ts` (state management) et `fileSearch.ts` (logique de filtrage)
+- Les prompts inquirer ne sont pas testés unitairement (difficile à mocker proprement) ; les commandes sous-jacentes ont leurs propres tests
+- Tests E2E via `test-cli-e2e.sh` si nécessaire pour le flux complet
+
+---
+
+## Périmètre explicitement hors scope (Phase 1)
+
+- Persistence de l'historique de session entre exécutions
+- Coloration syntaxique des outputs (chalk ou similaire)
+- Mode `graph-it ui` avec navigateur local (Phase 2)
+- Configuration du format par défaut dans `.graph-it/config`
+
+---
+
+## Chemin vers la Phase 2
+
+Le REPL valide les use cases et l'appétit utilisateur. Si les signaux sont positifs (issues, feedback, adoption), la Phase 2 (`graph-it ui`) réutilise :
+- Le protocole de messages déjà typé (`src/shared/messages.ts`)
+- Les composants React/ReactFlow/Cytoscape existants
+- Les guards `typeof acquireVsCodeApi === "function"` déjà en place dans le webview
+
+Effort estimé Phase 2 : 3-4 semaines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5026,12 +5026,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5132,9 +5132,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -5630,9 +5630,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5829,9 +5829,9 @@
       "optional": true
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
+        "@inquirer/prompts": "^8.4.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chokidar": "^5.0.0",
         "cytoscape": "^3.33.2",
@@ -1003,6 +1004,359 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.4.tgz",
+      "integrity": "sha512-w6KF8ZYRvqHhROkOTHXYC3qIV/KYEu5o12oLqQySvch61vrYtRxNSHTONSdJqWiFJPlCUQAHT5OgOIyuTr+MHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.1.1.tgz",
+      "integrity": "sha512-6y11LgmNpmn5D2aB5FgnCfBUBK8ZstwLCalyJmORcJZ/WrhOjm16mu6eSqIx8DnErxDqSLr+Jkp+GP8/Nwd5tA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/external-editor": "^3.0.0",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.13.tgz",
+      "integrity": "sha512-dF2zvrFo9LshkcB23/O1il13kBkBltWIXzut1evfbuBLXMiGIuC45c+ZQ0uukjCDsvI8OWqun4FRYMnzFCQa3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.0.tgz",
+      "integrity": "sha512-lDSwMgg+M5rq6JKBYaJwSX6T9e/HK2qqZ1oxmOwn4AQoJE5D+7TumsxLGC02PWS//rkIVqbZv3XA3ejsc9FYvg==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.1",
+        "iconv-lite": "^0.7.2"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.12.tgz",
+      "integrity": "sha512-uiMFBl4LqFzJClh80Q3f9hbOFJ6kgkDWI4LjAeBuyO6EanVVMF69AgOvpi1qdqjDSjDN6578B6nky9ceEpI+1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.12.tgz",
+      "integrity": "sha512-/vrwhEf7Xsuh+YlHF4IjSy3g1cyrQuPaSiHIxCEbLu8qnfvrcvJyCkoktOOF+xV9gSb77/G0n3h04RbMDW2sIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.12.tgz",
+      "integrity": "sha512-CBh7YHju623lxJRcAOo498ZUwIuMy63bqW/vVq0tQAZVv+lkWlHkP9ealYE1utWSisEShY5VMdzIXRmyEODzcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.4.2.tgz",
+      "integrity": "sha512-XJmn/wY4AX56l1BRU+ZjDrFtg9+2uBEi4JvJQj82kwJDQKiPgSn4CEsbfGGygS4Gw6rkL4W18oATjfVfaqub2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^5.1.4",
+        "@inquirer/confirm": "^6.0.12",
+        "@inquirer/editor": "^5.1.1",
+        "@inquirer/expand": "^5.0.13",
+        "@inquirer/input": "^5.0.12",
+        "@inquirer/number": "^4.0.12",
+        "@inquirer/password": "^5.0.12",
+        "@inquirer/rawlist": "^5.2.8",
+        "@inquirer/search": "^4.1.8",
+        "@inquirer/select": "^5.1.4"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.8.tgz",
+      "integrity": "sha512-Su7FQvp5buZmCymN3PPoYv31ZQQX4ve2j02k7piGgKAWgE+AQRB5YoYVveGXcl3TZ9ldgRMSxj56YfDFmmaqLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.8.tgz",
+      "integrity": "sha512-fGiHKGD6DyPIYUWxoXnQTeXeyYqSOUrasDMABBmMHUalH/LxkuzY0xVRtimXAt1sUeeyYkVuKQx1bebMuN11Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.4.tgz",
+      "integrity": "sha512-2kWcGKPMLAXAWRp1AH1SLsQmX+j0QjeljyXMUji9WMZC8nRDO0b7qquIGr6143E7KMLt3VAIGNXzwa/6PXQs4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2232,7 +2586,7 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.19.0"
@@ -3445,6 +3799,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "license": "MIT"
+    },
     "node_modules/cheerio": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
@@ -3545,6 +3905,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/cliui": {
@@ -4747,6 +5116,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -4762,6 +5146,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -8057,7 +8450,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -8830,7 +9222,7 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",
+        "@inquirer/core": "^11.1.9",
         "@inquirer/prompts": "^8.4.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chokidar": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1114,6 +1114,7 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
+    "@inquirer/prompts": "^8.4.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chokidar": "^5.0.0",
     "cytoscape": "^3.33.2",

--- a/package.json
+++ b/package.json
@@ -1104,7 +1104,8 @@
     "test:cli:e2e": "bash scripts/test-cli-e2e.sh",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
-    "check:types": "tsc --noEmit",
+    "check:types": "npm run check:types:clean",
+    "check:types:clean": "node -e \"require('node:fs').rmSync('out', { recursive: true, force: true });\" && tsc --noEmit",
     "audit": "npm audit",
     "audit:fix": "npm audit fix",
     "package": "vsce package",
@@ -1114,6 +1115,7 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^2.0.4",
+    "@inquirer/core": "^11.1.9",
     "@inquirer/prompts": "^8.4.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chokidar": "^5.0.0",

--- a/src/analyzer/spider/SpiderSymbolService.ts
+++ b/src/analyzer/spider/SpiderSymbolService.ts
@@ -478,7 +478,9 @@ export class SpiderSymbolService {
     }
 
     const config = this.getConfig();
-    const collector = new SourceFileCollector({ excludeNodeModules: config.excludeNodeModules });
+    const collector = new SourceFileCollector({
+      excludeNodeModules: config.excludeNodeModules ?? true,
+    });
 
     // Collect all source files under scopePath
     const allFiles = await collector.collectAllSourceFiles(scopePath);

--- a/src/cli/commandHelp.ts
+++ b/src/cli/commandHelp.ts
@@ -11,7 +11,7 @@ Usage: graph-it scan [options]
 
 Options:
   --workspace, -w   Workspace root directory (default: auto-detected)
-  --format, -f      Output format: text|json|toon|markdown (default: text)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
   --help, -h        Show this help
 
 Examples:
@@ -27,7 +27,7 @@ Arguments:
 
 Options:
   --workspace, -w   Workspace root directory (default: auto-detected)
-  --format, -f      Output format: text|json|toon|markdown (default: text)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
   --help, -h        Show this help
 
 Examples:
@@ -59,7 +59,7 @@ Arguments:
 
 Options:
   --workspace, -w   Workspace root directory (default: auto-detected)
-  --format, -f      Output format: text|json|toon|markdown (default: text)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
   --help, -h        Show this help
 
 Examples:
@@ -81,6 +81,67 @@ Examples:
   graph-it path src/index.ts
   graph-it path src/index.ts --format mermaid
 `,
+  "path-in": `graph-it path-in — Find incoming dependencies for a target file
+
+Usage: graph-it path-in <file> [options]
+
+Arguments:
+  <file>            Target file whose importers should be listed
+
+Options:
+  --workspace, -w   Workspace root directory (default: auto-detected)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
+  --help, -h        Show this help
+
+Examples:
+  graph-it path-in src/index.ts
+  graph-it path-in src/index.ts --format mermaid
+`,
+  "check-dependencies": `graph-it check-dependencies — Check incoming and outgoing dependencies
+
+Usage: graph-it check-dependencies <file> [options]
+
+Arguments:
+  <file>            Target file to analyze
+
+Options:
+  --workspace, -w   Workspace root directory (default: auto-detected)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
+  --help, -h        Show this help
+
+Examples:
+  graph-it check-dependencies src/index.ts
+`,
+  cycles: `graph-it cycles — List confirmed dependency cycles for a file
+
+Usage: graph-it cycles <file> [options]
+
+Arguments:
+  <file>            Target file to inspect for cycles
+
+Options:
+  --workspace, -w   Workspace root directory (default: auto-detected)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
+  --help, -h        Show this help
+
+Examples:
+  graph-it cycles src/index.ts
+`,
+  architecture: `graph-it architecture — Build full workspace dependency architecture
+
+Usage: graph-it architecture [options]
+
+Options:
+  --maxFiles N       Optional cap on analyzed source files
+  --workspace, -w    Workspace root directory (default: auto-detected)
+  --format, -f       Output format: text|json|toon|markdown|mermaid (default: text)
+  --help, -h         Show this help
+
+Examples:
+  graph-it architecture
+  graph-it architecture --format mermaid
+  graph-it architecture --maxFiles 2000
+`,
   check: `graph-it check — Find unused exported symbols in a file
 
 Usage: graph-it check <file> [options]
@@ -90,7 +151,7 @@ Arguments:
 
 Options:
   --workspace, -w   Workspace root directory (default: auto-detected)
-  --format, -f      Output format: text|json|toon|markdown (default: text)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
   --help, -h        Show this help
 
 Examples:
@@ -136,7 +197,7 @@ Options:
   --list            List all available MCP tools with descriptions
   --args '<json>'   Pass parameters as a JSON object
   --workspace, -w   Workspace root directory (default: auto-detected)
-  --format, -f      Output format: text|json|toon|markdown (default: text)
+  --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
   --help, -h        Show this help
 
 Examples:

--- a/src/cli/commands/architecture.ts
+++ b/src/cli/commands/architecture.ts
@@ -1,0 +1,193 @@
+/**
+ * CLI Command: architecture
+ *
+ * Build a complete workspace dependency architecture graph by aggregating
+ * direct dependencies for every source file in the workspace.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import * as path from "node:path";
+import { SourceFileCollector } from "../../analyzer/SourceFileCollector.js";
+import { executeAnalyzeDependencies } from "../../mcp/tools";
+import { validateFilePath } from "../../mcp/types";
+import { normalizePath } from "../../shared/path.js";
+import type { CliOutputFormat } from "../formatter";
+import { formatOutput } from "../formatter";
+import type { CliRuntime } from "../runtime";
+
+interface ArchitectureNode {
+  id: string;
+  path: string;
+  relativePath: string;
+  extension: string;
+  dependencyCount: number;
+  dependentCount: number;
+}
+
+interface ArchitectureEdge {
+  source: string;
+  target: string;
+  sourceRelative: string;
+  targetRelative: string;
+}
+
+interface ArchitectureAccumulator {
+  nodesByPath: Map<string, ArchitectureNode>;
+  edgesByKey: Map<string, ArchitectureEdge>;
+  dependencyCount: Map<string, number>;
+  dependentCount: Map<string, number>;
+}
+
+interface FailedArchitectureFile {
+  filePath: string;
+  relativePath: string;
+  reason: string;
+}
+
+function isWithinWorkspace(filePath: string, workspaceRoot: string): boolean {
+  const rel = path.relative(workspaceRoot, normalizePath(filePath));
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
+}
+
+function parseMaxFiles(args: string[]): number {
+  let maxFiles = Number.POSITIVE_INFINITY;
+  const maxFilesIdx = args.indexOf("--maxFiles");
+  if (maxFilesIdx >= 0 && args[maxFilesIdx + 1]) {
+    const parsed = Number.parseInt(args[maxFilesIdx + 1], 10);
+    if (!Number.isNaN(parsed) && parsed > 0) {
+      maxFiles = parsed;
+    }
+  }
+  return maxFiles;
+}
+
+function initializeAccumulator(): ArchitectureAccumulator {
+  return {
+    nodesByPath: new Map<string, ArchitectureNode>(),
+    edgesByKey: new Map<string, ArchitectureEdge>(),
+    dependencyCount: new Map<string, number>(),
+    dependentCount: new Map<string, number>(),
+  };
+}
+
+function registerNode(
+  acc: ArchitectureAccumulator,
+  workspaceRoot: string,
+  filePath: string,
+): void {
+  const normalizedPath = normalizePath(filePath);
+  const relativePath = normalizePath(path.relative(workspaceRoot, normalizedPath));
+  acc.nodesByPath.set(normalizedPath, {
+    id: normalizedPath,
+    path: normalizedPath,
+    relativePath,
+    extension: path.extname(normalizedPath).slice(1),
+    dependencyCount: 0,
+    dependentCount: 0,
+  });
+}
+
+function registerEdge(
+  acc: ArchitectureAccumulator,
+  sourcePath: string,
+  targetPath: string,
+  workspaceRoot: string,
+): void {
+  const normalizedSource = normalizePath(sourcePath);
+  const normalizedTarget = normalizePath(targetPath);
+  const edgeKey = `${normalizedSource}=>${normalizedTarget}`;
+  if (acc.edgesByKey.has(edgeKey)) {
+    return;
+  }
+
+  acc.edgesByKey.set(edgeKey, {
+    source: normalizedSource,
+    target: normalizedTarget,
+    sourceRelative: normalizePath(path.relative(workspaceRoot, normalizedSource)),
+    targetRelative: normalizePath(path.relative(workspaceRoot, normalizedTarget)),
+  });
+  acc.dependencyCount.set(normalizedSource, (acc.dependencyCount.get(normalizedSource) ?? 0) + 1);
+  acc.dependentCount.set(normalizedTarget, (acc.dependentCount.get(normalizedTarget) ?? 0) + 1);
+}
+
+async function collectArchitectureForFile(
+  acc: ArchitectureAccumulator,
+  workspaceRoot: string,
+  filePath: string,
+): Promise<FailedArchitectureFile | null> {
+  const normalizedPath = normalizePath(filePath);
+  registerNode(acc, workspaceRoot, normalizedPath);
+  try {
+    validateFilePath(normalizedPath, workspaceRoot);
+    const analysis = await executeAnalyzeDependencies({ filePath: normalizedPath });
+    for (const dep of analysis.dependencies) {
+      if (!isWithinWorkspace(dep.path, workspaceRoot)) {
+        continue;
+      }
+      const normalizedDependencyPath = normalizePath(dep.path);
+      registerNode(acc, workspaceRoot, normalizedDependencyPath);
+      registerEdge(acc, normalizedPath, normalizedDependencyPath, workspaceRoot);
+    }
+    return null;
+  } catch (err) {
+    return {
+      filePath: normalizedPath,
+      relativePath: normalizePath(path.relative(workspaceRoot, normalizedPath)),
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+export async function run(
+  args: string[],
+  runtime: CliRuntime,
+  format: CliOutputFormat,
+): Promise<string> {
+  await runtime.ensureIndexed();
+
+  const maxFiles = parseMaxFiles(args);
+
+  const collector = new SourceFileCollector({ excludeNodeModules: true });
+  const allFiles = await collector.collectAllSourceFiles(runtime.workspaceRoot);
+  const files = Number.isFinite(maxFiles) ? allFiles.slice(0, maxFiles) : allFiles;
+
+  const acc = initializeAccumulator();
+
+  let skippedFiles = 0;
+  const failedFiles: FailedArchitectureFile[] = [];
+
+  for (const filePath of files) {
+    const failure = await collectArchitectureForFile(
+      acc,
+      runtime.workspaceRoot,
+      filePath,
+    );
+    if (failure) {
+      skippedFiles += 1;
+      failedFiles.push(failure);
+    }
+  }
+
+  const nodes = [...acc.nodesByPath.values()].map((node) => ({
+    ...node,
+    dependencyCount: acc.dependencyCount.get(node.path) ?? 0,
+    dependentCount: acc.dependentCount.get(node.path) ?? 0,
+  }));
+
+  const edges = [...acc.edgesByKey.values()];
+
+  const architecture = {
+    workspaceRoot: runtime.workspaceRoot,
+    scannedFiles: allFiles.length,
+    analyzedFiles: files.length,
+    skippedFiles,
+    failedFiles,
+    nodeCount: nodes.length,
+    edgeCount: edges.length,
+    nodes,
+    edges,
+  };
+
+  return formatOutput(architecture, format, "architecture");
+}

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -7,6 +7,7 @@
  */
 
 import fs from "node:fs/promises";
+import path from "node:path";
 import { executeFindUnusedSymbols, executeScanDeadCode } from "../../mcp/tools";
 import type { CliOutputFormat } from "../formatter";
 import { formatOutput } from "../formatter";
@@ -26,22 +27,26 @@ export async function run(
     return formatOutput(result, format, "check");
   }
 
+  const candidatePath = path.isAbsolute(args[0])
+    ? path.resolve(args[0])
+    : path.resolve(runtime.workspaceRoot, args[0]);
+
   // Check if the argument is a directory → scoped dead code scan
   let isDirectory = false;
   try {
-    const stat = await fs.stat(args[0]);
+    const stat = await fs.stat(candidatePath);
     isDirectory = stat.isDirectory();
   } catch {
     // Not found or not accessible — treat as file reference below
   }
 
   if (isDirectory) {
-    const result = await executeScanDeadCode({ scopePath: args[0] });
+    const result = await executeScanDeadCode({ scopePath: candidatePath });
     return formatOutput(result, format, "check");
   }
 
   // File argument → existing per-file unused symbol check
-  const ref = parseSymbolRef(args[0], runtime.workspaceRoot);
+  const ref = parseSymbolRef(candidatePath, runtime.workspaceRoot);
 
   const result = await executeFindUnusedSymbols({
     filePath: ref.filePath,

--- a/src/cli/commands/checkDependencies.ts
+++ b/src/cli/commands/checkDependencies.ts
@@ -1,0 +1,51 @@
+/**
+ * CLI Command: check-dependencies
+ *
+ * Checks both outgoing and incoming dependencies for a target file.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import * as path from 'node:path';
+import { executeAnalyzeDependencies, executeFindReferencingFiles } from '../../mcp/tools';
+import { CliError, ExitCode } from '../errors';
+import type { CliOutputFormat } from '../formatter';
+import { formatOutput } from '../formatter';
+import type { CliRuntime } from '../runtime';
+import { parseSymbolRef } from '../symbols';
+
+export async function run(
+  args: string[],
+  runtime: CliRuntime,
+  format: CliOutputFormat,
+): Promise<string> {
+  if (args.length < 1) {
+    throw new CliError(
+      'Usage: graph-it check-dependencies <file>',
+      ExitCode.GENERAL_ERROR,
+    );
+  }
+
+  await runtime.ensureIndexed();
+
+  const targetFile = parseSymbolRef(args[0], runtime.workspaceRoot).filePath;
+  const [outgoing, incoming] = await Promise.all([
+    executeAnalyzeDependencies({ filePath: targetFile }),
+    executeFindReferencingFiles({ targetPath: targetFile }),
+  ]);
+
+  const result = {
+    filePath: targetFile,
+    relativePath: path.relative(runtime.workspaceRoot, targetFile),
+    outgoing: {
+      dependencyCount: outgoing.dependencyCount,
+      dependencies: outgoing.dependencies,
+    },
+    incoming: {
+      referencingFileCount: incoming.referencingFileCount,
+      referencingFiles: incoming.referencingFiles,
+    },
+  };
+
+  return formatOutput(result, format, 'check-dependencies');
+}

--- a/src/cli/commands/cycles.ts
+++ b/src/cli/commands/cycles.ts
@@ -1,0 +1,51 @@
+/**
+ * CLI Command: cycles
+ *
+ * Lists confirmed dependency cycles that include a target file.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import * as path from 'node:path';
+import { executeCrawlDependencyGraph } from '../../mcp/tools';
+import { CliError, ExitCode } from '../errors';
+import type { CliOutputFormat } from '../formatter';
+import { formatOutput } from '../formatter';
+import type { CliRuntime } from '../runtime';
+import { parseSymbolRef } from '../symbols';
+
+export async function run(
+  args: string[],
+  runtime: CliRuntime,
+  format: CliOutputFormat,
+): Promise<string> {
+  if (args.length < 1) {
+    throw new CliError(
+      'Usage: graph-it cycles <file>',
+      ExitCode.GENERAL_ERROR,
+    );
+  }
+
+  await runtime.ensureIndexed();
+
+  const targetFile = parseSymbolRef(args[0], runtime.workspaceRoot).filePath;
+  const graph = await executeCrawlDependencyGraph({
+    entryFile: targetFile,
+    maxDepth: 50,
+  });
+
+  const confirmedCycles = graph.circularDependencies.filter((cycle) =>
+    cycle.includes(targetFile),
+  );
+
+  const result = {
+    filePath: targetFile,
+    relativePath: path.relative(runtime.workspaceRoot, targetFile),
+    cycleCount: confirmedCycles.length,
+    confirmedCycles: confirmedCycles.map((cycle) =>
+      cycle.map((absPath) => path.relative(runtime.workspaceRoot, absPath)),
+    ),
+  };
+
+  return formatOutput(result, format, 'cycles');
+}

--- a/src/cli/commands/cycles.ts
+++ b/src/cli/commands/cycles.ts
@@ -7,6 +7,7 @@
  */
 
 import * as path from 'node:path';
+import { normalizePath } from '../../shared/path.js';
 import { executeCrawlDependencyGraph } from '../../mcp/tools';
 import { CliError, ExitCode } from '../errors';
 import type { CliOutputFormat } from '../formatter';
@@ -40,10 +41,10 @@ export async function run(
 
   const result = {
     filePath: targetFile,
-    relativePath: path.relative(runtime.workspaceRoot, targetFile),
+    relativePath: normalizePath(path.relative(runtime.workspaceRoot, targetFile)),
     cycleCount: confirmedCycles.length,
     confirmedCycles: confirmedCycles.map((cycle) =>
-      cycle.map((absPath) => path.relative(runtime.workspaceRoot, absPath)),
+      cycle.map((absPath) => normalizePath(path.relative(runtime.workspaceRoot, absPath))),
     ),
   };
 

--- a/src/cli/commands/pathIn.ts
+++ b/src/cli/commands/pathIn.ts
@@ -1,0 +1,83 @@
+/**
+ * CLI Command: path-in
+ *
+ * Finds incoming dependencies (referencing files) for a target file.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import { executeFindReferencingFiles } from '../../mcp/tools';
+import * as path from 'node:path';
+import { CliError, ExitCode } from '../errors';
+import type { CliOutputFormat } from '../formatter';
+import { formatOutput } from '../formatter';
+import type { CliRuntime } from '../runtime';
+import { parseSymbolRef } from '../symbols';
+
+interface PathInGraphNode {
+  id: string;
+  path: string;
+  relativePath: string;
+}
+
+interface PathInGraphEdge {
+  source: string;
+  target: string;
+}
+
+export async function run(
+  args: string[],
+  runtime: CliRuntime,
+  format: CliOutputFormat,
+): Promise<string> {
+  if (args.length < 1) {
+    throw new CliError(
+      'Usage: graph-it path-in <file>',
+      ExitCode.GENERAL_ERROR,
+    );
+  }
+
+  await runtime.ensureIndexed();
+
+  const ref = parseSymbolRef(args[0], runtime.workspaceRoot);
+  const result = await executeFindReferencingFiles({
+    targetPath: ref.filePath,
+  });
+
+  const nodes: PathInGraphNode[] = [{
+    id: result.targetPath,
+    path: result.targetPath,
+    relativePath: path.relative(runtime.workspaceRoot, result.targetPath),
+  }];
+
+  const nodeSet = new Set<string>([result.targetPath]);
+  const edges: PathInGraphEdge[] = [];
+
+  for (const referencingFile of result.referencingFiles) {
+    if (!nodeSet.has(referencingFile.path)) {
+      nodes.push({
+        id: referencingFile.path,
+        path: referencingFile.path,
+        relativePath: referencingFile.relativePath,
+      });
+      nodeSet.add(referencingFile.path);
+    }
+
+    edges.push({
+      source: referencingFile.path,
+      target: result.targetPath,
+    });
+  }
+
+  return formatOutput(
+    {
+      ...result,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      nodes,
+      edges,
+    },
+    format,
+    'path',
+  );
+}

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -127,14 +127,18 @@ async function runOneCycle(
   if (action === 'quit') return true;
 
   try {
-    const output = await runAction(action, runtime, state, allFiles);
+    const result = await runAction(action, runtime, state, allFiles);
+    const { output, contextFile, contextSymbol } = result;
+
+    state.lastFile = contextFile;
+    state.lastSymbol = contextSymbol;
 
     if (output) {
       state.lastResult = output;
       process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
     }
 
-    return await handlePostResult(output, action, runtime, state);
+    return await handlePostResult(output, action, runtime, state, contextFile);
   } catch (err) {
     if (err instanceof ExitPromptError) return true;
     process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
@@ -151,6 +155,7 @@ async function handlePostResult(
   command: string,
   runtime: CliRuntime,
   state: ReturnType<typeof createSessionState>,
+  contextFile: string | undefined,
 ): Promise<boolean> {
   let postAction: Awaited<ReturnType<typeof selectPostResultAction>>;
   try {
@@ -162,10 +167,21 @@ async function handlePostResult(
 
   if (postAction === 'quit') return true;
   if (postAction === 'export' && output) await handleExport(output, command);
-  if (postAction === 'drillDown' && state.lastFile) {
-    await handleDrillDown(state.lastFile, runtime, state);
+  if (postAction === 'drillDown') {
+    const drillDownFile = contextFile ?? state.lastFile;
+    if (!drillDownFile) {
+      process.stdout.write('Drill-down unavailable for this result (no file context).\n');
+      return false;
+    }
+    await handleDrillDown(drillDownFile, runtime, state);
   }
   return false; // 'newAnalysis' or handled above → keep looping
+}
+
+interface ReplActionResult {
+  output?: string;
+  contextFile?: string;
+  contextSymbol?: string;
 }
 
 async function runAction(
@@ -173,37 +189,55 @@ async function runAction(
   runtime: CliRuntime,
   state: ReturnType<typeof createSessionState>,
   allFiles: string[],
-): Promise<string | undefined> {
+): Promise<ReplActionResult> {
   if (action === 'summary') {
     const { run } = await import('./summary.js');
-    return run([], runtime, state.preferredFormat);
+    const args = state.lastFile ? [state.lastFile] : [];
+    const output = await run(args, runtime, state.preferredFormat);
+    return {
+      output,
+      contextFile: state.lastFile,
+      contextSymbol: state.lastSymbol,
+    };
   }
 
   if (action === 'check') {
     const { run } = await import('./check.js');
-    return run([], runtime, state.preferredFormat);
+    const args = state.lastFile ? [state.lastFile] : [];
+    const output = await run(args, runtime, state.preferredFormat);
+    return {
+      output,
+      contextFile: state.lastFile,
+      contextSymbol: state.lastSymbol,
+    };
   }
 
   // 'trace' and 'path' both need a file picker
   const rel = await searchFile(allFiles, runtime.workspaceRoot);
-  const absoluteFile = path.join(runtime.workspaceRoot, rel);
-  state.lastFile = absoluteFile;
+  const absoluteFile = path.resolve(runtime.workspaceRoot, rel);
 
   if (action === 'path') {
     const { run } = await import('./path.js');
-    return run([absoluteFile], runtime, state.preferredFormat);
+    const output = await run([absoluteFile], runtime, state.preferredFormat);
+    return { output, contextFile: absoluteFile };
   }
 
   // 'trace' — optionally pick a symbol
   const symbolName = await inputSymbol(rel);
   if (symbolName.trim()) {
     const { run } = await import('./trace.js');
-    return run([`${absoluteFile}#${symbolName.trim()}`], runtime, state.preferredFormat);
+    const output = await run([`${absoluteFile}#${symbolName.trim()}`], runtime, state.preferredFormat);
+    return {
+      output,
+      contextFile: absoluteFile,
+      contextSymbol: symbolName.trim(),
+    };
   }
 
   // No symbol entered → explain (intra-file analysis)
   const { run } = await import('./explain.js');
-  return run([absoluteFile], runtime, state.preferredFormat);
+  const output = await run([absoluteFile], runtime, state.preferredFormat);
+  return { output, contextFile: absoluteFile };
 }
 
 async function handleExport(output: string, command: string): Promise<void> {
@@ -228,7 +262,7 @@ async function handleDrillDown(
   state: ReturnType<typeof createSessionState>,
 ): Promise<void> {
   const rel = path.relative(runtime.workspaceRoot, filePath);
-  const symbolName = await inputSymbol(rel).catch(() => '');
+  const symbolName = await inputSymbol(rel, state.lastSymbol).catch(() => '');
   try {
     if (symbolName.trim()) {
       const { run } = await import('./trace.js');
@@ -237,11 +271,15 @@ async function handleDrillDown(
         runtime,
         state.preferredFormat,
       );
+      state.lastFile = filePath;
+      state.lastSymbol = symbolName.trim();
       state.lastResult = output;
       process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
     } else {
       const { run } = await import('./explain.js');
       const output = await run([filePath], runtime, state.preferredFormat);
+      state.lastFile = filePath;
+      state.lastSymbol = undefined;
       state.lastResult = output;
       process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
     }

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -23,6 +23,25 @@ import {
 } from '../repl/prompts.js';
 import { createSessionState } from '../repl/sessionState.js';
 
+const VERSION = process.env.CLI_VERSION ?? '0.0.0-dev';
+
+// ANSI helpers — skipped when NO_COLOR is set (https://no-color.org)
+const useColor = !process.env.NO_COLOR && process.stdout.isTTY;
+const DIM   = useColor ? '\x1b[2m'  : '';
+const BOLD  = useColor ? '\x1b[1m'  : '';
+const CYAN  = useColor ? '\x1b[36m' : '';
+const RESET = useColor ? '\x1b[0m'  : '';
+const BLUE  = useColor ? '\x1b[34m' : '';
+
+const BANNER = [
+  '',
+  `  ${CYAN}${BOLD}◆ Graph-It-Live${RESET}  ${DIM}v${VERSION}${RESET}`,
+  `  ${BLUE}${'─'.repeat(38)}${RESET}`,
+  `  ${DIM}Interactive dependency explorer${RESET}`,
+  `  ${DIM}Ctrl+C to quit · graph-it --help for commands${RESET}`,
+  '',
+].join('\n');
+
 const NON_TTY_MESSAGE =
   'Interactive mode unavailable (no TTY).\n' +
   'Use direct commands: graph-it --help\n';
@@ -72,7 +91,7 @@ export async function run(runtime: CliRuntime): Promise<void> {
 
   const state = createSessionState(runtime.workspaceRoot);
 
-  process.stdout.write('\n  Graph-It-Live — interactive mode  (Ctrl+C to quit)\n\n');
+  process.stdout.write(BANNER);
 
   // ── Main loop ────────────────────────────────────────────────────────────
   let quit = false;

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -22,9 +22,12 @@ import {
   confirmScan,
   inputCommandLine,
   inputSavePath,
-  inputSymbol,
   searchDirectory,
   searchFile,
+  selectOrInputSymbol,
+  askTraceOptions,
+  askArchitectureOptions,
+  askCheckDepsOptions,
   type MainActionSelection,
   selectExportFormat,
   selectMainAction,
@@ -34,6 +37,7 @@ import {
 import { createSessionState } from '../repl/sessionState.js';
 import { sanitizeTerminalText } from '../repl/terminal.js';
 import { tokenizeCommandLine } from '../repl/tokenize.js';
+import { getTip, getPersonaTip } from '../repl/tips.js';
 
 const VERSION = process.env.CLI_VERSION ?? '0.0.0-dev';
 
@@ -166,11 +170,14 @@ function buildPromptChrome(state: ReturnType<typeof createSessionState>): string
     ? path.relative(state.workspaceRoot, state.lastFile)
     : 'none';
   const symbol = state.lastSymbol ?? 'none';
+  const generalTip = getTip('general', state.tipCounter);
+  const personaTip = getPersonaTip(state.tipCounter);
 
   return [
     buildBanner(),
     `${DIM}workspace:${RESET} ${formatStatusValue(state.workspaceRoot)}  ${DIM}format:${RESET} ${state.preferredFormat}  ${DIM}last file:${RESET} ${formatStatusValue(relFile)}  ${DIM}last symbol:${RESET} ${formatStatusValue(symbol)}`,
-    `${DIM}tip:${RESET} Type ${BOLD}/${RESET} to browse commands. Use ${BOLD}/help${RESET} for examples.`,
+    `${DIM}tip:${RESET} ${generalTip}`,
+    `${DIM}    ${personaTip}${RESET}`,
   ].join('\n');
 }
 
@@ -310,6 +317,16 @@ function applyResultToSession(
 ): void {
   state.lastFile = result.contextFile;
   state.lastSymbol = result.contextSymbol;
+  state.tipCounter += 1;
+
+  // Track recently-visited files (deduped, newest first, max 5)
+  if (result.contextFile) {
+    const relFile = path.relative(state.workspaceRoot, result.contextFile);
+    state.recentFiles = [
+      relFile,
+      ...state.recentFiles.filter((f) => f !== relFile),
+    ].slice(0, 5);
+  }
 
   if (result.output) {
     state.lastResult = result.rawData ?? result.output;
@@ -739,6 +756,44 @@ async function selectMainActionWithRecovery(
   }
 }
 
+async function handleFollowUpAction(
+  postAction: string,
+  contextFile: string | undefined,
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+): Promise<void> {
+  const fileForFollowUp = contextFile ?? state.lastFile;
+
+  if (postAction === 'followUpDeps' && fileForFollowUp) {
+    const result = await runFileDrivenActionFor('checkDependencies', fileForFollowUp, runtime, state, state.preferredFormat);
+    applyResultToSession(state, result);
+    return;
+  }
+
+  if (postAction === 'followUpCycles' && fileForFollowUp) {
+    const result = await runFileDrivenActionFor('cycles', fileForFollowUp, runtime, state, state.preferredFormat);
+    applyResultToSession(state, result);
+    return;
+  }
+
+  if (postAction === 'followUpTrace' && fileForFollowUp) {
+    const result = await runFileDrivenActionForTrace(fileForFollowUp, runtime, state, state.preferredFormat);
+    applyResultToSession(state, result);
+    return;
+  }
+
+  if (postAction === 'followUpDeadCode') {
+    const result = await runStickyContextAction('check', runtime, state, state.preferredFormat);
+    applyResultToSession(state, result);
+    return;
+  }
+
+  if (postAction === 'followUpArchitecture') {
+    const result = await runStickyContextAction('architecture', runtime, state, state.preferredFormat);
+    applyResultToSession(state, result);
+  }
+}
+
 async function handlePostResult(
   rawData: unknown,
   output: string | undefined,
@@ -748,10 +803,14 @@ async function handlePostResult(
   state: ReturnType<typeof createSessionState>,
   contextFile: string | undefined,
 ): Promise<boolean> {
+  const resultTip = getTip(`result.${command}`, state.tipCounter);
+  const tipSuffix = resultTip ? `\n${DIM}  💡 ${resultTip}${RESET}` : '';
+
   let postAction: Awaited<ReturnType<typeof selectPostResultAction>>;
   try {
     postAction = await selectPostResultAction(
-      `${buildPromptChrome(state)}\n${DIM}current result:${RESET} ${sanitizeTerminalText(command, 40)}\n${DIM}tip:${RESET} Type ${BOLD}/${RESET} for follow-up actions.`,
+      `${buildPromptChrome(state)}\n${DIM}current result:${RESET} ${sanitizeTerminalText(command, 40)}\n${DIM}tip:${RESET} Type ${BOLD}/${RESET} for follow-up actions.${tipSuffix}`,
+      command,
     );
   } catch (err) {
     if (err instanceof ExitPromptError) return true;
@@ -781,6 +840,9 @@ async function handlePostResult(
     }
     await handleDrillDown(drillDownFile, runtime, state);
   }
+
+  // Context-aware follow-up actions — delegated to helper to keep complexity low
+  await handleFollowUpAction(postAction, contextFile, runtime, state);
 
   return false;
 }
@@ -878,7 +940,7 @@ async function runStickyContextAction(
     ReplStickyAction,
     {
       command: 'architecture' | 'summary' | 'check';
-      getArgs: () => string[];
+      getArgs: () => Promise<string[]> | string[];
       loadRunner: () => Promise<{
         run: (args: string[], rt: CliRuntime, fmt: CliOutputFormat) => Promise<string>;
       }>;
@@ -886,7 +948,11 @@ async function runStickyContextAction(
   > = {
     architecture: {
       command: 'architecture',
-      getArgs: () => [],
+      getArgs: async () => {
+        const opts = await askArchitectureOptions(state.tipCounter);
+        if (opts.maxFiles !== undefined) return [`--maxFiles=${opts.maxFiles}`];
+        return [];
+      },
       loadRunner: () => import('./architecture.js'),
     },
     summary: {
@@ -903,9 +969,10 @@ async function runStickyContextAction(
 
   const config = actionConfig[action];
   const { run } = await config.loadRunner();
+  const args = await config.getArgs();
   const result = await executeCommandForRepl(
     config.command,
-    config.getArgs(),
+    args,
     runtime,
     preferredFormat,
     run,
@@ -926,41 +993,137 @@ async function runFileDrivenAction(
   preferredFormat: CliOutputFormat,
 ): Promise<ReplActionResult> {
   const scopedFiles = getScopedFiles(allFiles, state.workspaceRoot);
-  const rel = await searchFile(scopedFiles, state.workspaceRoot);
+  const rel = await searchFile(
+    scopedFiles,
+    state.workspaceRoot,
+    state.recentFiles,
+    'trace.file',
+    state.tipCounter,
+  );
   const absoluteFile = path.resolve(state.workspaceRoot, rel);
 
+  if (action === 'checkDependencies') {
+    const opts = await askCheckDepsOptions(state.tipCounter);
+    return runCheckDepsWithDirection(opts.direction, absoluteFile, runtime, preferredFormat);
+  }
+
+  if (action === 'cycles') {
+    return runFileDrivenActionFor('cycles', absoluteFile, runtime, state, preferredFormat);
+  }
+
+  return runFileDrivenActionForTrace(absoluteFile, runtime, state, preferredFormat, rel);
+}
+
+/** Run check-dependencies, path, or path-in depending on chosen direction. */
+async function runCheckDepsWithDirection(
+  direction: 'both' | 'outgoing' | 'incoming',
+  absoluteFile: string,
+  runtime: CliRuntime,
+  preferredFormat: CliOutputFormat,
+): Promise<ReplActionResult> {
+  if (direction === 'outgoing') {
+    const { run } = await import('./path.js');
+    const result = await executeCommandForRepl('path', [absoluteFile], runtime, preferredFormat, run);
+    return { ...result, contextFile: absoluteFile };
+  }
+
+  if (direction === 'incoming') {
+    const { run } = await import('./pathIn.js');
+    const result = await executeCommandForRepl('path-in', [absoluteFile], runtime, preferredFormat, run);
+    return { ...result, contextFile: absoluteFile };
+  }
+
+  const { run } = await import('./checkDependencies.js');
+  const result = await executeCommandForRepl('check-dependencies', [absoluteFile], runtime, preferredFormat, run);
+  return { ...result, contextFile: absoluteFile };
+}
+
+/** Run cycles or checkDependencies for a pre-known file (used by follow-up actions). */
+async function runFileDrivenActionFor(
+  action: 'cycles' | 'checkDependencies',
+  absoluteFile: string,
+  runtime: CliRuntime,
+  _state: ReturnType<typeof createSessionState>,
+  preferredFormat: CliOutputFormat,
+): Promise<ReplActionResult> {
   if (action === 'checkDependencies') {
     const { run } = await import('./checkDependencies.js');
     const result = await executeCommandForRepl('check-dependencies', [absoluteFile], runtime, preferredFormat, run);
     return { ...result, contextFile: absoluteFile };
   }
 
-  if (action === 'cycles') {
-    const { run } = await import('./cycles.js');
-    const result = await executeCommandForRepl('cycles', [absoluteFile], runtime, preferredFormat, run);
-    return { ...result, contextFile: absoluteFile };
-  }
+  const { run } = await import('./cycles.js');
+  const result = await executeCommandForRepl('cycles', [absoluteFile], runtime, preferredFormat, run);
+  return { ...result, contextFile: absoluteFile };
+}
 
-  const symbolName = await inputSymbol(rel);
+/** Run trace (with symbol autocomplete) for a pre-known file (used by follow-up actions). */
+async function runFileDrivenActionForTrace(
+  absoluteFile: string,
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  preferredFormat: CliOutputFormat,
+  rel?: string,
+): Promise<ReplActionResult> {
+  const displayPath = rel ?? path.relative(state.workspaceRoot, absoluteFile);
+  const symbols = await extractFileSymbols(absoluteFile, runtime);
+  const opts = await askTraceOptions(state.tipCounter);
+  const symbolName = await selectOrInputSymbol(displayPath, symbols, state.tipCounter, state.lastSymbol ?? '');
+
   if (symbolName.trim()) {
+    const args: string[] = [`${absoluteFile}#${symbolName.trim()}`];
+    if (opts.maxDepth !== undefined) args.push(`--maxDepth=${opts.maxDepth}`);
     const { run } = await import('./trace.js');
-    const result = await executeCommandForRepl(
-      'trace',
-      [`${absoluteFile}#${symbolName.trim()}`],
-      runtime,
-      preferredFormat,
-      run,
-    );
-    return {
-      ...result,
-      contextFile: absoluteFile,
-      contextSymbol: symbolName.trim(),
-    };
+    const result = await executeCommandForRepl('trace', args, runtime, preferredFormat, run);
+    return { ...result, contextFile: absoluteFile, contextSymbol: symbolName.trim() };
   }
 
   const { run } = await import('./explain.js');
   const result = await executeCommandForRepl('explain', [absoluteFile], runtime, preferredFormat, run);
   return { ...result, contextFile: absoluteFile };
+}
+
+/**
+ * Silently extract symbol names from a file by running the explain command in JSON mode.
+ * Returns an empty array on any error or timeout — never throws.
+ */
+async function extractFileSymbols(
+  absoluteFile: string,
+  runtime: CliRuntime,
+): Promise<string[]> {
+  try {
+    const { run } = await import('./explain.js');
+    const jsonOutput = await Promise.race([
+      run([absoluteFile], runtime, 'json'),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error('timeout')), 5000);
+      }),
+    ]);
+
+    const parsed: unknown = JSON.parse(jsonOutput);
+    if (typeof parsed !== 'object' || parsed === null) return [];
+
+    const names = new Set<string>();
+    const record = parsed as Record<string, unknown>;
+
+    const extractFromArray = (arr: unknown): void => {
+      if (!Array.isArray(arr)) return;
+      for (const item of arr) {
+        if (typeof item === 'object' && item !== null) {
+          const obj = item as Record<string, unknown>;
+          if (typeof obj['symbolName'] === 'string') names.add(obj['symbolName']);
+          if (typeof obj['name'] === 'string') names.add(obj['name']);
+        }
+      }
+    };
+
+    extractFromArray(record['nodes']);
+    extractFromArray(record['symbols']);
+
+    return [...names].sort((a, b) => a.localeCompare(b));
+  } catch {
+    return [];
+  }
 }
 
 async function handleExport(rawData: unknown, command: string): Promise<void> {
@@ -1034,7 +1197,8 @@ async function handleDrillDown(
   state: ReturnType<typeof createSessionState>,
 ): Promise<void> {
   const rel = path.relative(runtime.workspaceRoot, filePath);
-  const symbolName = await inputSymbol(rel, state.lastSymbol).catch(() => '');
+  const symbols = await extractFileSymbols(filePath, runtime);
+  const symbolName = await selectOrInputSymbol(rel, symbols, state.tipCounter, state.lastSymbol ?? '').catch(() => '');
   try {
     if (symbolName.trim()) {
       const { run } = await import('./trace.js');

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -9,42 +9,180 @@
  */
 
 import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
 import { ExitPromptError } from '@inquirer/core';
 import { SourceFileCollector } from '../../analyzer/SourceFileCollector.js';
-import { formatOutput } from '../formatter.js';
+import { CLI_OUTPUT_FORMATS, formatOutput } from '../formatter.js';
+import type { CliOutputFormat } from '../formatter.js';
 import type { CliRuntime } from '../runtime.js';
+import { normalizePathForComparison } from '../../shared/path.js';
+import { loggerFactory, type LogLevel } from '../../shared/logger.js';
+import { parseSymbolRef } from '../symbols.js';
 import {
   confirmScan,
+  inputCommandLine,
+  inputSavePath,
   inputSymbol,
+  searchDirectory,
   searchFile,
+  type MainActionSelection,
   selectExportFormat,
   selectMainAction,
   selectPostResultAction,
+  selectPreferredFormat,
 } from '../repl/prompts.js';
 import { createSessionState } from '../repl/sessionState.js';
+import { sanitizeTerminalText } from '../repl/terminal.js';
+import { tokenizeCommandLine } from '../repl/tokenize.js';
 
 const VERSION = process.env.CLI_VERSION ?? '0.0.0-dev';
 
 // ANSI helpers — skipped when NO_COLOR is set (https://no-color.org)
 const useColor = !process.env.NO_COLOR && process.stdout.isTTY;
-const DIM   = useColor ? '\x1b[2m'  : '';
-const BOLD  = useColor ? '\x1b[1m'  : '';
-const CYAN  = useColor ? '\x1b[36m' : '';
-const RESET = useColor ? '\x1b[0m'  : '';
-const BLUE  = useColor ? '\x1b[34m' : '';
-
-const BANNER = [
-  '',
-  `  ${CYAN}${BOLD}◆ Graph-It-Live${RESET}  ${DIM}v${VERSION}${RESET}`,
-  `  ${BLUE}${'─'.repeat(38)}${RESET}`,
-  `  ${DIM}Interactive dependency explorer${RESET}`,
-  `  ${DIM}Ctrl+C to quit · graph-it --help for commands${RESET}`,
-  '',
-].join('\n');
+const DIM = useColor ? '\x1b[2m' : '';
+const BOLD = useColor ? '\x1b[1m' : '';
+const RESET = useColor ? '\x1b[0m' : '';
+const BLUE = useColor ? '\x1b[38;5;33m' : '';
+const ORANGE = useColor ? '\x1b[38;5;214m' : '';
+const SPARK = useColor ? '\x1b[38;5;117m' : '';
 
 const NON_TTY_MESSAGE =
   'Interactive mode unavailable (no TTY).\n' +
   'Use direct commands: graph-it --help\n';
+
+interface ReplActionResult {
+  command: string;
+  rawData?: unknown;
+  output?: string;
+  effectiveFormat?: CliOutputFormat;
+  contextFile?: string;
+  contextSymbol?: string;
+  shouldQuit?: boolean;
+  skipPostAction?: boolean;
+}
+
+type ReplMainAction = 'trace' | 'command' | 'setPath' | 'checkDependencies' | 'cycles' | 'check' | 'summary' | 'architecture' | 'format' | 'help';
+type ReplStickyAction = 'architecture' | 'summary' | 'check';
+type ReplFileAction = 'trace' | 'checkDependencies' | 'cycles';
+type ReplRunner = (args: string[], runtime: CliRuntime, format: CliOutputFormat) => Promise<string>;
+
+const REPL_TYPED_RUNNER_LOADERS = {
+  architecture: () => import('./architecture.js'),
+  summary: () => import('./summary.js'),
+  check: () => import('./check.js'),
+  path: () => import('./path.js'),
+  pathIn: () => import('./pathIn.js'),
+  checkDependencies: () => import('./checkDependencies.js'),
+  cycles: () => import('./cycles.js'),
+  trace: () => import('./trace.js'),
+  explain: () => import('./explain.js'),
+  scan: () => import('./scan.js'),
+} satisfies Record<string, () => Promise<{ run: ReplRunner }>>;
+
+function resolveTypedRunnerKey(command: string): keyof typeof REPL_TYPED_RUNNER_LOADERS | undefined {
+  if (command === 'path-in' || command === 'path-out' || command === 'deps-in' || command === 'deps-out') {
+    return 'checkDependencies';
+  }
+  if (command === 'check-dependencies' || command === 'deps' || command === 'dependencies') {
+    return 'checkDependencies';
+  }
+  if (command === 'cycles' || command === 'cycle') {
+    return 'cycles';
+  }
+  if (command in REPL_TYPED_RUNNER_LOADERS) {
+    return command as keyof typeof REPL_TYPED_RUNNER_LOADERS;
+  }
+  return undefined;
+}
+
+function buildBanner(): string {
+  return [
+    '',
+    `  ${BLUE}●${RESET}${DIM}─${RESET}${BLUE}■${RESET}   ${BOLD}Graph-It-Live${RESET} ${DIM}v${VERSION}${RESET} ${SPARK}✦${RESET}`,
+    `  ${BLUE}│${RESET} ${DIM}╲${RESET}   ${DIM}Type / to browse commands, or press Enter to search the palette${RESET}`,
+    `  ${BLUE}●${RESET}${DIM}─${RESET}${ORANGE}■${RESET}   ${DIM}Dependency & architecture explorer · Ctrl+C to quit${RESET}`,
+    '',
+  ].join('\n');
+}
+
+function buildReplHelpText(state: ReturnType<typeof createSessionState>): string {
+  const lastFile = state.lastFile ? path.relative(state.workspaceRoot, state.lastFile) : 'none';
+  return [
+    `${BOLD}Slash commands${RESET}`,
+    '  /trace          Select a file, then optionally a symbol to trace',
+    '  /path           Set workspace directory scope (browse or explicit)',
+    '  /file           Set active file context (browse or explicit)',
+    '  /check-dependencies  Check incoming and outgoing dependencies',
+    '  /cycles         List confirmed dependency cycles for a file',
+    '  /summary        Summarize the current file or whole workspace',
+    '  /architecture   Build the workspace graph',
+    '  /check          Find unused exports',
+    '  /format         Change the default display format',
+    '  /command        Run a raw CLI command line',
+    '  /help           Show this help',
+    '  /quit           Exit the REPL',
+    '',
+    `${DIM}Examples:${RESET}`,
+    '  /path src/cli',
+    '  /file src/cli/index.ts',
+    '  /check-dependencies',
+    '  /cycles src/cli/index.ts',
+    '  /trace src/index.ts#main',
+    '  /architecture --format mermaid',
+    '',
+    `${DIM}session:${RESET} format=${state.preferredFormat}  last-file=${lastFile}`,
+  ].join('\n');
+}
+
+function normalizeSelection(
+  selection: Awaited<ReturnType<typeof selectMainAction>> | MainActionSelection | ReplMainAction | 'quit',
+): MainActionSelection {
+  if (typeof selection !== 'string') {
+    return selection;
+  }
+
+  if (selection === 'quit') {
+    return { kind: 'quit' };
+  }
+
+  return { kind: 'action', action: selection };
+}
+
+function normalizeSlashCommand(command: string): string {
+  return command.startsWith('/') ? command.slice(1) : command;
+}
+
+function formatTerminalError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return sanitizeTerminalText(message, 240);
+}
+
+function formatStatusValue(value: string | undefined): string {
+  return sanitizeTerminalText(value ?? 'none', 120);
+}
+
+function buildPromptChrome(state: ReturnType<typeof createSessionState>): string {
+  const relFile = state.lastFile
+    ? path.relative(state.workspaceRoot, state.lastFile)
+    : 'none';
+  const symbol = state.lastSymbol ?? 'none';
+
+  return [
+    buildBanner(),
+    `${DIM}workspace:${RESET} ${formatStatusValue(state.workspaceRoot)}  ${DIM}format:${RESET} ${state.preferredFormat}  ${DIM}last file:${RESET} ${formatStatusValue(relFile)}  ${DIM}last symbol:${RESET} ${formatStatusValue(symbol)}`,
+    `${DIM}tip:${RESET} Type ${BOLD}/${RESET} to browse commands. Use ${BOLD}/help${RESET} for examples.`,
+  ].join('\n');
+}
+
+async function runQuietlyDuringBootstrap<T>(work: () => Promise<T>): Promise<T> {
+  const previousLevel: LogLevel = loggerFactory.getDefaultLevel();
+  loggerFactory.setDefaultLevel('none');
+  try {
+    return await work();
+  } finally {
+    loggerFactory.setDefaultLevel(previousLevel);
+  }
+}
 
 /**
  * Entry point for the REPL.
@@ -58,17 +196,15 @@ export async function run(runtime: CliRuntime): Promise<void> {
     return;
   }
 
-  // ── Initialise workspace ────────────────────────────────────────────────
   try {
-    await runtime.init();
+    await runQuietlyDuringBootstrap(() => runtime.init());
   } catch {
     process.stderr.write('Workspace not found or not accessible.\n');
     return;
   }
 
-  // ── Lazy index: offer to scan if not yet indexed ─────────────────────────
   try {
-    await runtime.ensureIndexed();
+    await runQuietlyDuringBootstrap(() => runtime.ensureIndexed({ silent: true }));
   } catch {
     const doScan = await confirmScan('Index missing or stale.').catch(() => false);
     if (!doScan) {
@@ -76,24 +212,21 @@ export async function run(runtime: CliRuntime): Promise<void> {
       return;
     }
     try {
-      await runtime.ensureIndexed();
+      await runQuietlyDuringBootstrap(() => runtime.ensureIndexed({ silent: true }));
     } catch (err) {
       process.stderr.write(
-        `Scan error: ${err instanceof Error ? err.message : String(err)}\n`,
+        `Scan error: ${formatTerminalError(err)}\n`,
       );
       return;
     }
   }
 
-  // ── Collect all source files for fuzzy search ────────────────────────────
   const collector = new SourceFileCollector({ excludeNodeModules: true });
-  const allFiles = await collector.collectAllSourceFiles(runtime.workspaceRoot);
-
+  const allFiles = await runQuietlyDuringBootstrap(
+    () => collector.collectAllSourceFiles(runtime.workspaceRoot),
+  );
   const state = createSessionState(runtime.workspaceRoot);
 
-  process.stdout.write(BANNER);
-
-  // ── Main loop ────────────────────────────────────────────────────────────
   let quit = false;
   while (!quit) {
     quit = await runOneCycle(runtime, state, allFiles);
@@ -102,56 +235,514 @@ export async function run(runtime: CliRuntime): Promise<void> {
   process.stdout.write('\nGoodbye!\n');
 }
 
-// ============================================================================
-// Helpers
-// ============================================================================
+function isPathInsideWorkspace(resolvedPath: string, workspaceRoot: string): boolean {
+  const relative = path.relative(workspaceRoot, resolvedPath);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
 
-/**
- * Run one full REPL cycle: pick action → execute → post-result menu.
- * Returns `true` when the user wants to quit.
- */
+async function findNearestExistingParent(targetDir: string): Promise<string> {
+  let current = targetDir;
+  for (;;) {
+    try {
+      await fs.access(current);
+      return current;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        throw new Error('No existing parent directory found for save path.');
+      }
+      current = parent;
+    }
+  }
+}
+
+async function isSafeWorkspaceWritePath(
+  targetPath: string,
+  workspaceRoot: string,
+): Promise<boolean> {
+  if (!isPathInsideWorkspace(targetPath, workspaceRoot)) {
+    return false;
+  }
+
+  const realWorkspaceRoot = normalizePathForComparison(
+    await fs.realpath(workspaceRoot),
+  );
+  const existingParent = await findNearestExistingParent(path.dirname(targetPath));
+  const realParent = normalizePathForComparison(await fs.realpath(existingParent));
+
+  return (
+    realParent === realWorkspaceRoot ||
+    realParent.startsWith(`${realWorkspaceRoot}/`) ||
+    realParent.startsWith(`${realWorkspaceRoot}${path.sep}`)
+  );
+}
+
+function parseRawCommandOutput(output: string): unknown {
+  try {
+    return JSON.parse(output);
+  } catch {
+    return output;
+  }
+}
+
+async function executeCommandForRepl(
+  command: string,
+  args: string[],
+  runtime: CliRuntime,
+  preferredFormat: CliOutputFormat,
+  runner: (args: string[], runtime: CliRuntime, format: CliOutputFormat) => Promise<string>,
+): Promise<Pick<ReplActionResult, 'command' | 'rawData' | 'output' | 'effectiveFormat'>> {
+  const jsonOutput = await runner(args, runtime, 'json');
+  const rawData = parseRawCommandOutput(jsonOutput);
+
+  try {
+    const output = formatOutput(rawData, preferredFormat, command);
+    return { command, rawData, output, effectiveFormat: preferredFormat };
+  } catch {
+    const output = formatOutput(rawData, 'text', command);
+    return { command, rawData, output, effectiveFormat: 'text' };
+  }
+}
+
+function applyResultToSession(
+  state: ReturnType<typeof createSessionState>,
+  result: ReplActionResult,
+): void {
+  state.lastFile = result.contextFile;
+  state.lastSymbol = result.contextSymbol;
+
+  if (result.output) {
+    state.lastResult = result.rawData ?? result.output;
+    const sanitizedOutput = stripSavedOutputNoise(result.output, result.effectiveFormat);
+    process.stdout.write(sanitizedOutput.endsWith('\n') ? sanitizedOutput : `${sanitizedOutput}\n`);
+  }
+
+  if (result.effectiveFormat && result.effectiveFormat !== state.preferredFormat) {
+    process.stdout.write(
+      `Rendered in ${result.effectiveFormat} (default ${state.preferredFormat} unsupported for this command).\n`,
+    );
+  }
+}
+
+async function runTypedCommandFromPrompt(
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  preferredFormat: CliOutputFormat,
+  allFiles: string[],
+): Promise<ReplActionResult> {
+  const commandLine = await inputCommandLine(state.lastCommandLine ?? '');
+  return runTypedCommandLine(runtime, state, preferredFormat, commandLine, allFiles);
+}
+
+async function runTypedCommandLine(
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  preferredFormat: CliOutputFormat,
+  commandLine: string,
+  allFiles: string[],
+): Promise<ReplActionResult> {
+  const trimmedCommandLine = commandLine.trim();
+  const parsed = tokenizeCommandLine(trimmedCommandLine);
+  const tokens = parsed.tokens;
+
+  if (parsed.error) {
+    return {
+      command: 'command',
+      output: `Invalid command line: ${sanitizeTerminalText(parsed.error)}`,
+      skipPostAction: true,
+    };
+  }
+
+  if (tokens.length === 0) {
+    return {
+      command: 'command',
+      output: 'Empty command. Try: path src/index.ts --format mermaid',
+    };
+  }
+
+  if (tokens[0] === 'graph-it') {
+    tokens.shift();
+  }
+
+  const [command, ...rawArgs] = tokens;
+  const normalizedCommand = command ? normalizeSlashCommand(command) : '';
+  if (!normalizedCommand) {
+    return {
+      command: 'command',
+      output: 'No command provided after graph-it prefix.',
+      skipPostAction: true,
+    };
+  }
+
+  const { effectiveFormat, cleanedArgs, invalidFormatValue } = extractFormatOverride(rawArgs, preferredFormat);
+  state.lastCommandLine = trimmedCommandLine;
+  const contextualArgs = rebaseTypedArgs(
+    normalizedCommand,
+    applyImplicitFileContext(normalizedCommand, cleanedArgs, state),
+    state,
+  );
+
+  if (invalidFormatValue) {
+    process.stdout.write(
+      `Unknown format "${sanitizeTerminalText(invalidFormatValue)}". Valid formats: ${CLI_OUTPUT_FORMATS.join(', ')}. Using ${effectiveFormat}.
+`,
+    );
+  }
+
+  const sessionCommand = await handleTypedSessionCommand(
+    normalizedCommand,
+    contextualArgs,
+    state,
+    runtime,
+    allFiles,
+  );
+  if (sessionCommand) {
+    return sessionCommand;
+  }
+
+  const runnerKey = resolveTypedRunnerKey(normalizedCommand);
+  const runnerLoader = runnerKey ? REPL_TYPED_RUNNER_LOADERS[runnerKey] : undefined;
+  if (runnerKey && runnerLoader) {
+    const { run } = await runnerLoader();
+    const commandLabel = runnerKey === 'checkDependencies'
+      ? 'check-dependencies'
+      : runnerKey;
+    return executeCommandForRepl(commandLabel, contextualArgs, runtime, effectiveFormat, run);
+  }
+
+  return {
+    command: normalizedCommand,
+    output: `Unknown REPL command "${sanitizeTerminalText(normalizedCommand)}". Try: /path, /file, /check-dependencies, /cycles, /summary, /check, /trace, /format, /help.`,
+    skipPostAction: true,
+  };
+}
+
+async function handleTypedSessionCommand(
+  command: string,
+  args: string[],
+  state: ReturnType<typeof createSessionState>,
+  runtime: CliRuntime,
+  allFiles: string[],
+): Promise<ReplActionResult | undefined> {
+  if (command === 'help') {
+    return {
+      command: 'help',
+      output: buildReplHelpText(state),
+      skipPostAction: true,
+    };
+  }
+
+  if (command === 'quit') {
+    return { command: 'quit', shouldQuit: true, skipPostAction: true };
+  }
+
+  if (command === 'path') {
+    return handlePathSessionCommand(args, state, runtime, allFiles);
+  }
+
+  if (command !== 'format') {
+    if (command !== 'file') {
+      return undefined;
+    }
+    return handleFileSessionCommand(args, state, runtime, allFiles);
+  }
+
+  const requestedFormat = args[0];
+  if (requestedFormat && CLI_OUTPUT_FORMATS.includes(requestedFormat as CliOutputFormat)) {
+    state.preferredFormat = requestedFormat as CliOutputFormat;
+  } else if (requestedFormat) {
+    return {
+      command: 'format',
+      output: `Unknown format "${sanitizeTerminalText(requestedFormat)}". Valid formats: ${CLI_OUTPUT_FORMATS.join(', ')}`,
+      skipPostAction: true,
+    };
+  } else {
+    state.preferredFormat = await selectPreferredFormat(state.preferredFormat);
+  }
+
+  return {
+    command: 'format',
+    output: `Default format set to ${state.preferredFormat}.`,
+    skipPostAction: true,
+  };
+}
+
+function applyWorkspaceScope(
+  state: ReturnType<typeof createSessionState>,
+  runtime: CliRuntime,
+  nextWorkspace: string,
+): ReplActionResult {
+  state.workspaceRoot = nextWorkspace;
+  state.lastFile = undefined;
+  state.lastSymbol = undefined;
+
+  return {
+    command: 'path',
+    output: `Session workspace set to ${path.relative(runtime.workspaceRoot, state.workspaceRoot) || '.'}.`,
+    skipPostAction: true,
+  };
+}
+
+async function handlePathSessionCommand(
+  args: string[],
+  state: ReturnType<typeof createSessionState>,
+  runtime: CliRuntime,
+  allFiles: string[],
+): Promise<ReplActionResult> {
+  let targetDirectory: string;
+  if (args[0]) {
+    targetDirectory = path.isAbsolute(args[0])
+      ? path.resolve(args[0])
+      : path.resolve(state.workspaceRoot, args[0]);
+  } else {
+    const selectedRelativeDirectory = await searchDirectory(
+      getScopedFiles(allFiles, state.workspaceRoot),
+      state.workspaceRoot,
+    );
+    targetDirectory = path.resolve(state.workspaceRoot, selectedRelativeDirectory || '.');
+  }
+
+  if (!isWithinRoot(targetDirectory, runtime.workspaceRoot)) {
+    return {
+      command: 'path',
+      output: 'Refusing to set workspace scope outside project root.',
+      skipPostAction: true,
+    };
+  }
+
+  const stats = await fs.stat(targetDirectory).catch(() => undefined);
+  if (!stats?.isDirectory()) {
+    return {
+      command: 'path',
+      output: `Directory not found: ${sanitizeTerminalText(args[0] ?? '', 140)}`,
+      skipPostAction: true,
+    };
+  }
+
+  return applyWorkspaceScope(state, runtime, targetDirectory);
+}
+
+async function handleFileSessionCommand(
+  args: string[],
+  state: ReturnType<typeof createSessionState>,
+  runtime: CliRuntime,
+  allFiles: string[],
+): Promise<ReplActionResult> {
+  const resolvedFile = args[0]
+    ? parseSymbolRef(args[0], state.workspaceRoot).filePath
+    : path.resolve(
+      state.workspaceRoot,
+      await searchFile(getScopedFiles(allFiles, state.workspaceRoot), state.workspaceRoot),
+    );
+
+  state.lastFile = resolvedFile;
+  state.lastSymbol = undefined;
+
+  return {
+    command: 'file',
+    output: `Current file context set to ${path.relative(runtime.workspaceRoot, resolvedFile)}.`,
+    contextFile: resolvedFile,
+    skipPostAction: true,
+  };
+}
+
+function parseFormatValue(
+  value: string,
+): { override: CliOutputFormat } | { invalid: string } | null {
+  if (!value) return null;
+  if (CLI_OUTPUT_FORMATS.includes(value as CliOutputFormat)) {
+    return { override: value as CliOutputFormat };
+  }
+  return { invalid: value };
+}
+
+function readFormatFlag(
+  arg: string,
+  nextArg: string | undefined,
+): { parsed: { override: CliOutputFormat } | { invalid: string }; skipNextArg: boolean } | undefined {
+  if (arg === '--format' || arg === '-f') {
+    return {
+      parsed: parseFormatValue(nextArg ?? '') ?? { invalid: '(missing value)' },
+      skipNextArg: true,
+    };
+  }
+
+  if (!arg.startsWith('--format=')) {
+    return undefined;
+  }
+
+  return {
+    parsed: parseFormatValue(arg.slice('--format='.length)) ?? { invalid: '(missing value)' },
+    skipNextArg: false,
+  };
+}
+
+function applyImplicitFileContext(
+  command: string,
+  args: string[],
+  state: ReturnType<typeof createSessionState>,
+): string[] {
+  if (args.length > 0) return args;
+  if (!state.lastFile) return args;
+  if (command !== 'summary' && command !== 'check' && command !== 'check-dependencies' && command !== 'cycles') return args;
+  return [state.lastFile];
+}
+
+function isWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const relative = path.relative(rootPath, candidatePath);
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+function getScopedFiles(allFiles: string[], workspaceScope: string): string[] {
+  return allFiles.filter((filePath) => isWithinRoot(filePath, workspaceScope));
+}
+
+function resolveScopedFileArg(command: string, firstArg: string, state: ReturnType<typeof createSessionState>): string {
+  if (command === 'trace') {
+    const parsed = parseSymbolRef(firstArg, state.workspaceRoot);
+    return parsed.symbolName ? `${parsed.filePath}#${parsed.symbolName}` : parsed.filePath;
+  }
+
+  if (command === 'check-dependencies' || command === 'cycles') {
+    return parseSymbolRef(firstArg, state.workspaceRoot).filePath;
+  }
+
+  return firstArg;
+}
+
+function rebaseTypedArgs(
+  command: string,
+  args: string[],
+  state: ReturnType<typeof createSessionState>,
+): string[] {
+  if (args.length === 0) {
+    return args;
+  }
+
+  const fileLikeCommands = new Set(['trace', 'check-dependencies', 'cycles']);
+  if (!fileLikeCommands.has(command)) {
+    return args;
+  }
+
+  return [resolveScopedFileArg(command, args[0], state), ...args.slice(1)];
+}
+
+function extractFormatOverride(
+  args: string[],
+  preferredFormat: CliOutputFormat,
+): { effectiveFormat: CliOutputFormat; cleanedArgs: string[]; invalidFormatValue?: string } {
+  const cleanedArgs: string[] = [];
+  let override: CliOutputFormat | undefined;
+  let invalidFormatValue: string | undefined;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+
+    const formatFlag = readFormatFlag(arg, args[i + 1]);
+    if (formatFlag) {
+      if ('override' in formatFlag.parsed) override = formatFlag.parsed.override;
+      else invalidFormatValue = formatFlag.parsed.invalid;
+      if (formatFlag.skipNextArg) {
+        i += 1;
+      }
+      continue;
+    }
+
+    cleanedArgs.push(arg);
+  }
+
+  return { effectiveFormat: override ?? preferredFormat, cleanedArgs, invalidFormatValue };
+}
+
+function getDefaultSaveExtension(format: CliOutputFormat | undefined): string {
+  switch (format) {
+    case 'mermaid':
+      return '.mmd';
+    case 'json':
+      return '.json';
+    case 'toon':
+      return '.toon';
+    case 'markdown':
+      return '.md';
+    case 'text':
+    default:
+      return '.txt';
+  }
+}
+
+function buildDefaultSavePathForFormat(command: string, format: CliOutputFormat | undefined): string {
+  const stamp = new Date().toISOString().replaceAll(':', '-');
+  const extension = getDefaultSaveExtension(format);
+  return path.join('.graph-it', 'exports', `${stamp}-${command}${extension}`);
+}
+
+function stripSavedOutputNoise(content: string, format: CliOutputFormat | undefined): string {
+  if (format !== 'mermaid' && format !== 'json' && format !== 'toon') {
+    return content;
+  }
+
+  const cleaned = content
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('%% output truncated')) return false;
+      if (/^PARSING ERROR\b/i.test(trimmed)) return false;
+      return true;
+    })
+    .join('\n');
+
+  return cleaned;
+}
+
 async function runOneCycle(
   runtime: CliRuntime,
   state: ReturnType<typeof createSessionState>,
   allFiles: string[],
 ): Promise<boolean> {
-  let action: Awaited<ReturnType<typeof selectMainAction>>;
-  try {
-    action = await selectMainAction();
-  } catch (err) {
-    if (err instanceof ExitPromptError) return true; // Ctrl+C at main menu
-    process.stderr.write(`Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`);
-    return true;
-  }
-
-  if (action === 'quit') return true;
+  const selection = normalizeSelection(
+    await selectMainActionWithRecovery(buildPromptChrome(state)),
+  );
+  if (selection.kind === 'quit') return true;
 
   try {
-    const result = await runAction(action, runtime, state, allFiles);
-    const { output, contextFile, contextSymbol } = result;
-
-    state.lastFile = contextFile;
-    state.lastSymbol = contextSymbol;
-
-    if (output) {
-      state.lastResult = output;
-      process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
-    }
-
-    return await handlePostResult(output, action, runtime, state, contextFile);
+    const result = await runAction(selection, runtime, state, allFiles);
+    applyResultToSession(state, result);
+    if (result.shouldQuit) return true;
+    if (result.skipPostAction) return false;
+    return await handlePostResult(
+      result.rawData,
+      result.output,
+      result.effectiveFormat,
+      result.command,
+      runtime,
+      state,
+      result.contextFile,
+    );
   } catch (err) {
     if (err instanceof ExitPromptError) return true;
-    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
-    return false; // Non-fatal — continue loop
+    process.stderr.write(`Error: ${formatTerminalError(err)}\n`);
+    return false;
   }
 }
 
-/**
- * Show the post-result menu and handle the chosen action.
- * Returns `true` when the user wants to quit.
- */
+async function selectMainActionWithRecovery(
+  promptMessage: string,
+): Promise<Awaited<ReturnType<typeof selectMainAction>>> {
+  try {
+    return await selectMainAction(promptMessage);
+  } catch (err) {
+    if (err instanceof ExitPromptError) {
+      return { kind: 'quit' };
+    }
+    process.stderr.write(`Unexpected error: ${formatTerminalError(err)}\n`);
+    return { kind: 'quit' };
+  }
+}
+
 async function handlePostResult(
+  rawData: unknown,
   output: string | undefined,
+  effectiveFormat: CliOutputFormat | undefined,
   command: string,
   runtime: CliRuntime,
   state: ReturnType<typeof createSessionState>,
@@ -159,14 +750,29 @@ async function handlePostResult(
 ): Promise<boolean> {
   let postAction: Awaited<ReturnType<typeof selectPostResultAction>>;
   try {
-    postAction = await selectPostResultAction();
+    postAction = await selectPostResultAction(
+      `${buildPromptChrome(state)}\n${DIM}current result:${RESET} ${sanitizeTerminalText(command, 40)}\n${DIM}tip:${RESET} Type ${BOLD}/${RESET} for follow-up actions.`,
+    );
   } catch (err) {
     if (err instanceof ExitPromptError) return true;
     throw err;
   }
 
   if (postAction === 'quit') return true;
-  if (postAction === 'export' && output) await handleExport(output, command);
+
+  if (postAction === 'export' && rawData !== undefined) {
+    await handleExport(rawData, command);
+  }
+
+  if (postAction === 'saveToFile' && output) {
+    await handleSaveToFile(output, command, runtime.workspaceRoot, rawData, effectiveFormat);
+  }
+
+  if (postAction === 'setFormat') {
+    state.preferredFormat = await selectPreferredFormat(state.preferredFormat);
+    process.stdout.write(`Default format set to ${state.preferredFormat}.\n`);
+  }
+
   if (postAction === 'drillDown') {
     const drillDownFile = contextFile ?? state.lastFile;
     if (!drillDownFile) {
@@ -175,83 +781,249 @@ async function handlePostResult(
     }
     await handleDrillDown(drillDownFile, runtime, state);
   }
-  return false; // 'newAnalysis' or handled above → keep looping
-}
 
-interface ReplActionResult {
-  output?: string;
-  contextFile?: string;
-  contextSymbol?: string;
+  return false;
 }
 
 async function runAction(
-  action: 'trace' | 'path' | 'check' | 'summary',
+  selection: MainActionSelection,
   runtime: CliRuntime,
   state: ReturnType<typeof createSessionState>,
   allFiles: string[],
 ): Promise<ReplActionResult> {
-  if (action === 'summary') {
-    const { run } = await import('./summary.js');
-    const args = state.lastFile ? [state.lastFile] : [];
-    const output = await run(args, runtime, state.preferredFormat);
+  if (selection.kind === 'typed') {
+    return runTypedCommandLine(
+      runtime,
+      state,
+      state.preferredFormat,
+      selection.commandLine ?? '',
+      allFiles,
+    );
+  }
+
+  const action = selection.action;
+  const preferredFormat: CliOutputFormat = state.preferredFormat;
+
+  if (!action) {
     return {
-      output,
-      contextFile: state.lastFile,
-      contextSymbol: state.lastSymbol,
+      command: 'help',
+      output: buildReplHelpText(state),
+      skipPostAction: true,
     };
   }
 
-  if (action === 'check') {
-    const { run } = await import('./check.js');
-    const args = state.lastFile ? [state.lastFile] : [];
-    const output = await run(args, runtime, state.preferredFormat);
+  if (action === 'command') {
+    return runTypedCommandFromPrompt(runtime, state, preferredFormat, allFiles);
+  }
+
+  if (action === 'setPath') {
+    const scopedFiles = getScopedFiles(allFiles, state.workspaceRoot);
+    const selectedRelativeDirectory = await searchDirectory(scopedFiles, state.workspaceRoot);
+    const nextWorkspace = path.resolve(state.workspaceRoot, selectedRelativeDirectory || '.');
+
+    if (!isWithinRoot(nextWorkspace, runtime.workspaceRoot)) {
+      return {
+        command: 'path',
+        output: 'Refusing to set workspace scope outside project root.',
+        skipPostAction: true,
+      };
+    }
+
+    state.workspaceRoot = nextWorkspace;
+    state.lastFile = undefined;
+    state.lastSymbol = undefined;
+
     return {
-      output,
-      contextFile: state.lastFile,
-      contextSymbol: state.lastSymbol,
+      command: 'path',
+      output: `Session workspace set to ${path.relative(runtime.workspaceRoot, state.workspaceRoot) || '.'}.`,
+      skipPostAction: true,
     };
   }
 
-  // 'trace' and 'path' both need a file picker
-  const rel = await searchFile(allFiles, runtime.workspaceRoot);
-  const absoluteFile = path.resolve(runtime.workspaceRoot, rel);
-
-  if (action === 'path') {
-    const { run } = await import('./path.js');
-    const output = await run([absoluteFile], runtime, state.preferredFormat);
-    return { output, contextFile: absoluteFile };
+  if (action === 'format') {
+    state.preferredFormat = await selectPreferredFormat(state.preferredFormat);
+    return {
+      command: 'format',
+      output: `Default format set to ${state.preferredFormat}.`,
+      skipPostAction: true,
+    };
   }
 
-  // 'trace' — optionally pick a symbol
+  if (action === 'help') {
+    return {
+      command: 'help',
+      output: buildReplHelpText(state),
+      skipPostAction: true,
+    };
+  }
+
+  if (action === 'architecture' || action === 'summary' || action === 'check') {
+    return runStickyContextAction(action, runtime, state, preferredFormat);
+  }
+
+  if (action === 'quit') {
+    return { command: 'quit', shouldQuit: true, skipPostAction: true };
+  }
+
+  return runFileDrivenAction(action, runtime, state, allFiles, preferredFormat);
+}
+
+async function runStickyContextAction(
+  action: ReplStickyAction,
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  preferredFormat: CliOutputFormat,
+): Promise<ReplActionResult> {
+  const actionConfig: Record<
+    ReplStickyAction,
+    {
+      command: 'architecture' | 'summary' | 'check';
+      getArgs: () => string[];
+      loadRunner: () => Promise<{
+        run: (args: string[], rt: CliRuntime, fmt: CliOutputFormat) => Promise<string>;
+      }>;
+    }
+  > = {
+    architecture: {
+      command: 'architecture',
+      getArgs: () => [],
+      loadRunner: () => import('./architecture.js'),
+    },
+    summary: {
+      command: 'summary',
+      getArgs: () => (state.lastFile ? [state.lastFile] : []),
+      loadRunner: () => import('./summary.js'),
+    },
+    check: {
+      command: 'check',
+      getArgs: () => (state.lastFile ? [state.lastFile] : []),
+      loadRunner: () => import('./check.js'),
+    },
+  };
+
+  const config = actionConfig[action];
+  const { run } = await config.loadRunner();
+  const result = await executeCommandForRepl(
+    config.command,
+    config.getArgs(),
+    runtime,
+    preferredFormat,
+    run,
+  );
+
+  return {
+    ...result,
+    contextFile: state.lastFile,
+    contextSymbol: state.lastSymbol,
+  };
+}
+
+async function runFileDrivenAction(
+  action: ReplFileAction,
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  allFiles: string[],
+  preferredFormat: CliOutputFormat,
+): Promise<ReplActionResult> {
+  const scopedFiles = getScopedFiles(allFiles, state.workspaceRoot);
+  const rel = await searchFile(scopedFiles, state.workspaceRoot);
+  const absoluteFile = path.resolve(state.workspaceRoot, rel);
+
+  if (action === 'checkDependencies') {
+    const { run } = await import('./checkDependencies.js');
+    const result = await executeCommandForRepl('check-dependencies', [absoluteFile], runtime, preferredFormat, run);
+    return { ...result, contextFile: absoluteFile };
+  }
+
+  if (action === 'cycles') {
+    const { run } = await import('./cycles.js');
+    const result = await executeCommandForRepl('cycles', [absoluteFile], runtime, preferredFormat, run);
+    return { ...result, contextFile: absoluteFile };
+  }
+
   const symbolName = await inputSymbol(rel);
   if (symbolName.trim()) {
     const { run } = await import('./trace.js');
-    const output = await run([`${absoluteFile}#${symbolName.trim()}`], runtime, state.preferredFormat);
+    const result = await executeCommandForRepl(
+      'trace',
+      [`${absoluteFile}#${symbolName.trim()}`],
+      runtime,
+      preferredFormat,
+      run,
+    );
     return {
-      output,
+      ...result,
       contextFile: absoluteFile,
       contextSymbol: symbolName.trim(),
     };
   }
 
-  // No symbol entered → explain (intra-file analysis)
   const { run } = await import('./explain.js');
-  const output = await run([absoluteFile], runtime, state.preferredFormat);
-  return { output, contextFile: absoluteFile };
+  const result = await executeCommandForRepl('explain', [absoluteFile], runtime, preferredFormat, run);
+  return { ...result, contextFile: absoluteFile };
 }
 
-async function handleExport(output: string, command: string): Promise<void> {
+async function handleExport(rawData: unknown, command: string): Promise<void> {
   try {
     const fmt = await selectExportFormat();
-    const data: unknown = (() => {
-      try { return JSON.parse(output); } catch { return output; }
-    })();
-    const exported = formatOutput(data, fmt, command);
-    process.stdout.write(exported.endsWith('\n') ? exported : `${exported}\n`);
+    const exported = formatOutput(rawData, fmt, command);
+    const sanitizedExport = stripSavedOutputNoise(exported, fmt);
+    process.stdout.write(sanitizedExport.endsWith('\n') ? sanitizedExport : `${sanitizedExport}\n`);
   } catch (err) {
     if (err instanceof ExitPromptError) return;
     process.stderr.write(
-      `Export error: ${err instanceof Error ? err.message : String(err)}\n`,
+      `Export error: ${formatTerminalError(err)}\n`,
+    );
+  }
+}
+
+async function handleSaveToFile(
+  output: string,
+  command: string,
+  workspaceRoot: string,
+  rawData?: unknown,
+  effectiveFormat?: CliOutputFormat,
+): Promise<void> {
+  try {
+    const chosenPath = await inputSavePath(buildDefaultSavePathForFormat(command, effectiveFormat));
+    const resolvedPath = path.resolve(workspaceRoot, chosenPath);
+
+    if (!(await isSafeWorkspaceWritePath(resolvedPath, workspaceRoot))) {
+      process.stderr.write('Refusing to write outside workspace root.\n');
+      return;
+    }
+
+    await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+
+    // TOCTOU mitigation: re-validate after directory creation.
+    if (!(await isSafeWorkspaceWritePath(resolvedPath, workspaceRoot))) {
+      process.stderr.write('Refusing to write outside workspace root.\n');
+      return;
+    }
+
+    // Symlink hardening: never follow a symlink at the target path.
+    try {
+      const stats = await fs.lstat(resolvedPath);
+      if (stats.isSymbolicLink()) {
+        process.stderr.write('Refusing to overwrite a symlink target.\n');
+        return;
+      }
+    } catch (lstatErr) {
+      const code = (lstatErr as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== 'ENOENT') throw lstatErr;
+    }
+
+    const baseContent = rawData !== undefined && effectiveFormat
+      ? formatOutput(rawData, effectiveFormat, command)
+      : output;
+    const sanitizedContent = stripSavedOutputNoise(baseContent, effectiveFormat);
+
+    await fs.writeFile(resolvedPath, sanitizedContent, 'utf-8');
+    process.stdout.write(`Saved: ${path.relative(workspaceRoot, resolvedPath)}\n`);
+  } catch (err) {
+    if (err instanceof ExitPromptError) return;
+    process.stderr.write(
+      `Save error: ${formatTerminalError(err)}\n`,
     );
   }
 }
@@ -266,27 +1038,37 @@ async function handleDrillDown(
   try {
     if (symbolName.trim()) {
       const { run } = await import('./trace.js');
-      const output = await run(
+      const result = await executeCommandForRepl(
+        'trace',
         [`${filePath}#${symbolName.trim()}`],
         runtime,
         state.preferredFormat,
+        run,
       );
       state.lastFile = filePath;
       state.lastSymbol = symbolName.trim();
-      state.lastResult = output;
+      state.lastResult = result.rawData ?? result.output;
+      const output = result.output ?? '';
       process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
     } else {
       const { run } = await import('./explain.js');
-      const output = await run([filePath], runtime, state.preferredFormat);
+      const result = await executeCommandForRepl(
+        'explain',
+        [filePath],
+        runtime,
+        state.preferredFormat,
+        run,
+      );
       state.lastFile = filePath;
       state.lastSymbol = undefined;
-      state.lastResult = output;
+      state.lastResult = result.rawData ?? result.output;
+      const output = result.output ?? '';
       process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
     }
   } catch (err) {
     if (!(err instanceof ExitPromptError)) {
       process.stderr.write(
-        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+        `Error: ${formatTerminalError(err)}\n`,
       );
     }
   }

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -1,0 +1,236 @@
+/**
+ * CLI Command: repl
+ *
+ * Guided interactive REPL. Launched when `graph-it` is invoked with no
+ * arguments in a TTY context. Orchestrates existing CLI commands without
+ * re-implementing analysis logic.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import * as path from 'node:path';
+import { ExitPromptError } from '@inquirer/core';
+import { SourceFileCollector } from '../../analyzer/SourceFileCollector.js';
+import { formatOutput } from '../formatter.js';
+import type { CliRuntime } from '../runtime.js';
+import {
+  confirmScan,
+  inputSymbol,
+  searchFile,
+  selectExportFormat,
+  selectMainAction,
+  selectPostResultAction,
+} from '../repl/prompts.js';
+import { createSessionState } from '../repl/sessionState.js';
+
+const NON_TTY_MESSAGE =
+  'Interactive mode unavailable (no TTY).\n' +
+  'Use direct commands: graph-it --help\n';
+
+/**
+ * Entry point for the REPL.
+ *
+ * `runtime` is already constructed but NOT yet `init()`ed — this function
+ * handles init itself so it can offer a guided scan on first use.
+ */
+export async function run(runtime: CliRuntime): Promise<void> {
+  if (!process.stdin.isTTY) {
+    process.stdout.write(NON_TTY_MESSAGE);
+    return;
+  }
+
+  // ── Initialise workspace ────────────────────────────────────────────────
+  try {
+    await runtime.init();
+  } catch {
+    process.stderr.write('Workspace not found or not accessible.\n');
+    return;
+  }
+
+  // ── Lazy index: offer to scan if not yet indexed ─────────────────────────
+  try {
+    await runtime.ensureIndexed();
+  } catch {
+    const doScan = await confirmScan('Index missing or stale.').catch(() => false);
+    if (!doScan) {
+      process.stdout.write('Goodbye!\n');
+      return;
+    }
+    try {
+      await runtime.ensureIndexed();
+    } catch (err) {
+      process.stderr.write(
+        `Scan error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return;
+    }
+  }
+
+  // ── Collect all source files for fuzzy search ────────────────────────────
+  const collector = new SourceFileCollector({ excludeNodeModules: true });
+  const allFiles = await collector.collectAllSourceFiles(runtime.workspaceRoot);
+
+  const state = createSessionState(runtime.workspaceRoot);
+
+  process.stdout.write('\n  Graph-It-Live — interactive mode  (Ctrl+C to quit)\n\n');
+
+  // ── Main loop ────────────────────────────────────────────────────────────
+  let quit = false;
+  while (!quit) {
+    quit = await runOneCycle(runtime, state, allFiles);
+  }
+
+  process.stdout.write('\nGoodbye!\n');
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Run one full REPL cycle: pick action → execute → post-result menu.
+ * Returns `true` when the user wants to quit.
+ */
+async function runOneCycle(
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  allFiles: string[],
+): Promise<boolean> {
+  let action: Awaited<ReturnType<typeof selectMainAction>>;
+  try {
+    action = await selectMainAction();
+  } catch (err) {
+    if (err instanceof ExitPromptError) return true; // Ctrl+C at main menu
+    process.stderr.write(`Unexpected error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return true;
+  }
+
+  if (action === 'quit') return true;
+
+  try {
+    const output = await runAction(action, runtime, state, allFiles);
+
+    if (output) {
+      state.lastResult = output;
+      process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
+    }
+
+    return await handlePostResult(output, action, runtime, state);
+  } catch (err) {
+    if (err instanceof ExitPromptError) return true;
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`);
+    return false; // Non-fatal — continue loop
+  }
+}
+
+/**
+ * Show the post-result menu and handle the chosen action.
+ * Returns `true` when the user wants to quit.
+ */
+async function handlePostResult(
+  output: string | undefined,
+  command: string,
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+): Promise<boolean> {
+  let postAction: Awaited<ReturnType<typeof selectPostResultAction>>;
+  try {
+    postAction = await selectPostResultAction();
+  } catch (err) {
+    if (err instanceof ExitPromptError) return true;
+    throw err;
+  }
+
+  if (postAction === 'quit') return true;
+  if (postAction === 'export' && output) await handleExport(output, command);
+  if (postAction === 'drillDown' && state.lastFile) {
+    await handleDrillDown(state.lastFile, runtime, state);
+  }
+  return false; // 'newAnalysis' or handled above → keep looping
+}
+
+async function runAction(
+  action: 'trace' | 'path' | 'check' | 'summary',
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+  allFiles: string[],
+): Promise<string | undefined> {
+  if (action === 'summary') {
+    const { run } = await import('./summary.js');
+    return run([], runtime, state.preferredFormat);
+  }
+
+  if (action === 'check') {
+    const { run } = await import('./check.js');
+    return run([], runtime, state.preferredFormat);
+  }
+
+  // 'trace' and 'path' both need a file picker
+  const rel = await searchFile(allFiles, runtime.workspaceRoot);
+  const absoluteFile = path.join(runtime.workspaceRoot, rel);
+  state.lastFile = absoluteFile;
+
+  if (action === 'path') {
+    const { run } = await import('./path.js');
+    return run([absoluteFile], runtime, state.preferredFormat);
+  }
+
+  // 'trace' — optionally pick a symbol
+  const symbolName = await inputSymbol(rel);
+  if (symbolName.trim()) {
+    const { run } = await import('./trace.js');
+    return run([`${absoluteFile}#${symbolName.trim()}`], runtime, state.preferredFormat);
+  }
+
+  // No symbol entered → explain (intra-file analysis)
+  const { run } = await import('./explain.js');
+  return run([absoluteFile], runtime, state.preferredFormat);
+}
+
+async function handleExport(output: string, command: string): Promise<void> {
+  try {
+    const fmt = await selectExportFormat();
+    const data: unknown = (() => {
+      try { return JSON.parse(output); } catch { return output; }
+    })();
+    const exported = formatOutput(data, fmt, command);
+    process.stdout.write(exported.endsWith('\n') ? exported : `${exported}\n`);
+  } catch (err) {
+    if (err instanceof ExitPromptError) return;
+    process.stderr.write(
+      `Export error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+async function handleDrillDown(
+  filePath: string,
+  runtime: CliRuntime,
+  state: ReturnType<typeof createSessionState>,
+): Promise<void> {
+  const rel = path.relative(runtime.workspaceRoot, filePath);
+  const symbolName = await inputSymbol(rel).catch(() => '');
+  try {
+    if (symbolName.trim()) {
+      const { run } = await import('./trace.js');
+      const output = await run(
+        [`${filePath}#${symbolName.trim()}`],
+        runtime,
+        state.preferredFormat,
+      );
+      state.lastResult = output;
+      process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
+    } else {
+      const { run } = await import('./explain.js');
+      const output = await run([filePath], runtime, state.preferredFormat);
+      state.lastResult = output;
+      process.stdout.write(output.endsWith('\n') ? output : `${output}\n`);
+    }
+  } catch (err) {
+    if (!(err instanceof ExitPromptError)) {
+      process.stderr.write(
+        `Error: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}

--- a/src/cli/commands/summary.ts
+++ b/src/cli/commands/summary.ts
@@ -10,6 +10,7 @@ import { executeGetIndexStatus, executeGenerateCodemap } from "../../mcp/tools";
 import type { CliOutputFormat } from "../formatter";
 import { formatOutput } from "../formatter";
 import type { CliRuntime } from "../runtime";
+import { parseSymbolRef } from "../symbols";
 
 export async function run(
   args: string[],
@@ -22,8 +23,8 @@ export async function run(
 
   // If a file argument is provided, also generate a codemap for it
   if (args.length > 0) {
-    const filePath = args[0];
-    const codemap = await executeGenerateCodemap({ filePath });
+    const ref = parseSymbolRef(args[0], runtime.workspaceRoot);
+    const codemap = await executeGenerateCodemap({ filePath: ref.filePath });
     return formatOutput({ indexStatus: status, codemap }, format, "summary");
   }
 

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -9,29 +9,32 @@
  */
 
 import { estimateTokenSavings, jsonToToon } from "../shared/toon";
-import { CliError, ExitCode } from "./errors";
 
 export type CliOutputFormat = "text" | "json" | "toon" | "markdown" | "mermaid";
 
 export const CLI_OUTPUT_FORMATS: readonly CliOutputFormat[] = ["text", "json", "toon", "markdown", "mermaid"];
 
 /** Commands that can produce graph / mermaid output */
-const GRAPH_COMMANDS = new Set(["trace", "path", "scan"]);
+const GRAPH_COMMANDS = new Set(["trace", "path", "scan", "architecture"]);
 
-/** Commands that support mermaid */
-const MERMAID_COMMANDS = new Set(["trace", "path"]);
+const MAX_GENERIC_DEPTH = 3;
+const MAX_GENERIC_ITEMS_PER_LEVEL = 20;
+const MAX_GENERIC_NODES = 220;
+const MAX_MERMAID_LABEL_LENGTH = 120;
+const MAX_MERMAID_LINES = 700;
+const MAX_GRAPH_NODES = 260;
+const MAX_GRAPH_EDGES = 500;
+const MAX_TRACE_EDGES = 500;
+const MAX_CALLCHAIN_EDGES = 500;
+const MAX_DEPENDENCY_RELATIONS = 400;
 
 /**
  * Check whether a format is valid for the given command.
  * Throws CliError with UNSUPPORTED_FORMAT if not.
  */
-export function validateFormatForCommand(format: CliOutputFormat, command: string): void {
-  if (format === "mermaid" && !MERMAID_COMMANDS.has(command)) {
-    throw new CliError(
-      `Format "mermaid" is not supported for command "${command}". ` +
-        `Mermaid output is available for: ${[...MERMAID_COMMANDS].join(", ")}`,
-      ExitCode.UNSUPPORTED_FORMAT,
-    );
+export function validateFormatForCommand(format: CliOutputFormat, _command: string): void {
+  if (format === "mermaid") {
+    return;
   }
 }
 
@@ -100,6 +103,10 @@ function formatText(data: unknown, command: string): string {
     return formatTrace(data as Record<string, unknown>);
   }
 
+  if (command === "architecture" && typeof data === "object" && data !== null && !Array.isArray(data)) {
+    return formatArchitecture(data as Record<string, unknown>);
+  }
+
   if (Array.isArray(data)) {
     return data.map((item, i) => formatTextItem(item, i)).join("\n");
   }
@@ -110,6 +117,51 @@ function formatText(data: unknown, command: string): string {
 
   // data is a primitive at this point (number, boolean, bigint, symbol)
   return String(data as number | boolean | bigint | symbol);
+}
+
+function formatArchitecture(data: Record<string, unknown>): string {
+  const workspaceRootRaw = data["workspaceRoot"];
+  const workspaceRoot = typeof workspaceRootRaw === "string" ? workspaceRootRaw : "unknown";
+  const scannedFiles = Number(data["scannedFiles"] ?? 0);
+  const analyzedFiles = Number(data["analyzedFiles"] ?? 0);
+  const skippedFiles = Number(data["skippedFiles"] ?? 0);
+  const nodeCount = Number(data["nodeCount"] ?? 0);
+  const edgeCount = Number(data["edgeCount"] ?? 0);
+
+  const nodes = Array.isArray(data["nodes"])
+    ? (data["nodes"] as Array<Record<string, unknown>>)
+    : [];
+
+  const topDependents = [...nodes]
+    .sort((a, b) => Number(b["dependentCount"] ?? 0) - Number(a["dependentCount"] ?? 0))
+    .slice(0, 8)
+    .map((node) => {
+      const relCandidate = node["relativePath"] ?? node["path"] ?? node["id"];
+      const rel = typeof relCandidate === "string" ? relCandidate : "unknown";
+      const deps = Number(node["dependencyCount"] ?? 0);
+      const usedBy = Number(node["dependentCount"] ?? 0);
+      return `  - ${rel}  deps:${deps}  usedBy:${usedBy}`;
+    });
+
+  const lines = [
+    "Workspace Architecture",
+    `  root: ${workspaceRoot}`,
+    `  scanned files: ${scannedFiles}`,
+    `  analyzed files: ${analyzedFiles}`,
+    `  skipped files: ${skippedFiles}`,
+    `  nodes: ${nodeCount}`,
+    `  edges: ${edgeCount}`,
+  ];
+
+  if (topDependents.length > 0) {
+    lines.push("", "Top files by incoming dependencies:", ...topDependents);
+  }
+
+  if (skippedFiles > 0) {
+    lines.push("", "Note: some files were skipped (details available with --format json). ");
+  }
+
+  return lines.join("\n");
 }
 
 function formatTextItem(item: unknown, index: number): string {
@@ -191,25 +243,20 @@ function formatTrace(data: Record<string, unknown>): string {
 function formatMarkdown(data: unknown, command: string): string {
   const heading = `## graph-it ${command}\n\n`;
 
-  // For graph commands, embed mermaid if applicable
+  const mermaid = tryBuildMermaid(data) ?? buildMermaidFromGenericJson(data, command);
+  if (mermaid) {
+    return heading + "```mermaid\n" + mermaid + "\n```\n\n" + "```json\n" + JSON.stringify(data, null, 2) + "\n```";
+  }
+
   if (GRAPH_COMMANDS.has(command)) {
-    const mermaid = tryBuildMermaid(data);
-    if (mermaid) {
-      return heading + "```mermaid\n" + mermaid + "\n```\n\n" + "```json\n" + JSON.stringify(data, null, 2) + "\n```";
-    }
+    return heading + "```json\n" + JSON.stringify(data, null, 2) + "\n```";
   }
 
   return heading + "```json\n" + JSON.stringify(data, null, 2) + "\n```";
 }
 
-function formatMermaid(data: unknown, _command: string): string {
-  const mermaid = tryBuildMermaid(data);
-  if (!mermaid) {
-    throw new CliError(
-      "Could not generate Mermaid diagram from the data. The response must contain nodes/edges or a trace structure.",
-      ExitCode.UNSUPPORTED_FORMAT,
-    );
-  }
+function formatMermaid(data: unknown, command: string): string {
+  const mermaid = tryBuildMermaid(data) ?? buildMermaidFromGenericJson(data, command);
   return mermaid;
 }
 
@@ -225,6 +272,17 @@ interface GraphLike {
 interface TraceLike {
   trace?: { caller?: string; callee?: string; from?: string; to?: string; file?: string; depth?: number }[];
   steps?: { caller?: string; callee?: string; from?: string; to?: string }[];
+}
+
+interface DependencyCheckLike {
+  filePath?: string;
+  relativePath?: string;
+  outgoing?: {
+    dependencies?: Array<Record<string, unknown>>;
+  };
+  incoming?: {
+    referencingFiles?: Array<Record<string, unknown>>;
+  };
 }
 
 function tryBuildMermaid(data: unknown): string | null {
@@ -251,11 +309,41 @@ function tryBuildMermaid(data: unknown): string | null {
     );
   }
 
+  // check-dependencies result (incoming + outgoing)
+  if (
+    typeof obj["filePath"] === "string"
+    && typeof obj["outgoing"] === "object"
+    && obj["outgoing"] !== null
+    && typeof obj["incoming"] === "object"
+    && obj["incoming"] !== null
+  ) {
+    return buildMermaidFromDependencyCheck(obj as unknown as DependencyCheckLike);
+  }
+
   return null;
 }
 
 function sanitizeMermaidId(id: string): string {
   return id.replaceAll(/\W/g, "_");
+}
+
+function escapeMermaidLabel(label: string): string {
+  // Replace double-quotes to avoid breaking Mermaid node syntax.
+  // Strip ASCII control characters (U+0000–U+001F and U+007F) that break diagram structure.
+  // eslint-disable-next-line no-control-regex
+  const cleaned = label.replaceAll('"', "'").replaceAll(/[\x00-\x1F\x7F]/g, ' ').trim();
+  if (cleaned.length <= MAX_MERMAID_LABEL_LENGTH) {
+    return cleaned;
+  }
+  return `${cleaned.slice(0, MAX_MERMAID_LABEL_LENGTH - 1)}…`;
+}
+
+function finalizeMermaid(lines: string[]): string {
+  if (lines.length <= MAX_MERMAID_LINES) {
+    return lines.join("\n");
+  }
+
+  return lines.slice(0, MAX_MERMAID_LINES).join("\n");
 }
 
 function buildMermaidFromGraph(graph: GraphLike): string | null {
@@ -267,15 +355,23 @@ function buildMermaidFromGraph(graph: GraphLike): string | null {
   const idMap = new Map<string, string>();
   const lines = ["graph LR"];
 
-  nodes.forEach((node, i) => {
+  const visibleNodeCount = Math.min(nodes.length, MAX_GRAPH_NODES);
+  for (let i = 0; i < visibleNodeCount; i += 1) {
+    const node = nodes[i];
     const originalId = node.id ?? node.file ?? node.filePath ?? node.path ?? node.name ?? "unknown";
     const shortId = `N${i}`;
     idMap.set(originalId, shortId);
     const label = node.relativePath ?? node.name ?? node.file ?? node.filePath ?? originalId;
-    lines.push(`  ${shortId}["${label}"]`);
-  });
+    lines.push(`  ${shortId}["${escapeMermaidLabel(String(label))}"]`);
+  }
 
-  for (const edge of edges) {
+  if (nodes.length > visibleNodeCount) {
+    lines.push(`  NTRUNC["… ${nodes.length - visibleNodeCount} more node(s)"]`);
+  }
+
+  const visibleEdgeCount = Math.min(edges.length, MAX_GRAPH_EDGES);
+  for (let i = 0; i < visibleEdgeCount; i += 1) {
+    const edge = edges[i];
     const srcOriginal = String(edge.source ?? edge.from ?? "?");
     const tgtOriginal = String(edge.target ?? edge.to ?? "?");
     const src = idMap.get(srcOriginal) ?? sanitizeMermaidId(srcOriginal);
@@ -283,7 +379,11 @@ function buildMermaidFromGraph(graph: GraphLike): string | null {
     lines.push(`  ${src} --> ${tgt}`);
   }
 
-  return lines.join("\n");
+  if (edges.length > visibleEdgeCount) {
+    lines.push(`%% edge list truncated (${edges.length - visibleEdgeCount} hidden edge(s))`);
+  }
+
+  return finalizeMermaid(lines);
 }
 
 function buildMermaidFromTrace(trace: TraceLike): string | null {
@@ -292,13 +392,19 @@ function buildMermaidFromTrace(trace: TraceLike): string | null {
 
   const lines = ["graph TD"];
 
-  for (const step of steps) {
+  const visibleStepCount = Math.min(steps.length, MAX_TRACE_EDGES);
+  for (let i = 0; i < visibleStepCount; i += 1) {
+    const step = steps[i];
     const from = sanitizeMermaidId(String(step.caller ?? step.from ?? "?"));
     const to = sanitizeMermaidId(String(step.callee ?? step.to ?? "?"));
     lines.push(`  ${from} --> ${to}`);
   }
 
-  return lines.join("\n");
+  if (steps.length > visibleStepCount) {
+    lines.push(`%% trace truncated (${steps.length - visibleStepCount} hidden step(s))`);
+  }
+
+  return finalizeMermaid(lines);
 }
 
 function buildMermaidFromCallChain(
@@ -309,7 +415,9 @@ function buildMermaidFromCallChain(
   const lines = ["graph TD"];
   const seen = new Set<string>();
 
-  for (const entry of chain) {
+  const visibleEntryCount = Math.min(chain.length, MAX_CALLCHAIN_EDGES);
+  for (let i = 0; i < visibleEntryCount; i += 1) {
+    const entry = chain[i];
     const from = sanitizeMermaidId(entry.callerSymbolId.split(":").pop() ?? entry.callerSymbolId);
     const to = sanitizeMermaidId(entry.calledSymbolId.split(":").pop() ?? entry.calledSymbolId);
     const edge = `  ${from} --> ${to}`;
@@ -319,7 +427,200 @@ function buildMermaidFromCallChain(
     }
   }
 
-  return lines.join("\n");
+  if (chain.length > visibleEntryCount) {
+    lines.push(`%% call chain truncated (${chain.length - visibleEntryCount} hidden edge(s))`);
+  }
+
+  return finalizeMermaid(lines);
+}
+
+function pickPathLikeValue(item: Record<string, unknown>): string | undefined {
+  const candidates = ["path", "filePath", "relativePath", "id", "name"] as const;
+  for (const key of candidates) {
+    const value = item[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function toNodeId(rawId: string): string {
+  return sanitizeMermaidId(rawId);
+}
+
+function toNodeLabel(raw: string): string {
+  const normalized = raw.replaceAll("\\", "/");
+  const segments = normalized.split("/");
+  return segments.at(-1) ?? normalized;
+}
+
+function buildMermaidFromDependencyCheck(data: DependencyCheckLike): string | null {
+  const centerRaw = data.relativePath ?? data.filePath;
+  if (!centerRaw) return null;
+
+  const outgoing = data.outgoing?.dependencies ?? [];
+  const incoming = data.incoming?.referencingFiles ?? [];
+  if (outgoing.length === 0 && incoming.length === 0) {
+    return null;
+  }
+
+  const lines = ["graph LR"];
+  const nodes = new Map<string, string>();
+  const centerId = toNodeId(centerRaw);
+
+  nodes.set(centerRaw, centerId);
+  lines.push(`  ${centerId}["${escapeMermaidLabel(toNodeLabel(centerRaw))}"]`);
+
+  const visibleOutgoingCount = Math.min(outgoing.length, MAX_DEPENDENCY_RELATIONS);
+  for (let i = 0; i < visibleOutgoingCount; i += 1) {
+    const dep = outgoing[i];
+    const depPath = pickPathLikeValue(dep);
+    if (!depPath) continue;
+    const depId = toNodeId(depPath);
+    if (!nodes.has(depPath)) {
+      nodes.set(depPath, depId);
+      lines.push(`  ${depId}["${escapeMermaidLabel(toNodeLabel(depPath))}"]`);
+    }
+    lines.push(`  ${centerId} --> ${depId}`);
+  }
+
+  const visibleIncomingCount = Math.min(incoming.length, MAX_DEPENDENCY_RELATIONS);
+  for (let i = 0; i < visibleIncomingCount; i += 1) {
+    const ref = incoming[i];
+    const refPath = pickPathLikeValue(ref);
+    if (!refPath) continue;
+    const refId = toNodeId(refPath);
+    if (!nodes.has(refPath)) {
+      nodes.set(refPath, refId);
+      lines.push(`  ${refId}["${escapeMermaidLabel(toNodeLabel(refPath))}"]`);
+    }
+    lines.push(`  ${refId} --> ${centerId}`);
+  }
+
+  if (outgoing.length > visibleOutgoingCount) {
+    lines.push(`%% outgoing dependencies truncated (${outgoing.length - visibleOutgoingCount} hidden item(s))`);
+  }
+
+  if (incoming.length > visibleIncomingCount) {
+    lines.push(`%% incoming references truncated (${incoming.length - visibleIncomingCount} hidden item(s))`);
+  }
+
+  return finalizeMermaid(lines);
+}
+
+function toPrimitiveLabel(value: unknown): string {
+  switch (typeof value) {
+    case "string":
+      return value;
+    case "number":
+    case "bigint":
+    case "boolean":
+      return `${value}`;
+    case "undefined":
+      return "undefined";
+    case "symbol":
+      return value.description ?? "symbol";
+    default:
+      return value === null ? "null" : "value";
+  }
+}
+
+function summarizeValue(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return `array[${value.length}]`;
+  if (typeof value === "object") return "object";
+  return toPrimitiveLabel(value);
+}
+
+interface GenericMermaidState {
+  rootId: string;
+  nodeIndex: number;
+  nodeLines: string[];
+  edges: string[];
+}
+
+function createGenericMermaidState(): GenericMermaidState {
+  return {
+    rootId: "G0",
+    nodeIndex: 1,
+    nodeLines: [],
+    edges: [],
+  };
+}
+
+function pushGenericNode(state: GenericMermaidState, label: string): string {
+  const nodeId = `G${state.nodeIndex}`;
+  state.nodeIndex += 1;
+  state.nodeLines.push(`  ${nodeId}["${escapeMermaidLabel(label)}"]`);
+  return nodeId;
+}
+
+function addGenericEdge(state: GenericMermaidState, fromId: string, toId: string): void {
+  state.edges.push(`  ${fromId} --> ${toId}`);
+}
+
+function appendArrayNodes(state: GenericMermaidState, values: unknown[]): void {
+  const limit = Math.min(values.length, Math.min(MAX_GENERIC_ITEMS_PER_LEVEL, MAX_GENERIC_NODES));
+  for (let i = 0; i < limit; i += 1) {
+    const nodeId = pushGenericNode(state, `[${i}] ${summarizeValue(values[i])}`);
+    addGenericEdge(state, state.rootId, nodeId);
+  }
+  if (values.length > limit) {
+    const truncId = pushGenericNode(state, `… ${values.length - limit} more item(s)`);
+    addGenericEdge(state, state.rootId, truncId);
+  }
+}
+
+function appendNestedObjectNodes(
+  state: GenericMermaidState,
+  parentId: string,
+  value: Record<string, unknown>,
+): void {
+  const nestedEntries = Object.entries(value).slice(0, Math.max(0, MAX_GENERIC_ITEMS_PER_LEVEL - 5));
+  for (const [nestedKey, nestedValue] of nestedEntries) {
+    if (state.nodeIndex >= MAX_GENERIC_NODES) return;
+    const nestedId = pushGenericNode(state, `${nestedKey}: ${summarizeValue(nestedValue)}`);
+    addGenericEdge(state, parentId, nestedId);
+  }
+}
+
+function appendObjectNodes(state: GenericMermaidState, value: Record<string, unknown>): void {
+  const entries = Object.entries(value);
+  const limit = Math.min(entries.length, Math.min(MAX_GENERIC_ITEMS_PER_LEVEL, MAX_GENERIC_NODES));
+
+  for (let i = 0; i < limit; i += 1) {
+    const [key, entryValue] = entries[i];
+    const nodeId = pushGenericNode(state, `${key}: ${summarizeValue(entryValue)}`);
+    addGenericEdge(state, state.rootId, nodeId);
+
+    if (MAX_GENERIC_DEPTH > 1 && typeof entryValue === "object" && entryValue !== null && !Array.isArray(entryValue)) {
+      appendNestedObjectNodes(state, nodeId, entryValue as Record<string, unknown>);
+    }
+  }
+
+  if (entries.length > limit && state.nodeIndex < MAX_GENERIC_NODES) {
+    const truncId = pushGenericNode(state, `… ${entries.length - limit} more key(s)`);
+    addGenericEdge(state, state.rootId, truncId);
+  }
+}
+
+function buildMermaidFromGenericJson(data: unknown, command: string): string {
+  const lines = ["graph TD"];
+  const state = createGenericMermaidState();
+  lines.push(`  ${state.rootId}["${escapeMermaidLabel(command)}"]`);
+
+  if (Array.isArray(data)) {
+    appendArrayNodes(state, data);
+  } else if (typeof data === "object" && data !== null) {
+    appendObjectNodes(state, data as Record<string, unknown>);
+  } else {
+    const primitiveId = pushGenericNode(state, summarizeValue(data));
+    addGenericEdge(state, state.rootId, primitiveId);
+  }
+
+  lines.push(...state.nodeLines, ...state.edges);
+  return finalizeMermaid(lines);
 }
 
 // ============================================================================

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,6 +10,10 @@
  *   trace <sym>       Trace execution flow from a symbol
  *   explain <file>    Explain file logic
  *   path <file>       Crawl dependency graph from file
+ *   path-in <file>    List files that depend on a file
+ *   check-dependencies <file>  Check incoming and outgoing dependencies
+ *   cycles <file>     List confirmed dependency cycles involving file
+ *   architecture      Build full workspace architecture graph
  *   check <file>      Check for unused symbols
  *   serve             Launch MCP stdio server
  *   tool <name>       Invoke any MCP tool directly
@@ -49,6 +53,11 @@ Commands:
   trace <sym>       Trace execution flow: file.ts#FunctionName
   explain <file>    Analyze file logic (intra-file call hierarchy)
   path <file>       Crawl dependency graph from entry file
+  path-in <file>    Find incoming dependencies (who imports this file)
+  check-dependencies <file>
+                    Check incoming and outgoing dependencies for a file
+  cycles <file>     List confirmed dependency cycles for a file
+  architecture      Build full workspace architecture graph
   check <file>      Find unused exported symbols
   serve             Launch MCP stdio server (passthrough)
   tool <name>       Invoke any MCP tool: graph-it tool get_index_status
@@ -62,13 +71,13 @@ Options:
   --version, -v     Show version
 
 Output Format Availability:
-  Format    | scan | summary | trace | explain | path | check | tool
-  ----------|------|---------|-------|---------|------|-------|-----
-  text      |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |   ✓   |  ✓
-  json      |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |   ✓   |  ✓
-  toon      |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |   ✓   |  ✓
-  markdown  |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |   ✓   |  ✓
-  mermaid   |  —   |    —    |   ✓   |    —    |  ✓   |   —   |  —
+  Format    | scan | summary | trace | explain | path | architecture | check | tool
+  ----------|------|---------|-------|---------|------|--------------|-------|-----
+  text      |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |      ✓       |   ✓   |  ✓
+  json      |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |      ✓       |   ✓   |  ✓
+  toon      |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |      ✓       |   ✓   |  ✓
+  markdown  |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |      ✓       |   ✓   |  ✓
+  mermaid   |  ✓   |    ✓    |   ✓   |    ✓    |  ✓   |      ✓       |   ✓   |  ✓
 
 MCP Client Integration:
   Use "graph-it serve" as the MCP server command in any MCP-compatible client.
@@ -118,6 +127,11 @@ Examples:
   graph-it trace src/index.ts#main
   graph-it explain src/utils.ts
   graph-it path src/index.ts
+  graph-it path-in src/index.ts
+  graph-it check-dependencies src/index.ts
+  graph-it cycles src/index.ts
+  graph-it architecture
+  graph-it architecture --format mermaid
   graph-it check src/api.ts
   graph-it tool analyze_dependencies --filePath=/abs/path/file.ts
   graph-it update
@@ -272,6 +286,22 @@ async function dispatch(
     }
     case "path": {
       const { run } = await import("./commands/path.js");
+      return run(args, runtime, format);
+    }
+    case "path-in": {
+      const { run } = await import("./commands/pathIn.js");
+      return run(args, runtime, format);
+    }
+    case "check-dependencies": {
+      const { run } = await import("./commands/checkDependencies.js");
+      return run(args, runtime, format);
+    }
+    case "cycles": {
+      const { run } = await import("./commands/cycles.js");
+      return run(args, runtime, format);
+    }
+    case "architecture": {
+      const { run } = await import("./commands/architecture.js");
       return run(args, runtime, format);
     }
     case "check": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -137,6 +137,19 @@ function commandWantsHelp(command: string, commandArgs: string[], rawArgvSlice: 
 // Main
 // ============================================================================
 
+/** Handle the no-command case: launch REPL in TTY, print help otherwise. */
+async function handleNoCommand(values: Record<string, unknown>): Promise<void> {
+  if (process.stdin.isTTY) {
+    const workspaceRaw = (values.workspace as string | undefined) ?? process.cwd();
+    const workspaceRoot = findWorkspaceRoot(path.resolve(workspaceRaw));
+    const { run } = await import("./commands/repl.js");
+    await run(new CliRuntime(workspaceRoot));
+    process.exit(ExitCode.SUCCESS);
+  }
+  process.stdout.write(HELP);
+  process.exit(ExitCode.SUCCESS);
+}
+
 async function main(): Promise<void> {
   let parsedArgs: ReturnType<typeof parseArgs>;
 
@@ -172,8 +185,8 @@ async function main(): Promise<void> {
   const [command, ...commandArgs] = positionals;
 
   if (!command) {
-    process.stdout.write(HELP);
-    process.exit(ExitCode.SUCCESS);
+    await handleNoCommand(values);
+    return;
   }
 
   // Per-command --help dispatch (check both parsed positionals and raw argv flags)

--- a/src/cli/repl/fileSearch.ts
+++ b/src/cli/repl/fileSearch.ts
@@ -1,0 +1,31 @@
+/**
+ * REPL File Search
+ *
+ * Filters a list of absolute file paths by a case-insensitive substring query.
+ * Returns relative paths sorted alphabetically.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import * as path from 'node:path';
+
+/**
+ * Filter `files` (absolute paths) by `query` substring against relative paths.
+ *
+ * @param files - Absolute file paths from SourceFileCollector
+ * @param query - User-typed string (case-insensitive)
+ * @param workspaceRoot - Workspace root for computing relative paths
+ * @returns Sorted array of relative paths that match `query`
+ */
+export function filterFiles(
+  files: string[],
+  query: string,
+  workspaceRoot: string,
+): string[] {
+  const q = query.toLowerCase();
+  const matches = files
+    .map((f) => path.relative(workspaceRoot, f))
+    .filter((rel) => rel.toLowerCase().includes(q));
+  matches.sort((a, b) => a.localeCompare(b));
+  return matches;
+}

--- a/src/cli/repl/fileSearch.ts
+++ b/src/cli/repl/fileSearch.ts
@@ -8,6 +8,7 @@
  */
 
 import * as path from 'node:path';
+import { normalizePath } from '../../shared/path.js';
 
 /**
  * Filter `files` (absolute paths) by `query` substring against relative paths.
@@ -24,7 +25,7 @@ export function filterFiles(
 ): string[] {
   const q = query.toLowerCase();
   const matches = files
-    .map((f) => path.relative(workspaceRoot, f))
+    .map((f) => normalizePath(path.relative(workspaceRoot, f)))
     .filter((rel) => rel.toLowerCase().includes(q));
   matches.sort((a, b) => a.localeCompare(b));
   return matches;

--- a/src/cli/repl/prompts.ts
+++ b/src/cli/repl/prompts.ts
@@ -13,6 +13,7 @@ import { sanitizeTerminalText } from './terminal.js';
 import { normalizePath } from '../../shared/path.js';
 import * as path from 'node:path';
 import { filterFiles } from './fileSearch.js';
+import { getTip } from './tips.js';
 
 // ============================================================================
 // Action types
@@ -30,7 +31,18 @@ export type MainAction =
   | 'format'
   | 'help'
   | 'quit';
-export type PostResultAction = 'drillDown' | 'export' | 'saveToFile' | 'setFormat' | 'newAnalysis' | 'quit';
+export type PostResultAction =
+  | 'drillDown'
+  | 'export'
+  | 'saveToFile'
+  | 'setFormat'
+  | 'newAnalysis'
+  | 'followUpDeps'
+  | 'followUpCycles'
+  | 'followUpTrace'
+  | 'followUpDeadCode'
+  | 'followUpArchitecture'
+  | 'quit';
 export type ExportFormat = 'json' | 'markdown' | 'mermaid';
 
 export interface MainActionSelection {
@@ -46,6 +58,7 @@ interface PaletteEntry<TValue> {
   aliases: string[];
   keywords: string[];
   value: TValue;
+  group: string;
 }
 
 interface BrowserEntries {
@@ -78,56 +91,63 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     title: 'Trace a symbol or file',
     description: 'Select a file, then optionally drill into a symbol.',
     aliases: ['trace'],
-    keywords: ['symbol', 'call', 'flow', 'execution'],
+    keywords: ['symbol', 'call', 'flow', 'execution', 'developer', 'qa'],
     value: 'trace',
+    group: '🔍 Code Analysis',
   },
   {
     slash: '/path',
     title: 'Set workspace directory',
     description: 'Navigate directories and set the active workspace scope.',
     aliases: ['path', 'workspace'],
-    keywords: ['directory', 'root', 'scope', 'folder'],
+    keywords: ['directory', 'root', 'scope', 'folder', 'architect'],
     value: 'setPath',
+    group: '📐 Architecture',
   },
   {
     slash: '/check-dependencies',
     title: 'Check incoming & outgoing deps',
     description: 'Analyze both importers (in) and imports (out) for a file.',
     aliases: ['check-dependencies', 'deps', 'dependencies'],
-    keywords: ['incoming', 'outgoing', 'in', 'out', 'graph'],
+    keywords: ['incoming', 'outgoing', 'in', 'out', 'graph', 'developer', 'architect'],
     value: 'checkDependencies',
+    group: '🔍 Code Analysis',
   },
   {
     slash: '/cycles',
     title: 'List confirmed dependency cycles',
     description: 'Detect and list cycle chains that include the selected file.',
     aliases: ['cycles', 'cycle'],
-    keywords: ['circular', 'dependencies', 'loop'],
+    keywords: ['circular', 'dependencies', 'loop', 'security', 'qa'],
     value: 'cycles',
+    group: '🔍 Code Analysis',
   },
   {
     slash: '/summary',
     title: 'Summarize workspace or file',
     description: 'Show the current file summary when available, otherwise the workspace.',
     aliases: ['summary', 'codemap'],
-    keywords: ['overview', 'map', 'workspace'],
+    keywords: ['overview', 'map', 'workspace', 'architect', 'functional'],
     value: 'summary',
+    group: '📐 Architecture',
   },
   {
     slash: '/architecture',
     title: 'Build workspace architecture',
     description: 'Render the full project graph, including Mermaid when supported.',
     aliases: ['architecture', 'arch'],
-    keywords: ['workspace', 'mermaid', 'graph'],
+    keywords: ['workspace', 'mermaid', 'graph', 'architect'],
     value: 'architecture',
+    group: '📐 Architecture',
   },
   {
     slash: '/check',
     title: 'Find dead code',
     description: 'Inspect the current file or workspace for unused exports.',
     aliases: ['check', 'unused'],
-    keywords: ['dead', 'unused', 'analysis'],
+    keywords: ['dead', 'unused', 'analysis', 'security', 'qa'],
     value: 'check',
+    group: '🔍 Code Analysis',
   },
   {
     slash: '/command',
@@ -136,6 +156,7 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     aliases: ['command', 'raw'],
     keywords: ['cli', 'manual', 'freeform'],
     value: 'command',
+    group: '⚙ Session',
   },
   {
     slash: '/file',
@@ -144,6 +165,7 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     aliases: ['file', 'context'],
     keywords: ['current', 'active', 'path'],
     value: 'command',
+    group: '⚙ Session',
   },
   {
     slash: '/format',
@@ -152,6 +174,7 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     aliases: ['format'],
     keywords: ['text', 'json', 'markdown', 'toon', 'mermaid'],
     value: 'format',
+    group: '⚙ Session',
   },
   {
     slash: '/help',
@@ -160,6 +183,7 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     aliases: ['help'],
     keywords: ['commands', 'examples', 'tips'],
     value: 'help',
+    group: '⚙ Session',
   },
   {
     slash: '/quit',
@@ -168,6 +192,7 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     aliases: ['quit', 'exit'],
     keywords: ['leave', 'close'],
     value: 'quit',
+    group: '⚙ Session',
   },
 ];
 
@@ -179,6 +204,7 @@ const POST_RESULT_ENTRIES: PaletteEntry<PostResultAction>[] = [
     aliases: ['drill-down', 'drill'],
     keywords: ['symbol', 'node', 'trace'],
     value: 'drillDown',
+    group: '🔍 Analysis',
   },
   {
     slash: '/export',
@@ -187,6 +213,7 @@ const POST_RESULT_ENTRIES: PaletteEntry<PostResultAction>[] = [
     aliases: ['export'],
     keywords: ['json', 'markdown', 'mermaid'],
     value: 'export',
+    group: '💾 Save',
   },
   {
     slash: '/save',
@@ -195,9 +222,11 @@ const POST_RESULT_ENTRIES: PaletteEntry<PostResultAction>[] = [
     aliases: ['save'],
     keywords: ['file', 'write'],
     value: 'saveToFile',
+    group: '💾 Save',
   },
   {
     slash: '/format',
+    group: '⚙ Session',
     title: 'Change default format',
     description: 'Update the session default rendering format.',
     aliases: ['format'],
@@ -211,6 +240,7 @@ const POST_RESULT_ENTRIES: PaletteEntry<PostResultAction>[] = [
     aliases: ['again', 'new'],
     keywords: ['analysis', 'back'],
     value: 'newAnalysis',
+    group: '⚙ Session',
   },
   {
     slash: '/quit',
@@ -219,8 +249,53 @@ const POST_RESULT_ENTRIES: PaletteEntry<PostResultAction>[] = [
     aliases: ['quit', 'exit'],
     keywords: ['leave', 'close'],
     value: 'quit',
+    group: '⚙ Session',
   },
 ];
+
+/** Contextual follow-up entries keyed by last command. */
+const FOLLOW_UP_ENTRIES: Record<string, PaletteEntry<PostResultAction>[]> = {
+  'trace': [
+    { slash: '/→ check-dependencies', title: 'Check who depends on this file', description: 'See incoming and outgoing imports for the traced file.', aliases: [], keywords: [], value: 'followUpDeps', group: '🔍 Follow-up' },
+    { slash: '/→ cycles',            title: 'Find circular dependencies',   description: 'Detect cycles that include the traced file.',          aliases: [], keywords: [], value: 'followUpCycles', group: '🔍 Follow-up' },
+  ],
+  'explain': [
+    { slash: '/→ check-dependencies', title: 'Check who depends on this file', description: 'See incoming and outgoing imports for this file.',       aliases: [], keywords: [], value: 'followUpDeps', group: '🔍 Follow-up' },
+    { slash: '/→ cycles',            title: 'Find circular dependencies',   description: 'Detect cycles that include this file.',                  aliases: [], keywords: [], value: 'followUpCycles', group: '🔍 Follow-up' },
+  ],
+  'check-dependencies': [
+    { slash: '/→ trace',  title: 'Trace a symbol in this file', description: 'Dive into a specific symbol\'s execution path.', aliases: [], keywords: [], value: 'followUpTrace', group: '🔍 Follow-up' },
+    { slash: '/→ cycles', title: 'Find circular dependencies',  description: 'Detect cycles involving this file.',              aliases: [], keywords: [], value: 'followUpCycles', group: '🔍 Follow-up' },
+  ],
+  'cycles': [
+    { slash: '/→ check-dependencies', title: 'Check file dependencies',  description: 'See all imports for a file in the cycle.',    aliases: [], keywords: [], value: 'followUpDeps',     group: '🔍 Follow-up' },
+    { slash: '/→ check',              title: 'Find dead code',            description: 'Detect unused exports in the cycle members.', aliases: [], keywords: [], value: 'followUpDeadCode', group: '🔍 Follow-up' },
+  ],
+  'architecture': [
+    { slash: '/→ check', title: 'Find dead code across workspace', description: 'Detect unused exports after mapping the graph.',        aliases: [], keywords: [], value: 'followUpDeadCode',     group: '🔍 Follow-up' },
+    { slash: '/→ trace', title: 'Trace a symbol',                  description: 'Drill into a specific file\'s execution flow.',           aliases: [], keywords: [], value: 'followUpTrace',        group: '🔍 Follow-up' },
+  ],
+  'check': [
+    { slash: '/→ architecture',       title: 'Build workspace architecture', description: 'Map the full dependency graph.',                       aliases: [], keywords: [], value: 'followUpArchitecture', group: '🔍 Follow-up' },
+    { slash: '/→ check-dependencies', title: 'Check file dependencies',      description: 'See incoming and outgoing imports for a flagged file.', aliases: [], keywords: [], value: 'followUpDeps',         group: '🔍 Follow-up' },
+  ],
+  'summary': [
+    { slash: '/→ architecture', title: 'Build workspace architecture', description: 'Get the full project dependency map.',         aliases: [], keywords: [], value: 'followUpArchitecture', group: '🔍 Follow-up' },
+    { slash: '/→ trace',        title: 'Trace a symbol',              description: 'Follow the execution flow from a key symbol.', aliases: [], keywords: [], value: 'followUpTrace',        group: '🔍 Follow-up' },
+  ],
+  'path': [
+    { slash: '/→ check-dependencies', title: 'Check full deps (in + out)', description: 'See both import directions for the entry file.', aliases: [], keywords: [], value: 'followUpDeps',   group: '🔍 Follow-up' },
+    { slash: '/→ cycles',             title: 'Find circular dependencies', description: 'Detect cycles in the dependency graph.',       aliases: [], keywords: [], value: 'followUpCycles', group: '🔍 Follow-up' },
+  ],
+};
+
+/**
+ * Return contextual follow-up palette entries for a given command result.
+ * Returns [] for unknown commands.
+ */
+export function buildContextualPostResultEntries(command: string): PaletteEntry<PostResultAction>[] {
+  return FOLLOW_UP_ENTRIES[command] ?? [];
+}
 
 function normalizePaletteQuery(input: string | undefined): string {
   return (input ?? '').trim().toLowerCase();
@@ -243,11 +318,13 @@ function scorePaletteEntry<TValue>(entry: PaletteEntry<TValue>, query: string): 
   const haystack = [entry.title, entry.description, ...entry.aliases, ...entry.keywords]
     .join(' ')
     .toLowerCase();
-  return haystack.includes(query) ? 10 : Number.POSITIVE_INFINITY;
+  const bareQuery = query.startsWith('/') ? query.slice(1) : query;
+  return haystack.includes(bareQuery) ? 10 : Number.POSITIVE_INFINITY;
 }
 
-function renderPaletteLabel<TValue>(entry: PaletteEntry<TValue>): string {
-  return `${entry.slash.padEnd(14)} ${entry.title} — ${entry.description}`;
+function renderPaletteLabel<TValue>(entry: PaletteEntry<TValue>, showGroup = false): string {
+  const groupSuffix = showGroup ? `  [${entry.group}]` : '';
+  return `${entry.slash.padEnd(22)} ${entry.title} — ${entry.description}${groupSuffix}`;
 }
 
 function filterPaletteEntries<TValue>(
@@ -266,6 +343,22 @@ function filterPaletteEntries<TValue>(
     .map(({ entry }) => entry);
 }
 
+/** Insert disabled group-header separators between groups when showing the full palette (query = '/'). */
+function injectGroupSeparators<TValue>(
+  entries: PaletteEntry<TValue>[],
+): Array<{ name: string; value: TValue; disabled?: boolean }> {
+  const result: Array<{ name: string; value: TValue; disabled?: boolean }> = [];
+  let lastGroup = '';
+  for (const entry of entries) {
+    if (entry.group !== lastGroup) {
+      result.push({ name: `── ${entry.group} ──`, value: entry.value, disabled: true });
+      lastGroup = entry.group;
+    }
+    result.push({ name: renderPaletteLabel(entry), value: entry.value });
+  }
+  return result;
+}
+
 function shouldOfferTypedCommand(trimmedInput: string): boolean {
   return trimmedInput.startsWith('/');
 }
@@ -273,15 +366,35 @@ function shouldOfferTypedCommand(trimmedInput: string): boolean {
 export function buildMainActionChoices(input?: string): Array<{
   name: string;
   value: MainActionSelection;
+  disabled?: boolean;
 }> {
   const trimmed = (input ?? '').trim();
-  const matchedEntries = filterPaletteEntries(MAIN_ACTION_ENTRIES, input).slice(0, 8);
-  const choices: Array<{ name: string; value: MainActionSelection }> = matchedEntries.map((entry) => ({
-    name: renderPaletteLabel(entry),
-    value: entry.value === 'quit'
-      ? ({ kind: 'quit' } satisfies MainActionSelection)
-      : ({ kind: 'action', action: entry.value } satisfies MainActionSelection),
-  }));
+  const isShowAll = !trimmed || trimmed === '/';
+  const matchedEntries = filterPaletteEntries(MAIN_ACTION_ENTRIES, input).slice(0, 12);
+
+  let choices: Array<{ name: string; value: MainActionSelection; disabled?: boolean }>;
+
+  if (isShowAll) {
+    // Insert group separators between sections
+    choices = injectGroupSeparators(matchedEntries).map((c) => ({
+      ...c,
+      value: (() => {
+        if (c.disabled) return { kind: 'action', action: 'help' } satisfies MainActionSelection;
+        const entry = matchedEntries.find((e) => renderPaletteLabel(e) === c.name);
+        if (!entry) return { kind: 'action', action: 'help' } satisfies MainActionSelection;
+        return entry.value === 'quit'
+          ? ({ kind: 'quit' } satisfies MainActionSelection)
+          : ({ kind: 'action', action: entry.value } satisfies MainActionSelection);
+      })(),
+    }));
+  } else {
+    choices = matchedEntries.map((entry) => ({
+      name: renderPaletteLabel(entry),
+      value: entry.value === 'quit'
+        ? ({ kind: 'quit' } satisfies MainActionSelection)
+        : ({ kind: 'action', action: entry.value } satisfies MainActionSelection),
+    }));
+  }
 
   if (trimmed && trimmed !== '/' && shouldOfferTypedCommand(trimmed)) {
     const preview = sanitizeTerminalText(trimmed, 96);
@@ -294,13 +407,23 @@ export function buildMainActionChoices(input?: string): Array<{
   return choices;
 }
 
-export function buildPostResultChoices(input?: string): Array<{
-  name: string;
-  value: PostResultAction;
-}> {
-  return filterPaletteEntries(POST_RESULT_ENTRIES, input)
-    .slice(0, 8)
-    .map((entry) => ({ name: renderPaletteLabel(entry), value: entry.value }));
+export function buildPostResultChoices(
+  input?: string,
+  command?: string,
+): Array<{ name: string; value: PostResultAction; disabled?: boolean }> {
+  const contextual = command ? buildContextualPostResultEntries(command) : [];
+  const standard = filterPaletteEntries(POST_RESULT_ENTRIES, input).slice(0, 8);
+
+  const filteredContextual = input && input !== '/'
+    ? contextual.filter((e) => {
+        const q = normalizePaletteQuery(input);
+        const haystack = [e.title, e.description].join(' ').toLowerCase();
+        return haystack.includes(q);
+      })
+    : contextual;
+
+  const all = [...filteredContextual, ...standard];
+  return all.map((entry) => ({ name: renderPaletteLabel(entry), value: entry.value }));
 }
 
 // ============================================================================
@@ -324,48 +447,56 @@ export async function selectMainAction(message = 'Type / to browse commands'): P
 export async function searchFile(
   allFiles: string[],
   workspaceRoot: string,
+  recentFiles: string[] = [],
+  tipKey?: string,
+  tipCounter = 0,
 ): Promise<string> {
   const relativeFiles = allFiles
     .map((absPath) => normalizePath(path.relative(workspaceRoot, absPath)))
     .sort((left, right) => left.localeCompare(right));
 
+  const tip = tipKey ? getTip(tipKey, tipCounter) : '';
+  const tipLine = tip ? `\n  💡 ${tip}` : '';
+
   let currentDirectory = '';
 
   for (;;) {
-    const choices = buildFileBrowserChoices(relativeFiles, currentDirectory);
+    const choices = buildFileBrowserChoices(relativeFiles, currentDirectory, recentFiles);
     const location = currentDirectory || '.';
+    const message = `Browse files (${location})${currentDirectory ? '' : tipLine}`;
 
-    const selected = await select<string>({
-      message: `Browse files (${location})`,
-      choices,
-    });
+    const selected = await select<string>({ message, choices });
+    const next = await resolveFileBrowserSelection(selected, relativeFiles, currentDirectory);
 
-    if (selected === '__jump__') {
-      const jumpResult = await handleJumpSelection(relativeFiles, currentDirectory);
-      if (jumpResult.filePath) {
-        return jumpResult.filePath;
-      }
-      if (jumpResult.nextDirectory !== undefined) {
-        currentDirectory = jumpResult.nextDirectory;
-        continue;
-      }
-      continue;
-    }
-
-    if (selected === '__up__') {
-      currentDirectory = parentDirectoryOf(currentDirectory);
-      continue;
-    }
-
-    if (selected.startsWith('dir:')) {
-      currentDirectory = selected.slice('dir:'.length);
-      continue;
-    }
-
-    if (selected.startsWith('file:')) {
-      return selected.slice('file:'.length);
-    }
+    if (next.filePath !== undefined) return next.filePath;
+    if (next.nextDirectory !== undefined) currentDirectory = next.nextDirectory;
   }
+}
+
+async function resolveFileBrowserSelection(
+  selected: string,
+  relativeFiles: string[],
+  currentDirectory: string,
+): Promise<{ filePath?: string; nextDirectory?: string }> {
+  if (selected === '__jump__') {
+    const jumpResult = await handleJumpSelection(relativeFiles, currentDirectory);
+    return jumpResult;
+  }
+
+  if (selected === '__up__') {
+    return { nextDirectory: parentDirectoryOf(currentDirectory) };
+  }
+
+  if (selected.startsWith('dir:')) {
+    return { nextDirectory: selected.slice('dir:'.length) };
+  }
+
+  if (selected.startsWith('file:')) {
+    return { filePath: selected.slice('file:'.length) };
+  }
+
+  // Disabled separators and unknown values — stay in current directory
+  return { nextDirectory: currentDirectory };
 }
 
 /**
@@ -607,6 +738,7 @@ function listSubdirectories(
 export function buildFileBrowserChoices(
   relativeFiles: string[],
   currentDirectory: string,
+  recentFiles: string[] = [],
 ): FileBrowserChoice[] {
   const { directories, files } = listDirectoryEntries(relativeFiles, currentDirectory);
   const choices: FileBrowserChoice[] = [
@@ -615,6 +747,20 @@ export function buildFileBrowserChoices(
       value: '__jump__',
     },
   ];
+
+  // Recent files section (only show at root level)
+  const visibleRecent = recentFiles.filter((f) => !currentDirectory || f.startsWith(`${currentDirectory}/`));
+  if (visibleRecent.length > 0 && !currentDirectory) {
+    choices.push({ name: '─── Recent ───', value: '__recent_sep__', disabled: true });
+    for (const recentRel of visibleRecent) {
+      const basename = recentRel.split('/').at(-1) ?? recentRel;
+      choices.push({
+        name: `★ ${sanitizeTerminalText(basename, 80)}  ${sanitizeTerminalText(recentRel, 160)}`,
+        value: `file:${recentRel}`,
+      });
+    }
+    choices.push({ name: '─── All files ───', value: '__all_sep__', disabled: true });
+  }
 
   if (currentDirectory) {
     choices.push({
@@ -709,16 +855,142 @@ export async function inputSymbol(
   defaultSymbol = '',
 ): Promise<string> {
   return input({
-    message: `Symbol to analyze in ${displayPath} (leave empty for full-file analysis)`,
+    message: `Symbol to analyze in ${displayPath} · e.g. MyClass, processRequest, handleClick (leave empty for full-file)`,
     default: defaultSymbol,
   });
 }
 
-/** Post-result menu. */
-export async function selectPostResultAction(message = 'Type / for next actions'): Promise<PostResultAction> {
+/**
+ * Symbol selector with autocomplete when symbols are available.
+ * Falls back to plain text input when the symbol list is empty.
+ *
+ * @param displayPath  - Relative path shown in the prompt label
+ * @param symbols      - Candidate symbol names extracted from the file's AST (may be empty)
+ * @param tipCounter   - Session tip counter for deterministic tip rotation
+ * @param defaultSymbol - Pre-filled default (last used symbol)
+ */
+export async function selectOrInputSymbol(
+  displayPath: string,
+  symbols: string[],
+  tipCounter = 0,
+  defaultSymbol = '',
+): Promise<string> {
+  const tip = getTip('trace.symbol', tipCounter);
+  const msgSuffix = tip ? `\n  💡 ${tip}` : '';
+
+  if (symbols.length === 0) {
+    return input({
+      message: `Symbol to analyze in ${displayPath} · e.g. MyClass, handleClick (empty = full-file)${msgSuffix}`,
+      default: defaultSymbol,
+    });
+  }
+
+  const symbolChoices = [
+    { name: '(full-file analysis)', value: '' },
+    ...symbols.map((s) => ({ name: s, value: s })),
+  ];
+
+  return search<string>({
+    message: `Symbol in ${displayPath} — type to filter · Enter for full-file${msgSuffix}`,
+    source: async (inp) => {
+      if (!inp) return symbolChoices;
+      const q = inp.toLowerCase();
+      return symbolChoices.filter((c) => c.name.toLowerCase().includes(q));
+    },
+  });
+}
+
+// ============================================================================
+// Option configurators (always shown, Enter = accept pre-selected default)
+// ============================================================================
+
+export interface TraceOptions {
+  maxDepth: number | undefined;
+}
+
+/**
+ * Ask the user for trace depth. Pre-selects 10 (sensible default).
+ * User can press Enter immediately to accept without thinking.
+ */
+export async function askTraceOptions(tipCounter = 0): Promise<TraceOptions> {
+  const tip = getTip('trace.file', tipCounter);
+  const msgSuffix = tip ? `\n  💡 ${tip}` : '';
+
+  const depthValue = await select<string>({
+    message: `Trace depth (Enter to accept default)${msgSuffix}`,
+    choices: [
+      { name: '3  — surface-level calls',    value: '3' },
+      { name: '5  — moderate depth',         value: '5' },
+      { name: '10 — standard (recommended)', value: '10' },
+      { name: '20 — deep analysis',          value: '20' },
+      { name: 'Unlimited — full traversal',  value: 'unlimited' },
+    ],
+    default: '10',
+  });
+
+  return { maxDepth: depthValue === 'unlimited' ? undefined : Number.parseInt(depthValue, 10) };
+}
+
+export interface ArchitectureOptions {
+  maxFiles: number | undefined;
+}
+
+/**
+ * Ask the user for the architecture file cap.
+ * Pre-selects "All" — user can press Enter to accept.
+ */
+export async function askArchitectureOptions(tipCounter = 0): Promise<ArchitectureOptions> {
+  const tip = getTip('architecture.start', tipCounter);
+  const msgSuffix = tip ? `\n  💡 ${tip}` : '';
+
+  const value = await select<string>({
+    message: `Files to include in architecture map (Enter to accept default)${msgSuffix}`,
+    choices: [
+      { name: '100  — fast preview',          value: '100' },
+      { name: '500  — medium workspace',       value: '500' },
+      { name: 'All  — full workspace (recommended)', value: 'all' },
+    ],
+    default: 'all',
+  });
+
+  return { maxFiles: value === 'all' ? undefined : Number.parseInt(value, 10) };
+}
+
+export type CheckDepsDirection = 'both' | 'outgoing' | 'incoming';
+
+export interface CheckDepsOptions {
+  direction: CheckDepsDirection;
+}
+
+/**
+ * Ask the user which dependency direction to analyse.
+ * Pre-selects "Both" — user can press Enter to accept.
+ */
+export async function askCheckDepsOptions(tipCounter = 0): Promise<CheckDepsOptions> {
+  const tip = getTip('checkDeps.file', tipCounter);
+  const msgSuffix = tip ? `\n  💡 ${tip}` : '';
+
+  const direction = await select<CheckDepsDirection>({
+    message: `Dependency direction to analyze (Enter to accept default)${msgSuffix}`,
+    choices: [
+      { name: 'Both  — incoming + outgoing (recommended)', value: 'both' },
+      { name: 'Outgoing only — what this file imports',    value: 'outgoing' },
+      { name: 'Incoming only — who imports this file',     value: 'incoming' },
+    ],
+    default: 'both',
+  });
+
+  return { direction };
+}
+
+/** Post-result menu. Accepts the last command name to inject contextual follow-up suggestions. */
+export async function selectPostResultAction(
+  message = 'Type / for next actions',
+  command?: string,
+): Promise<PostResultAction> {
   return search<PostResultAction>({
     message,
-    source: async (input) => buildPostResultChoices(input),
+    source: async (inp) => buildPostResultChoices(inp, command),
   });
 }
 

--- a/src/cli/repl/prompts.ts
+++ b/src/cli/repl/prompts.ts
@@ -61,10 +61,13 @@ export async function searchFile(
  *
  * @param displayPath - Relative path shown in the prompt label
  */
-export async function inputSymbol(displayPath: string): Promise<string> {
+export async function inputSymbol(
+  displayPath: string,
+  defaultSymbol = '',
+): Promise<string> {
   return input({
     message: `Symbol to analyse in ${displayPath} (leave empty for whole file)`,
-    default: '',
+    default: defaultSymbol,
   });
 }
 

--- a/src/cli/repl/prompts.ts
+++ b/src/cli/repl/prompts.ts
@@ -1,0 +1,99 @@
+/**
+ * REPL Prompts
+ *
+ * All @inquirer/prompts questions used by the REPL, centralised here
+ * so each can be updated independently from the REPL loop.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import { confirm, input, search, select } from '@inquirer/prompts';
+import { filterFiles } from './fileSearch.js';
+
+// ============================================================================
+// Action types
+// ============================================================================
+
+export type MainAction = 'trace' | 'path' | 'check' | 'summary' | 'quit';
+export type PostResultAction = 'drillDown' | 'export' | 'newAnalysis' | 'quit';
+export type ExportFormat = 'json' | 'markdown' | 'mermaid';
+
+// ============================================================================
+// Prompts
+// ============================================================================
+
+/** Main menu: what would you like to do? */
+export async function selectMainAction(): Promise<MainAction> {
+  return select<MainAction>({
+    message: 'Que voulez-vous faire ?',
+    choices: [
+      { name: 'Analyser un fichier ou symbole', value: 'trace' },
+      { name: "Cartographier les dépendances d'un fichier", value: 'path' },
+      { name: 'Trouver du code mort', value: 'check' },
+      { name: 'Résumé du workspace', value: 'summary' },
+      { name: 'Quitter', value: 'quit' },
+    ],
+  });
+}
+
+/**
+ * File fuzzy-search: type to filter, pick from live list.
+ *
+ * @param allFiles - Absolute paths from SourceFileCollector
+ * @param workspaceRoot - Root for computing relative display paths
+ */
+export async function searchFile(
+  allFiles: string[],
+  workspaceRoot: string,
+): Promise<string> {
+  return search<string>({
+    message: 'Rechercher un fichier',
+    source: async (input) => {
+      const matches = filterFiles(allFiles, input ?? '', workspaceRoot);
+      return matches.slice(0, 20).map((rel) => ({ name: rel, value: rel }));
+    },
+  });
+}
+
+/**
+ * Optional symbol input after file selection.
+ * Empty answer means "analyse the whole file".
+ *
+ * @param displayPath - Relative path shown in the prompt label
+ */
+export async function inputSymbol(displayPath: string): Promise<string> {
+  return input({
+    message: `Symbole à analyser dans ${displayPath} (laisser vide = tout le fichier)`,
+    default: '',
+  });
+}
+
+/** Post-result menu. */
+export async function selectPostResultAction(): Promise<PostResultAction> {
+  return select<PostResultAction>({
+    message: 'Que faire ensuite ?',
+    choices: [
+      { name: 'Explorer un nœud de ce graphe', value: 'drillDown' },
+      { name: 'Exporter (json / markdown / mermaid)', value: 'export' },
+      { name: 'Nouvelle analyse', value: 'newAnalysis' },
+      { name: 'Quitter', value: 'quit' },
+    ],
+  });
+}
+
+/** Export format selector. */
+export async function selectExportFormat(): Promise<ExportFormat> {
+  return select<ExportFormat>({
+    message: "Format d'export",
+    choices: [
+      { name: 'JSON', value: 'json' },
+      { name: 'Markdown', value: 'markdown' },
+      { name: 'Mermaid', value: 'mermaid' },
+    ],
+  });
+}
+
+/** Offer to re-index when the workspace has no index yet. */
+export async function confirmScan(reason: string): Promise<boolean> {
+  return confirm({ message: `${reason} Scanner maintenant ?`, default: true });
+}

--- a/src/cli/repl/prompts.ts
+++ b/src/cli/repl/prompts.ts
@@ -8,31 +8,310 @@
  */
 
 import { confirm, input, search, select } from '@inquirer/prompts';
+import type { CliOutputFormat } from '../formatter.js';
+import { sanitizeTerminalText } from './terminal.js';
+import { normalizePath } from '../../shared/path.js';
+import * as path from 'node:path';
 import { filterFiles } from './fileSearch.js';
 
 // ============================================================================
 // Action types
 // ============================================================================
 
-export type MainAction = 'trace' | 'path' | 'check' | 'summary' | 'quit';
-export type PostResultAction = 'drillDown' | 'export' | 'newAnalysis' | 'quit';
+export type MainAction =
+  | 'trace'
+  | 'command'
+  | 'setPath'
+  | 'checkDependencies'
+  | 'cycles'
+  | 'check'
+  | 'summary'
+  | 'architecture'
+  | 'format'
+  | 'help'
+  | 'quit';
+export type PostResultAction = 'drillDown' | 'export' | 'saveToFile' | 'setFormat' | 'newAnalysis' | 'quit';
 export type ExportFormat = 'json' | 'markdown' | 'mermaid';
+
+export interface MainActionSelection {
+  kind: 'action' | 'typed' | 'quit';
+  action?: MainAction;
+  commandLine?: string;
+}
+
+interface PaletteEntry<TValue> {
+  slash: string;
+  title: string;
+  description: string;
+  aliases: string[];
+  keywords: string[];
+  value: TValue;
+}
+
+interface BrowserEntries {
+  directories: string[];
+  files: string[];
+}
+
+interface FileBrowserChoice {
+  name: string;
+  value: string;
+  disabled?: boolean;
+}
+
+interface DirectoryBrowserChoice {
+  name: string;
+  value: string;
+}
+
+type JumpResolution =
+  | { kind: 'file'; value: string }
+  | { kind: 'directory'; value: string }
+  | { kind: 'none'; suggestions: string[] };
+
+const FILE_BROWSER_MAX_FILES = 60;
+const FILE_BROWSER_MAX_SUGGESTIONS = 5;
+
+const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
+  {
+    slash: '/trace',
+    title: 'Trace a symbol or file',
+    description: 'Select a file, then optionally drill into a symbol.',
+    aliases: ['trace'],
+    keywords: ['symbol', 'call', 'flow', 'execution'],
+    value: 'trace',
+  },
+  {
+    slash: '/path',
+    title: 'Set workspace directory',
+    description: 'Navigate directories and set the active workspace scope.',
+    aliases: ['path', 'workspace'],
+    keywords: ['directory', 'root', 'scope', 'folder'],
+    value: 'setPath',
+  },
+  {
+    slash: '/check-dependencies',
+    title: 'Check incoming & outgoing deps',
+    description: 'Analyze both importers (in) and imports (out) for a file.',
+    aliases: ['check-dependencies', 'deps', 'dependencies'],
+    keywords: ['incoming', 'outgoing', 'in', 'out', 'graph'],
+    value: 'checkDependencies',
+  },
+  {
+    slash: '/cycles',
+    title: 'List confirmed dependency cycles',
+    description: 'Detect and list cycle chains that include the selected file.',
+    aliases: ['cycles', 'cycle'],
+    keywords: ['circular', 'dependencies', 'loop'],
+    value: 'cycles',
+  },
+  {
+    slash: '/summary',
+    title: 'Summarize workspace or file',
+    description: 'Show the current file summary when available, otherwise the workspace.',
+    aliases: ['summary', 'codemap'],
+    keywords: ['overview', 'map', 'workspace'],
+    value: 'summary',
+  },
+  {
+    slash: '/architecture',
+    title: 'Build workspace architecture',
+    description: 'Render the full project graph, including Mermaid when supported.',
+    aliases: ['architecture', 'arch'],
+    keywords: ['workspace', 'mermaid', 'graph'],
+    value: 'architecture',
+  },
+  {
+    slash: '/check',
+    title: 'Find dead code',
+    description: 'Inspect the current file or workspace for unused exports.',
+    aliases: ['check', 'unused'],
+    keywords: ['dead', 'unused', 'analysis'],
+    value: 'check',
+  },
+  {
+    slash: '/command',
+    title: 'Run a raw command line',
+    description: 'Type a full CLI command such as /path-in file.ts or /trace file.ts#fn.',
+    aliases: ['command', 'raw'],
+    keywords: ['cli', 'manual', 'freeform'],
+    value: 'command',
+  },
+  {
+    slash: '/file',
+    title: 'Set current file context',
+    description: 'Set the active file used by /summary and /check when no file is provided.',
+    aliases: ['file', 'context'],
+    keywords: ['current', 'active', 'path'],
+    value: 'command',
+  },
+  {
+    slash: '/format',
+    title: 'Change default format',
+    description: 'Pick the default REPL rendering format for the current session.',
+    aliases: ['format'],
+    keywords: ['text', 'json', 'markdown', 'toon', 'mermaid'],
+    value: 'format',
+  },
+  {
+    slash: '/help',
+    title: 'Show REPL help',
+    description: 'Display common slash commands and examples.',
+    aliases: ['help'],
+    keywords: ['commands', 'examples', 'tips'],
+    value: 'help',
+  },
+  {
+    slash: '/quit',
+    title: 'Quit the REPL',
+    description: 'Exit the interactive session.',
+    aliases: ['quit', 'exit'],
+    keywords: ['leave', 'close'],
+    value: 'quit',
+  },
+];
+
+const POST_RESULT_ENTRIES: PaletteEntry<PostResultAction>[] = [
+  {
+    slash: '/drill-down',
+    title: 'Drill into the current node',
+    description: 'Jump deeper into the current file or symbol context.',
+    aliases: ['drill-down', 'drill'],
+    keywords: ['symbol', 'node', 'trace'],
+    value: 'drillDown',
+  },
+  {
+    slash: '/export',
+    title: 'Export in another format',
+    description: 'Render the current structured result as JSON, Markdown, or Mermaid.',
+    aliases: ['export'],
+    keywords: ['json', 'markdown', 'mermaid'],
+    value: 'export',
+  },
+  {
+    slash: '/save',
+    title: 'Save current result to a file',
+    description: 'Write the visible output to a safe path inside the workspace.',
+    aliases: ['save'],
+    keywords: ['file', 'write'],
+    value: 'saveToFile',
+  },
+  {
+    slash: '/format',
+    title: 'Change default format',
+    description: 'Update the session default rendering format.',
+    aliases: ['format'],
+    keywords: ['text', 'json', 'markdown', 'toon', 'mermaid'],
+    value: 'setFormat',
+  },
+  {
+    slash: '/again',
+    title: 'Start a new analysis',
+    description: 'Return to the main palette for another action.',
+    aliases: ['again', 'new'],
+    keywords: ['analysis', 'back'],
+    value: 'newAnalysis',
+  },
+  {
+    slash: '/quit',
+    title: 'Quit the REPL',
+    description: 'Exit the interactive session.',
+    aliases: ['quit', 'exit'],
+    keywords: ['leave', 'close'],
+    value: 'quit',
+  },
+];
+
+function normalizePaletteQuery(input: string | undefined): string {
+  return (input ?? '').trim().toLowerCase();
+}
+
+function isSlashPaletteQuery(input: string | undefined): boolean {
+  return normalizePaletteQuery(input).startsWith('/');
+}
+
+function scorePaletteEntry<TValue>(entry: PaletteEntry<TValue>, query: string): number {
+  if (!query || query === '/') return 0;
+
+  const normalizedSlash = entry.slash.toLowerCase();
+  const normalizedQuery = query.startsWith('/') ? query : `/${query}`;
+  if (normalizedSlash === normalizedQuery) return 0;
+  if (normalizedSlash.startsWith(normalizedQuery)) return 1;
+  if (entry.aliases.some((alias) => alias.toLowerCase() === query)) return 2;
+  if (entry.aliases.some((alias) => alias.toLowerCase().startsWith(query))) return 3;
+
+  const haystack = [entry.title, entry.description, ...entry.aliases, ...entry.keywords]
+    .join(' ')
+    .toLowerCase();
+  return haystack.includes(query) ? 10 : Number.POSITIVE_INFINITY;
+}
+
+function renderPaletteLabel<TValue>(entry: PaletteEntry<TValue>): string {
+  return `${entry.slash.padEnd(14)} ${entry.title} — ${entry.description}`;
+}
+
+function filterPaletteEntries<TValue>(
+  entries: PaletteEntry<TValue>[],
+  input?: string,
+): PaletteEntry<TValue>[] {
+  if (!isSlashPaletteQuery(input)) {
+    return [];
+  }
+
+  const query = normalizePaletteQuery(input);
+  return entries
+    .map((entry) => ({ entry, score: scorePaletteEntry(entry, query) }))
+    .filter(({ score }) => score !== Number.POSITIVE_INFINITY)
+    .sort((left, right) => left.score - right.score || left.entry.slash.localeCompare(right.entry.slash))
+    .map(({ entry }) => entry);
+}
+
+function shouldOfferTypedCommand(trimmedInput: string): boolean {
+  return trimmedInput.startsWith('/');
+}
+
+export function buildMainActionChoices(input?: string): Array<{
+  name: string;
+  value: MainActionSelection;
+}> {
+  const trimmed = (input ?? '').trim();
+  const matchedEntries = filterPaletteEntries(MAIN_ACTION_ENTRIES, input).slice(0, 8);
+  const choices: Array<{ name: string; value: MainActionSelection }> = matchedEntries.map((entry) => ({
+    name: renderPaletteLabel(entry),
+    value: entry.value === 'quit'
+      ? ({ kind: 'quit' } satisfies MainActionSelection)
+      : ({ kind: 'action', action: entry.value } satisfies MainActionSelection),
+  }));
+
+  if (trimmed && trimmed !== '/' && shouldOfferTypedCommand(trimmed)) {
+    const preview = sanitizeTerminalText(trimmed, 96);
+    choices.unshift({
+      name: `Run typed command  ${preview}`,
+      value: { kind: 'typed', commandLine: trimmed },
+    });
+  }
+
+  return choices;
+}
+
+export function buildPostResultChoices(input?: string): Array<{
+  name: string;
+  value: PostResultAction;
+}> {
+  return filterPaletteEntries(POST_RESULT_ENTRIES, input)
+    .slice(0, 8)
+    .map((entry) => ({ name: renderPaletteLabel(entry), value: entry.value }));
+}
 
 // ============================================================================
 // Prompts
 // ============================================================================
 
-/** Main menu: what would you like to do? */
-export async function selectMainAction(): Promise<MainAction> {
-  return select<MainAction>({
-    message: 'What would you like to do?',
-    choices: [
-      { name: 'Analyse a file or symbol', value: 'trace' },
-      { name: 'Map dependencies of a file', value: 'path' },
-      { name: 'Find dead code', value: 'check' },
-      { name: 'Workspace summary', value: 'summary' },
-      { name: 'Quit', value: 'quit' },
-    ],
+/** Main command palette: type / to browse commands, or enter a command directly. */
+export async function selectMainAction(message = 'Type / to browse commands'): Promise<MainActionSelection> {
+  return search<MainActionSelection>({
+    message,
+    source: async (input) => buildMainActionChoices(input),
   });
 }
 
@@ -46,13 +325,377 @@ export async function searchFile(
   allFiles: string[],
   workspaceRoot: string,
 ): Promise<string> {
-  return search<string>({
-    message: 'Search for a file',
-    source: async (input) => {
-      const matches = filterFiles(allFiles, input ?? '', workspaceRoot);
-      return matches.slice(0, 20).map((rel) => ({ name: rel, value: rel }));
-    },
+  const relativeFiles = allFiles
+    .map((absPath) => normalizePath(path.relative(workspaceRoot, absPath)))
+    .sort((left, right) => left.localeCompare(right));
+
+  let currentDirectory = '';
+
+  for (;;) {
+    const choices = buildFileBrowserChoices(relativeFiles, currentDirectory);
+    const location = currentDirectory || '.';
+
+    const selected = await select<string>({
+      message: `Browse files (${location})`,
+      choices,
+    });
+
+    if (selected === '__jump__') {
+      const jumpResult = await handleJumpSelection(relativeFiles, currentDirectory);
+      if (jumpResult.filePath) {
+        return jumpResult.filePath;
+      }
+      if (jumpResult.nextDirectory !== undefined) {
+        currentDirectory = jumpResult.nextDirectory;
+        continue;
+      }
+      continue;
+    }
+
+    if (selected === '__up__') {
+      currentDirectory = parentDirectoryOf(currentDirectory);
+      continue;
+    }
+
+    if (selected.startsWith('dir:')) {
+      currentDirectory = selected.slice('dir:'.length);
+      continue;
+    }
+
+    if (selected.startsWith('file:')) {
+      return selected.slice('file:'.length);
+    }
+  }
+}
+
+/**
+ * Directory browser used by /path to set session workspace scope.
+ */
+export async function searchDirectory(
+  allFiles: string[],
+  workspaceRoot: string,
+): Promise<string> {
+  const relativeFiles = allFiles
+    .map((absPath) => normalizePath(path.relative(workspaceRoot, absPath)))
+    .filter((relPath) => relPath && !relPath.startsWith('..'))
+    .sort((left, right) => left.localeCompare(right));
+
+  let currentDirectory = '';
+
+  for (;;) {
+    const choices = buildDirectoryBrowserChoices(relativeFiles, currentDirectory);
+    const location = currentDirectory || '.';
+
+    const selected = await select<string>({
+      message: `Browse directories (${location})`,
+      choices,
+    });
+
+    const outcome = await handleDirectorySelection(
+      selected,
+      relativeFiles,
+      currentDirectory,
+    );
+
+    if (outcome.selectedDirectory !== undefined) {
+      return outcome.selectedDirectory;
+    }
+
+    if (outcome.nextDirectory !== undefined) {
+      currentDirectory = outcome.nextDirectory;
+    }
+  }
+}
+
+export async function handleDirectorySelection(
+  selected: string,
+  relativeFiles: string[],
+  currentDirectory: string,
+): Promise<{ selectedDirectory?: string; nextDirectory?: string }> {
+  if (selected === '__select_current__') {
+    return { selectedDirectory: currentDirectory };
+  }
+
+  if (selected === '__up__') {
+    return { nextDirectory: parentDirectoryOf(currentDirectory) };
+  }
+
+  if (selected.startsWith('dir:')) {
+    return { selectedDirectory: selected.slice('dir:'.length) };
+  }
+
+  if (selected !== '__jump__') {
+    return {};
+  }
+
+  const typedPath = await input({
+    message: 'Jump to directory path (workspace-relative)',
+    default: currentDirectory ? `${currentDirectory}/` : '',
   });
+
+  const normalized = normalizeUserPathInput(typedPath);
+  if (!normalized) {
+    process.stdout.write('Empty path. Keeping current directory.\n');
+    return {};
+  }
+
+  if (normalized === '.') {
+    return { selectedDirectory: currentDirectory };
+  }
+
+  const jumpResult = resolveDirectoryJumpTarget(relativeFiles, currentDirectory, normalized);
+  if (jumpResult.kind === 'directory') {
+    return { nextDirectory: jumpResult.value };
+  }
+
+  process.stdout.write(
+    `No directory match for "${sanitizeTerminalText(typedPath, 120)}".\n`,
+  );
+  return {};
+}
+
+async function handleJumpSelection(
+  relativeFiles: string[],
+  currentDirectory: string,
+): Promise<{ filePath?: string; nextDirectory?: string }> {
+  const typedPath = await input({
+    message: 'Jump to file path (workspace-relative)',
+    default: currentDirectory ? `${currentDirectory}/` : '',
+  });
+
+  const resolution = resolveJumpTarget(relativeFiles, currentDirectory, typedPath);
+  if (resolution.kind === 'file') {
+    return { filePath: resolution.value };
+  }
+
+  if (resolution.kind === 'directory') {
+    return { nextDirectory: resolution.value };
+  }
+
+  printJumpNotFoundMessage(typedPath, resolution.suggestions);
+  return {};
+}
+
+function printJumpNotFoundMessage(typedPath: string, suggestions: string[]): void {
+  if (suggestions.length > 0) {
+    process.stdout.write(
+      `No exact match for "${sanitizeTerminalText(typedPath, 120)}". Suggestions: ${suggestions.join(', ')}\n`,
+    );
+    return;
+  }
+
+  process.stdout.write(
+    `No match for "${sanitizeTerminalText(typedPath, 120)}". Try a different path.\n`,
+  );
+}
+
+function normalizeUserPathInput(rawInput: string): string {
+  return normalizePath(rawInput.trim())
+    .replace(/^\.\//, '')
+    .replace(/^\//, '');
+}
+
+function hasDirectory(relativeFiles: string[], directory: string): boolean {
+  const prefix = `${directory}/`;
+  return relativeFiles.some((filePath) => filePath.startsWith(prefix));
+}
+
+function dedupeCandidates(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function buildJumpCandidates(inputPath: string, currentDirectory: string): string[] {
+  if (!currentDirectory) return [inputPath];
+  return dedupeCandidates([
+    inputPath,
+    normalizePath(path.posix.join(currentDirectory, inputPath)),
+  ]);
+}
+
+function toSuggestionText(matches: string[]): string[] {
+  return matches
+    .slice(0, FILE_BROWSER_MAX_SUGGESTIONS)
+    .map((match) => sanitizeTerminalText(match, 120));
+}
+
+function findJumpSuggestions(relativeFiles: string[], query: string): string[] {
+  const syntheticWorkspace = '/workspace';
+  const absoluteFiles = relativeFiles.map((rel) => path.posix.join(syntheticWorkspace, rel));
+  const matches = filterFiles(absoluteFiles, query, syntheticWorkspace);
+  return toSuggestionText(matches);
+}
+
+export function resolveJumpTarget(
+  relativeFiles: string[],
+  currentDirectory: string,
+  rawInput: string,
+): JumpResolution {
+  const inputPath = normalizeUserPathInput(rawInput);
+  if (!inputPath) {
+    return { kind: 'none', suggestions: [] };
+  }
+
+  const fileSet = new Set(relativeFiles);
+  const candidates = buildJumpCandidates(inputPath, currentDirectory);
+
+  for (const candidate of candidates) {
+    if (fileSet.has(candidate)) {
+      return { kind: 'file', value: candidate };
+    }
+    if (hasDirectory(relativeFiles, candidate)) {
+      return { kind: 'directory', value: candidate };
+    }
+  }
+
+  return {
+    kind: 'none',
+    suggestions: findJumpSuggestions(relativeFiles, inputPath),
+  };
+}
+
+function parentDirectoryOf(currentDirectory: string): string {
+  if (!currentDirectory) return '';
+  const lastSlash = currentDirectory.lastIndexOf('/');
+  if (lastSlash <= 0) return '';
+  return currentDirectory.slice(0, lastSlash);
+}
+
+function listDirectoryEntries(
+  relativeFiles: string[],
+  currentDirectory: string,
+): BrowserEntries {
+  const prefix = currentDirectory ? `${currentDirectory}/` : '';
+  const directories = new Set<string>();
+  const files: string[] = [];
+
+  for (const relPath of relativeFiles) {
+    if (prefix && !relPath.startsWith(prefix)) {
+      continue;
+    }
+
+    const remainder = prefix ? relPath.slice(prefix.length) : relPath;
+    if (!remainder || remainder.startsWith('..')) {
+      continue;
+    }
+
+    const slashIndex = remainder.indexOf('/');
+    if (slashIndex < 0) {
+      files.push(relPath);
+      continue;
+    }
+
+    const nextDirectorySegment = remainder.slice(0, slashIndex);
+    directories.add(nextDirectorySegment);
+  }
+
+  const sortedDirectories = [...directories].sort((left, right) => left.localeCompare(right));
+  const sortedFiles = [...files].sort((left, right) => left.localeCompare(right));
+
+  return {
+    directories: sortedDirectories,
+    files: sortedFiles,
+  };
+}
+
+function listSubdirectories(
+  relativeFiles: string[],
+  currentDirectory: string,
+): string[] {
+  return listDirectoryEntries(relativeFiles, currentDirectory).directories;
+}
+
+export function buildFileBrowserChoices(
+  relativeFiles: string[],
+  currentDirectory: string,
+): FileBrowserChoice[] {
+  const { directories, files } = listDirectoryEntries(relativeFiles, currentDirectory);
+  const choices: FileBrowserChoice[] = [
+    {
+      name: '⌨ Jump to path…',
+      value: '__jump__',
+    },
+  ];
+
+  if (currentDirectory) {
+    choices.push({
+      name: '↩ Go to parent directory',
+      value: '__up__',
+    });
+  }
+
+  for (const directoryName of directories) {
+    const nextPath = currentDirectory ? `${currentDirectory}/${directoryName}` : directoryName;
+    choices.push({
+      name: `📁 ${sanitizeTerminalText(directoryName, 80)}/`,
+      value: `dir:${nextPath}`,
+    });
+  }
+
+  const visibleFiles = files.slice(0, FILE_BROWSER_MAX_FILES);
+  for (const filePath of visibleFiles) {
+    const basename = filePath.split('/').at(-1) ?? filePath;
+    choices.push({
+      name: `📄 ${sanitizeTerminalText(basename, 80)}  ${sanitizeTerminalText(filePath, 160)}`,
+      value: `file:${filePath}`,
+    });
+  }
+
+  if (files.length > FILE_BROWSER_MAX_FILES) {
+    choices.push({
+      name: `… ${files.length - FILE_BROWSER_MAX_FILES} more files in this directory`,
+      value: '__too_many__',
+      disabled: true,
+    });
+  }
+
+  if (directories.length === 0 && files.length === 0) {
+    choices.push({
+      name: 'No files found in this directory',
+      value: '__empty__',
+      disabled: true,
+    });
+  }
+
+  return choices;
+}
+
+function resolveDirectoryJumpTarget(
+  relativeFiles: string[],
+  currentDirectory: string,
+  normalizedInput: string,
+): { kind: 'directory'; value: string } | { kind: 'none' } {
+  const candidates = buildJumpCandidates(normalizedInput, currentDirectory);
+  for (const candidate of candidates) {
+    if (hasDirectory(relativeFiles, candidate)) {
+      return { kind: 'directory', value: candidate };
+    }
+  }
+  return { kind: 'none' };
+}
+
+export function buildDirectoryBrowserChoices(
+  relativeFiles: string[],
+  currentDirectory: string,
+): DirectoryBrowserChoice[] {
+  const directories = listSubdirectories(relativeFiles, currentDirectory);
+  const choices: DirectoryBrowserChoice[] = [
+    { name: '✅ Select this directory', value: '__select_current__' },
+    { name: '⌨ Jump to path…', value: '__jump__' },
+  ];
+
+  if (currentDirectory) {
+    choices.push({ name: '↩ Go to parent directory', value: '__up__' });
+  }
+
+  for (const directoryName of directories) {
+    const nextPath = currentDirectory ? `${currentDirectory}/${directoryName}` : directoryName;
+    choices.push({
+      name: `📁 ${sanitizeTerminalText(directoryName, 80)}/`,
+      value: `dir:${nextPath}`,
+    });
+  }
+
+  return choices;
 }
 
 /**
@@ -66,21 +709,16 @@ export async function inputSymbol(
   defaultSymbol = '',
 ): Promise<string> {
   return input({
-    message: `Symbol to analyse in ${displayPath} (leave empty for whole file)`,
+    message: `Symbol to analyze in ${displayPath} (leave empty for full-file analysis)`,
     default: defaultSymbol,
   });
 }
 
 /** Post-result menu. */
-export async function selectPostResultAction(): Promise<PostResultAction> {
-  return select<PostResultAction>({
-    message: 'What next?',
-    choices: [
-      { name: 'Drill into a node from this graph', value: 'drillDown' },
-      { name: 'Export (json / markdown / mermaid)', value: 'export' },
-      { name: 'New analysis', value: 'newAnalysis' },
-      { name: 'Quit', value: 'quit' },
-    ],
+export async function selectPostResultAction(message = 'Type / for next actions'): Promise<PostResultAction> {
+  return search<PostResultAction>({
+    message,
+    source: async (input) => buildPostResultChoices(input),
   });
 }
 
@@ -93,6 +731,39 @@ export async function selectExportFormat(): Promise<ExportFormat> {
       { name: 'Markdown', value: 'markdown' },
       { name: 'Mermaid', value: 'mermaid' },
     ],
+  });
+}
+
+/** Preferred output format selector for interactive session defaults. */
+export async function selectPreferredFormat(
+  currentFormat: CliOutputFormat,
+): Promise<CliOutputFormat> {
+  return select<CliOutputFormat>({
+    message: `Default output format (current: ${currentFormat})`,
+    choices: [
+      { name: 'Text (best readability)', value: 'text' },
+      { name: 'JSON (best for scripts)', value: 'json' },
+      { name: 'TOON (compact for LLM)', value: 'toon' },
+      { name: 'Markdown', value: 'markdown' },
+      { name: 'Mermaid (diagram output)', value: 'mermaid' },
+    ],
+    default: currentFormat,
+  });
+}
+
+/** Prompt for a free-form command line (without or with "graph-it" prefix). */
+export async function inputCommandLine(defaultValue = ''): Promise<string> {
+  return input({
+    message: 'Command (/help for examples)',
+    default: defaultValue,
+  });
+}
+
+/** Ask where to save current result (relative path from workspace root). */
+export async function inputSavePath(defaultPath: string): Promise<string> {
+  return input({
+    message: 'Save result as (path in workspace)',
+    default: defaultPath,
   });
 }
 

--- a/src/cli/repl/prompts.ts
+++ b/src/cli/repl/prompts.ts
@@ -25,13 +25,13 @@ export type ExportFormat = 'json' | 'markdown' | 'mermaid';
 /** Main menu: what would you like to do? */
 export async function selectMainAction(): Promise<MainAction> {
   return select<MainAction>({
-    message: 'Que voulez-vous faire ?',
+    message: 'What would you like to do?',
     choices: [
-      { name: 'Analyser un fichier ou symbole', value: 'trace' },
-      { name: "Cartographier les dépendances d'un fichier", value: 'path' },
-      { name: 'Trouver du code mort', value: 'check' },
-      { name: 'Résumé du workspace', value: 'summary' },
-      { name: 'Quitter', value: 'quit' },
+      { name: 'Analyse a file or symbol', value: 'trace' },
+      { name: 'Map dependencies of a file', value: 'path' },
+      { name: 'Find dead code', value: 'check' },
+      { name: 'Workspace summary', value: 'summary' },
+      { name: 'Quit', value: 'quit' },
     ],
   });
 }
@@ -47,7 +47,7 @@ export async function searchFile(
   workspaceRoot: string,
 ): Promise<string> {
   return search<string>({
-    message: 'Rechercher un fichier',
+    message: 'Search for a file',
     source: async (input) => {
       const matches = filterFiles(allFiles, input ?? '', workspaceRoot);
       return matches.slice(0, 20).map((rel) => ({ name: rel, value: rel }));
@@ -63,7 +63,7 @@ export async function searchFile(
  */
 export async function inputSymbol(displayPath: string): Promise<string> {
   return input({
-    message: `Symbole à analyser dans ${displayPath} (laisser vide = tout le fichier)`,
+    message: `Symbol to analyse in ${displayPath} (leave empty for whole file)`,
     default: '',
   });
 }
@@ -71,12 +71,12 @@ export async function inputSymbol(displayPath: string): Promise<string> {
 /** Post-result menu. */
 export async function selectPostResultAction(): Promise<PostResultAction> {
   return select<PostResultAction>({
-    message: 'Que faire ensuite ?',
+    message: 'What next?',
     choices: [
-      { name: 'Explorer un nœud de ce graphe', value: 'drillDown' },
-      { name: 'Exporter (json / markdown / mermaid)', value: 'export' },
-      { name: 'Nouvelle analyse', value: 'newAnalysis' },
-      { name: 'Quitter', value: 'quit' },
+      { name: 'Drill into a node from this graph', value: 'drillDown' },
+      { name: 'Export (json / markdown / mermaid)', value: 'export' },
+      { name: 'New analysis', value: 'newAnalysis' },
+      { name: 'Quit', value: 'quit' },
     ],
   });
 }
@@ -84,7 +84,7 @@ export async function selectPostResultAction(): Promise<PostResultAction> {
 /** Export format selector. */
 export async function selectExportFormat(): Promise<ExportFormat> {
   return select<ExportFormat>({
-    message: "Format d'export",
+    message: 'Export format',
     choices: [
       { name: 'JSON', value: 'json' },
       { name: 'Markdown', value: 'markdown' },
@@ -95,5 +95,5 @@ export async function selectExportFormat(): Promise<ExportFormat> {
 
 /** Offer to re-index when the workspace has no index yet. */
 export async function confirmScan(reason: string): Promise<boolean> {
-  return confirm({ message: `${reason} Scanner maintenant ?`, default: true });
+  return confirm({ message: `${reason} Scan now?`, default: true });
 }

--- a/src/cli/repl/sessionState.ts
+++ b/src/cli/repl/sessionState.ts
@@ -12,6 +12,7 @@ import type { CliOutputFormat } from '../formatter.js';
 export interface SessionState {
   workspaceRoot: string;
   lastFile?: string;
+  lastSymbol?: string;
   lastResult?: unknown;
   preferredFormat: CliOutputFormat;
 }

--- a/src/cli/repl/sessionState.ts
+++ b/src/cli/repl/sessionState.ts
@@ -16,6 +16,10 @@ export interface SessionState {
   lastResult?: unknown;
   lastCommandLine?: string;
   preferredFormat: CliOutputFormat;
+  /** Most-recently-visited files, newest first. Max 5. Session-only. */
+  recentFiles: string[];
+  /** Monotonic counter for deterministic tip rotation (incremented each cycle). */
+  tipCounter: number;
 }
 
 /**
@@ -25,5 +29,7 @@ export function createSessionState(workspaceRoot: string): SessionState {
   return {
     workspaceRoot,
     preferredFormat: 'text',
+    recentFiles: [],
+    tipCounter: 0,
   };
 }

--- a/src/cli/repl/sessionState.ts
+++ b/src/cli/repl/sessionState.ts
@@ -1,0 +1,27 @@
+/**
+ * REPL Session State
+ *
+ * In-memory context shared across the REPL loop for a single invocation.
+ * No persistence — state lives only for the duration of the REPL session.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+import type { CliOutputFormat } from '../formatter.js';
+
+export interface SessionState {
+  workspaceRoot: string;
+  lastFile?: string;
+  lastResult?: unknown;
+  preferredFormat: CliOutputFormat;
+}
+
+/**
+ * Create a fresh session state for the given workspace root.
+ */
+export function createSessionState(workspaceRoot: string): SessionState {
+  return {
+    workspaceRoot,
+    preferredFormat: 'text',
+  };
+}

--- a/src/cli/repl/sessionState.ts
+++ b/src/cli/repl/sessionState.ts
@@ -14,6 +14,7 @@ export interface SessionState {
   lastFile?: string;
   lastSymbol?: string;
   lastResult?: unknown;
+  lastCommandLine?: string;
   preferredFormat: CliOutputFormat;
 }
 

--- a/src/cli/repl/terminal.ts
+++ b/src/cli/repl/terminal.ts
@@ -1,0 +1,30 @@
+/**
+ * Terminal text helpers for the CLI REPL.
+ *
+ * Ensures user-derived text stays safe and readable when echoed back into
+ * ANSI-capable terminals.
+ */
+
+function isControlOrBidiCodePoint(codePoint: number): boolean {
+  return (
+    codePoint < 0x20 ||
+    codePoint === 0x7f ||
+    (codePoint >= 0x80 && codePoint <= 0x9f) ||
+    codePoint === 0x1b ||
+    (codePoint >= 0x202a && codePoint <= 0x202e) ||
+    (codePoint >= 0x2066 && codePoint <= 0x2069)
+  );
+}
+
+export function sanitizeTerminalText(input: string, maxLength = 80): string {
+  let sanitized = '';
+
+  for (const char of input) {
+    if (sanitized.length >= maxLength) break;
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined) continue;
+    sanitized += isControlOrBidiCodePoint(codePoint) ? ' ' : char;
+  }
+
+  return sanitized.replaceAll(/\s+/g, ' ').trim();
+}

--- a/src/cli/repl/tips.ts
+++ b/src/cli/repl/tips.ts
@@ -1,0 +1,132 @@
+/**
+ * REPL Tips
+ *
+ * Step-specific tips shown at each prompt to guide users through the REPL.
+ * Tips rotate deterministically per REPL cycle — no randomness, fully testable.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ */
+
+/**
+ * Tips keyed by step. Each array rotates round-robin via `getTip(key, counter)`.
+ */
+const COMMAND_TIPS: Record<string, string[]> = {
+  'trace.file': [
+    'Select the entry-point (e.g. index.ts) to trace the full call chain from the top.',
+    'Pick any file — the tracer will follow imports recursively from the symbol you choose.',
+    'Tip: for libraries, select the main export file to map all outbound call paths.',
+  ],
+  'trace.symbol': [
+    'Leave empty to analyze the whole file structure instead of a single symbol.',
+    'Type to filter symbols — e.g. "handle", "process", "init". Pick one to trace its callers.',
+    'Symbol autocomplete is extracted from the file\'s AST. Empty = full-file mode.',
+  ],
+  'checkDeps.file': [
+    'Outgoing = what this file imports · Incoming = who imports this file.',
+    'Use "Both" to get a full picture; "Incoming only" to find who depends on this module.',
+    'High incoming count = high-impact file. Changes here ripple across many dependents.',
+  ],
+  'cycles.file': [
+    'Cycles create brittle coupling. Files in a cycle cannot be safely refactored independently.',
+    'Pick a file suspected of being in a circular dependency chain to inspect all cycle members.',
+    'Security tip: cycles in auth or config modules can hide initialization-order vulnerabilities.',
+  ],
+  'architecture.start': [
+    'Use Mermaid format (/format mermaid) to get a visual dependency diagram.',
+    'Architecture gives a workspace-wide view: nodes are files, edges are import relationships.',
+    'Architect tip: run /check (dead code) after /architecture to find unused modules.',
+  ],
+  'check.start': [
+    'Dead code check finds exported symbols that are never imported anywhere in the project.',
+    'Run this regularly before releases to keep the bundle lean and reduce attack surface.',
+    'QA tip: unused exports often indicate forgotten feature flags or abandoned refactors.',
+  ],
+  'pathIn.file': [
+    'Path-in shows who imports this file — useful for impact analysis before refactoring.',
+    'If path-in returns many files, changing this module will affect a large surface area.',
+    'Security tip: modules imported by many entry points should be hardened first.',
+  ],
+  'result.trace': [
+    'Next: run /check-dependencies to see who depends on the traced file.',
+    'Next: run /cycles to check if the traced symbol is part of a circular dependency.',
+    'Trace result shows call depth — deep chains (>10) may indicate tight coupling.',
+  ],
+  'result.check-dependencies': [
+    'Next: run /trace to dive into a specific symbol within this file.',
+    'Next: run /cycles to find circular dependency chains involving this file.',
+    'High outgoing count = this file imports many things. Consider splitting responsibilities.',
+  ],
+  'result.cycles': [
+    'Next: run /check to find dead code that may be entangled in the cycle.',
+    'Next: run /check-dependencies to understand which files are involved.',
+    'Breaking cycles often requires extracting shared types into a separate module.',
+  ],
+  'result.architecture': [
+    'Next: run /check to find unused exports across the whole workspace.',
+    'Next: run /trace on a heavily-connected file to understand its role.',
+    'Save as Mermaid (/save) to embed this diagram in your documentation.',
+  ],
+  'result.check': [
+    'Next: run /architecture to see the full dependency picture.',
+    'Next: run /check-dependencies on a flagged file to understand its context.',
+    'Removing dead exports reduces the public API surface and improves maintainability.',
+  ],
+  'result.summary': [
+    'Next: run /architecture for a workspace-wide dependency map.',
+    'Next: run /trace on a key file to explore its call hierarchy.',
+    'Summary includes codemap (TOON format) — useful for LLM context.',
+  ],
+  'result.explain': [
+    'Next: run /check-dependencies to see who imports this file.',
+    'Next: run /trace to follow a specific symbol across the codebase.',
+    'Explain reveals intra-file call hierarchy — cycles inside a file appear here.',
+  ],
+  'result.path': [
+    'Next: run /check-dependencies for both incoming and outgoing directions.',
+    'Next: run /cycles to check if any file in the graph creates a circular dependency.',
+    'The dependency graph shows transitive imports — deeper = more tightly coupled.',
+  ],
+  'general': [
+    'Type / to browse commands. Start typing a keyword (e.g. "deps", "arch") to filter.',
+    'Use /format mermaid then /architecture for a visual project map.',
+    'Set a working file with /file to make /summary and /check context-aware.',
+    'Use /path src/ to narrow the workspace scope to a specific subdirectory.',
+    '/command lets you run raw CLI args: e.g. "trace src/cli/index.ts#run --format json".',
+    'After any analysis, type / in the post-result menu to see smart follow-up suggestions.',
+    'Save results with /save — Mermaid exports as .mmd, JSON as .json, Markdown as .md.',
+  ],
+};
+
+/**
+ * Persona-tagged tips that rotate across all roles.
+ * Each tip hints at features relevant to a specific professional perspective.
+ */
+const PERSONA_TIPS: string[] = [
+  '👩‍💻 Developer: Use /trace to follow execution from an entry point symbol.',
+  '🏛  Architect: Use /architecture + Mermaid to map the full dependency structure.',
+  '🔒 Security: Use /cycles to find circular deps that may hide init-order vulnerabilities.',
+  '🔒 Security: Use /check to eliminate unused exports that expand your attack surface.',
+  '🧪 QA: Use /check-dependencies to understand the blast radius before a refactor.',
+  '🧪 QA: Use /cycles to detect brittle circular coupling before regression testing.',
+  '📊 Data: Use /summary --format toon to get a compact AI-friendly structural overview.',
+  '📋 Functional: Use /summary to get a human-readable overview of any module.',
+  '🏛  Architect: High incoming-dependency count on a file = high-risk change zone.',
+  '👩‍💻 Developer: Use /check (dead code) before PRs to keep exports intentional.',
+];
+
+/**
+ * Return the tip for `key` at position `counter % tips.length`.
+ * Falls back to `''` if the key is unknown or has no tips.
+ */
+export function getTip(key: string, counter: number): string {
+  const tips = COMMAND_TIPS[key];
+  if (!tips || tips.length === 0) return '';
+  return tips[counter % tips.length];
+}
+
+/**
+ * Return the persona tip at position `counter % PERSONA_TIPS.length`.
+ */
+export function getPersonaTip(counter: number): string {
+  return PERSONA_TIPS[counter % PERSONA_TIPS.length];
+}

--- a/src/cli/repl/tokenize.ts
+++ b/src/cli/repl/tokenize.ts
@@ -1,0 +1,92 @@
+/**
+ * Minimal tokenizer for REPL command lines.
+ *
+ * Supports spaces, single/double quotes, and backslash escapes without trying
+ * to emulate a full shell.
+ */
+
+export interface TokenizeResult {
+  tokens: string[];
+  error?: string;
+}
+
+function isWhitespace(char: string): boolean {
+  return /\s/.test(char);
+}
+
+function handleQuotedChar(
+  char: string,
+  quote: "'" | '"',
+  current: string,
+): { current: string; quote?: "'" | '"' } {
+  if (char === quote) {
+    return { current, quote: undefined };
+  }
+  return { current: current + char, quote };
+}
+
+function handleUnquotedChar(
+  char: string,
+  current: string,
+): { current: string; quote?: "'" | '"'; pushCurrent?: boolean } {
+  if (char === '"' || char === "'") {
+    return { current, quote: char };
+  }
+
+  if (isWhitespace(char)) {
+    return { current, pushCurrent: true };
+  }
+
+  return { current: current + char };
+}
+
+export function tokenizeCommandLine(input: string): TokenizeResult {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+
+  const pushCurrent = (): void => {
+    if (!current) return;
+    tokens.push(current);
+    current = '';
+  };
+
+  for (const char of input) {
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (quote) {
+      const next = handleQuotedChar(char, quote, current);
+      current = next.current;
+      quote = next.quote;
+      continue;
+    }
+
+    const next = handleUnquotedChar(char, current);
+    current = next.current;
+    quote = next.quote;
+    if (next.pushCurrent) {
+      pushCurrent();
+    }
+  }
+
+  if (escaped) {
+    return { tokens: [], error: 'dangling escape at end of command' };
+  }
+
+  if (quote) {
+    return { tokens: [], error: `unterminated ${quote} quote` };
+  }
+
+  pushCurrent();
+  return { tokens };
+}

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -78,6 +78,7 @@ export class CliRuntime {
   readonly workspaceRoot: string;
   private readonly stateDir: string;
   private _initialized = false;
+  private _indexReady = false;
 
   constructor(workspaceRoot: string) {
     this.workspaceRoot = path.resolve(workspaceRoot);
@@ -147,7 +148,7 @@ export class CliRuntime {
    * Ensure the workspace is indexed (warmup / full build).
    * Streams progress to stderr.
    */
-  async ensureIndexed(): Promise<{ filesIndexed: number; durationMs: number }> {
+  async ensureIndexed(options?: { silent?: boolean }): Promise<{ filesIndexed: number; durationMs: number }> {
     if (!this._initialized || !workerState.spider) {
       throw new CliError(
         "Runtime not initialized. Call init() first.",
@@ -155,12 +156,21 @@ export class CliRuntime {
       );
     }
 
+    if (this._indexReady) {
+      const warm = workerState.warmupInfo;
+      return {
+        filesIndexed: warm?.filesIndexed ?? 0,
+        durationMs: warm?.durationMs ?? 0,
+      };
+    }
+
     const spider = workerState.spider;
     const startTime = Date.now();
+    const silent = options?.silent ?? false;
 
     // Subscribe to progress → stderr
     const unsubscribe = spider.subscribeToIndexStatus((snapshot) => {
-      if (snapshot.state === "indexing") {
+      if (!silent && snapshot.state === "indexing") {
         process.stderr.write(
           `\r  Indexing: ${snapshot.processed}/${snapshot.total} files...`,
         );
@@ -170,7 +180,9 @@ export class CliRuntime {
     try {
       const result = await spider.buildFullIndex();
       const durationMs = Date.now() - startTime;
-      process.stderr.write("\n");
+      if (!silent) {
+        process.stderr.write("\n");
+      }
       log.info("Indexed", result.indexedFiles, "files in", result.duration, "ms");
 
       // Persist state
@@ -185,6 +197,8 @@ export class CliRuntime {
         durationMs: result.duration,
         filesIndexed: result.indexedFiles,
       };
+
+      this._indexReady = true;
 
       return { filesIndexed: result.indexedFiles, durationMs };
     } finally {
@@ -204,6 +218,7 @@ export class CliRuntime {
     }
     workerState.reset();
     this._initialized = false;
+    this._indexReady = false;
   }
 
   // ============================================================================

--- a/tests/cli/architecture.test.ts
+++ b/tests/cli/architecture.test.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizePath } from '../../src/shared/path';
 
 const mocks = vi.hoisted(() => ({
   collectAllSourceFiles: vi.fn(),
@@ -26,8 +27,8 @@ describe('architecture command', () => {
 
   it('builds workspace architecture graph from all source files', async () => {
     const workspaceRoot = '/workspace';
-    const fileA = path.resolve(workspaceRoot, 'src/index.ts');
-    const fileB = path.resolve(workspaceRoot, 'src/utils.ts');
+    const fileA = normalizePath(path.resolve(workspaceRoot, 'src/index.ts'));
+    const fileB = normalizePath(path.resolve(workspaceRoot, 'src/utils.ts'));
 
     mocks.collectAllSourceFiles.mockResolvedValueOnce([fileA, fileB]);
     mocks.executeAnalyzeDependencies

--- a/tests/cli/architecture.test.ts
+++ b/tests/cli/architecture.test.ts
@@ -1,0 +1,112 @@
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  collectAllSourceFiles: vi.fn(),
+  executeAnalyzeDependencies: vi.fn(),
+}));
+
+vi.mock('../../src/analyzer/SourceFileCollector.js', () => ({
+  SourceFileCollector: class {
+    collectAllSourceFiles = mocks.collectAllSourceFiles;
+  },
+}));
+
+vi.mock('../../src/mcp/tools', () => ({
+  executeAnalyzeDependencies: mocks.executeAnalyzeDependencies,
+}));
+
+import { run } from '../../src/cli/commands/architecture.js';
+
+describe('architecture command', () => {
+  beforeEach(() => {
+    mocks.collectAllSourceFiles.mockReset();
+    mocks.executeAnalyzeDependencies.mockReset();
+  });
+
+  it('builds workspace architecture graph from all source files', async () => {
+    const workspaceRoot = '/workspace';
+    const fileA = path.resolve(workspaceRoot, 'src/index.ts');
+    const fileB = path.resolve(workspaceRoot, 'src/utils.ts');
+
+    mocks.collectAllSourceFiles.mockResolvedValueOnce([fileA, fileB]);
+    mocks.executeAnalyzeDependencies
+      .mockResolvedValueOnce({
+        dependencies: [
+          {
+            path: fileB,
+            relativePath: 'src/utils.ts',
+            type: 'import',
+            line: 1,
+            module: './utils',
+            extension: 'ts',
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ dependencies: [] });
+
+    const runtime = {
+      workspaceRoot,
+      ensureIndexed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await run([], runtime as never, 'json');
+    const parsed = JSON.parse(output) as {
+      nodeCount: number;
+      edgeCount: number;
+      analyzedFiles: number;
+      nodes: Array<{ path: string }>;
+      edges: Array<{ source: string; target: string }>;
+    };
+
+    expect(parsed.analyzedFiles).toBe(2);
+    expect(parsed.nodeCount).toBe(2);
+    expect(parsed.edgeCount).toBe(1);
+    expect(parsed.nodes.map((n) => n.path)).toEqual(expect.arrayContaining([fileA, fileB]));
+    expect(parsed.edges[0]).toMatchObject({ source: fileA, target: fileB });
+  });
+
+  it('respects --maxFiles cap', async () => {
+    const workspaceRoot = '/workspace';
+    const files = [
+      path.resolve(workspaceRoot, 'src/a.ts'),
+      path.resolve(workspaceRoot, 'src/b.ts'),
+      path.resolve(workspaceRoot, 'src/c.ts'),
+    ];
+
+    mocks.collectAllSourceFiles.mockResolvedValueOnce(files);
+    mocks.executeAnalyzeDependencies.mockResolvedValue({ dependencies: [] });
+
+    const runtime = {
+      workspaceRoot,
+      ensureIndexed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await run(['--maxFiles', '2'], runtime as never, 'json');
+    const parsed = JSON.parse(output) as { analyzedFiles: number; scannedFiles: number };
+
+    expect(parsed.scannedFiles).toBe(3);
+    expect(parsed.analyzedFiles).toBe(2);
+    expect(mocks.executeAnalyzeDependencies).toHaveBeenCalledTimes(2);
+  });
+
+  it('supports mermaid output for workspace architecture graph', async () => {
+    const workspaceRoot = '/workspace';
+    const fileA = path.resolve(workspaceRoot, 'src/index.ts');
+    const fileB = path.resolve(workspaceRoot, 'src/utils.ts');
+
+    mocks.collectAllSourceFiles.mockResolvedValueOnce([fileA, fileB]);
+    mocks.executeAnalyzeDependencies
+      .mockResolvedValueOnce({ dependencies: [{ path: fileB }] })
+      .mockResolvedValueOnce({ dependencies: [] });
+
+    const runtime = {
+      workspaceRoot,
+      ensureIndexed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await run([], runtime as never, 'mermaid');
+    expect(output).toContain('graph LR');
+    expect(output).toContain('-->');
+  });
+});

--- a/tests/cli/checkDependencies.test.ts
+++ b/tests/cli/checkDependencies.test.ts
@@ -1,0 +1,78 @@
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  executeAnalyzeDependencies: vi.fn(),
+  executeFindReferencingFiles: vi.fn(),
+}));
+
+vi.mock('../../src/mcp/tools', () => ({
+  executeAnalyzeDependencies: mocks.executeAnalyzeDependencies,
+  executeFindReferencingFiles: mocks.executeFindReferencingFiles,
+}));
+
+import { run } from '../../src/cli/commands/checkDependencies.js';
+
+describe('check-dependencies command', () => {
+  beforeEach(() => {
+    mocks.executeAnalyzeDependencies.mockReset();
+    mocks.executeFindReferencingFiles.mockReset();
+  });
+
+  it('returns incoming and outgoing dependencies for a file', async () => {
+    const workspaceRoot = '/workspace';
+    const target = path.resolve(workspaceRoot, 'src/index.ts');
+
+    mocks.executeAnalyzeDependencies.mockResolvedValueOnce({
+      filePath: target,
+      dependencyCount: 1,
+      dependencies: [{ path: path.resolve(workspaceRoot, 'src/utils.ts') }],
+    });
+
+    mocks.executeFindReferencingFiles.mockResolvedValueOnce({
+      targetPath: target,
+      referencingFileCount: 1,
+      referencingFiles: [{ path: path.resolve(workspaceRoot, 'src/app.ts') }],
+    });
+
+    const runtime = {
+      workspaceRoot,
+      ensureIndexed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await run(['src/index.ts'], runtime as never, 'json');
+    const parsed = JSON.parse(output) as {
+      outgoing: { dependencyCount: number };
+      incoming: { referencingFileCount: number };
+    };
+
+    expect(parsed.outgoing.dependencyCount).toBe(1);
+    expect(parsed.incoming.referencingFileCount).toBe(1);
+  });
+
+  it('supports mermaid output for dependency graph export', async () => {
+    const workspaceRoot = '/workspace';
+    const target = path.resolve(workspaceRoot, 'src/index.ts');
+
+    mocks.executeAnalyzeDependencies.mockResolvedValueOnce({
+      filePath: target,
+      dependencyCount: 1,
+      dependencies: [{ path: path.resolve(workspaceRoot, 'src/utils.ts') }],
+    });
+
+    mocks.executeFindReferencingFiles.mockResolvedValueOnce({
+      targetPath: target,
+      referencingFileCount: 1,
+      referencingFiles: [{ path: path.resolve(workspaceRoot, 'src/app.ts') }],
+    });
+
+    const runtime = {
+      workspaceRoot,
+      ensureIndexed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await run(['src/index.ts'], runtime as never, 'mermaid');
+    expect(output).toContain('graph LR');
+    expect(output).toContain('-->');
+  });
+});

--- a/tests/cli/commands.test.ts
+++ b/tests/cli/commands.test.ts
@@ -81,7 +81,7 @@ describe("tool command", () => {
 describe("commandHelp", () => {
   it("returns help for each known command", async () => {
     const { getCommandHelp } = await import("../../src/cli/commandHelp.js");
-    const commands = ["scan", "summary", "trace", "explain", "path", "check", "serve", "tool", "install"];
+    const commands = ["scan", "summary", "trace", "explain", "path", "path-in", "check-dependencies", "cycles", "architecture", "check", "serve", "tool", "install"];
     for (const cmd of commands) {
       const help = getCommandHelp(cmd);
       expect(help).toContain(`graph-it ${cmd}`);

--- a/tests/cli/cycles.test.ts
+++ b/tests/cli/cycles.test.ts
@@ -1,0 +1,45 @@
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  executeCrawlDependencyGraph: vi.fn(),
+}));
+
+vi.mock('../../src/mcp/tools', () => ({
+  executeCrawlDependencyGraph: mocks.executeCrawlDependencyGraph,
+}));
+
+import { run } from '../../src/cli/commands/cycles.js';
+
+describe('cycles command', () => {
+  beforeEach(() => {
+    mocks.executeCrawlDependencyGraph.mockReset();
+  });
+
+  it('returns confirmed cycles that include the target file', async () => {
+    const workspaceRoot = '/workspace';
+    const target = path.resolve(workspaceRoot, 'src/index.ts');
+    const fileB = path.resolve(workspaceRoot, 'src/b.ts');
+
+    mocks.executeCrawlDependencyGraph.mockResolvedValueOnce({
+      circularDependencies: [
+        [target, fileB, target],
+        [fileB, target],
+      ],
+    });
+
+    const runtime = {
+      workspaceRoot,
+      ensureIndexed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await run(['src/index.ts'], runtime as never, 'json');
+    const parsed = JSON.parse(output) as {
+      cycleCount: number;
+      confirmedCycles: string[][];
+    };
+
+    expect(parsed.cycleCount).toBe(2);
+    expect(parsed.confirmedCycles[0][0]).toBe('src/index.ts');
+  });
+});

--- a/tests/cli/formatter.test.ts
+++ b/tests/cli/formatter.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { CliError, ExitCode } from "../../src/cli/errors";
 import {
   CLI_OUTPUT_FORMATS,
   formatOutput,
@@ -25,25 +24,24 @@ describe("CLI_OUTPUT_FORMATS", () => {
 });
 
 describe("validateFormatForCommand", () => {
-  it("allows mermaid for trace command", () => {
-    expect(() => validateFormatForCommand("mermaid", "trace")).not.toThrow();
-  });
+  it("allows mermaid for all formatOutput-based commands", () => {
+    const commands = [
+      "scan",
+      "summary",
+      "trace",
+      "explain",
+      "path",
+      "path-in",
+      "check-dependencies",
+      "cycles",
+      "architecture",
+      "check",
+      "tool",
+    ];
 
-  it("allows mermaid for path command", () => {
-    expect(() => validateFormatForCommand("mermaid", "path")).not.toThrow();
-  });
-
-  it("throws UNSUPPORTED_FORMAT for mermaid on summary", () => {
-    expect(() => validateFormatForCommand("mermaid", "summary")).toThrow(CliError);
-    try {
-      validateFormatForCommand("mermaid", "summary");
-    } catch (err) {
-      expect((err as CliError).exitCode).toBe(ExitCode.UNSUPPORTED_FORMAT);
+    for (const command of commands) {
+      expect(() => validateFormatForCommand("mermaid", command)).not.toThrow();
     }
-  });
-
-  it("throws UNSUPPORTED_FORMAT for mermaid on explain", () => {
-    expect(() => validateFormatForCommand("mermaid", "explain")).toThrow(CliError);
   });
 
   it("allows all formats for non-mermaid-restricted commands", () => {
@@ -108,6 +106,30 @@ describe("formatOutput - text", () => {
     expect(out).toContain("Visited Symbols:");
     expect(out).toContain("- main");
   });
+
+  it("renders architecture summary without dumping failure details", () => {
+    const architectureData = {
+      workspaceRoot: "/workspace",
+      scannedFiles: 10,
+      analyzedFiles: 10,
+      skippedFiles: 2,
+      nodeCount: 12,
+      edgeCount: 18,
+      nodes: [
+        { relativePath: "src/index.ts", dependencyCount: 3, dependentCount: 7 },
+        { relativePath: "src/utils.ts", dependencyCount: 1, dependentCount: 2 },
+      ],
+      failedFiles: [
+        { relativePath: "src/bad.ts", reason: "Parse error: unexpected token" },
+      ],
+    };
+
+    const out = formatOutput(architectureData, "text", "architecture");
+    expect(out).toContain("Workspace Architecture");
+    expect(out).toContain("skipped files: 2");
+    expect(out).toContain("details available with --format json");
+    expect(out).not.toContain("Parse error: unexpected token");
+  });
 });
 
 describe("formatOutput - toon", () => {
@@ -159,12 +181,97 @@ describe("formatOutput - mermaid", () => {
     expect(out).toContain("main --> helper");
   });
 
-  it("throws UNSUPPORTED_FORMAT when no graph data", () => {
-    expect(() => formatOutput(objectData, "mermaid", "trace")).toThrow(CliError);
-    try {
-      formatOutput(objectData, "mermaid", "trace");
-    } catch (err) {
-      expect((err as CliError).exitCode).toBe(ExitCode.UNSUPPORTED_FORMAT);
-    }
+  it("generates graph from check-dependencies result", () => {
+    const dependencyData = {
+      filePath: "/workspace/src/index.ts",
+      relativePath: "src/index.ts",
+      outgoing: {
+        dependencyCount: 1,
+        dependencies: [{ path: "src/utils.ts" }],
+      },
+      incoming: {
+        referencingFileCount: 1,
+        referencingFiles: [{ path: "src/app.ts" }],
+      },
+    };
+
+    const out = formatOutput(dependencyData, "mermaid", "check-dependencies");
+    expect(out).toContain("graph LR");
+    expect(out).toContain("index.ts");
+    expect(out).toContain("utils.ts");
+    expect(out).toContain("app.ts");
+    expect(out).toContain("--> ");
+  });
+
+  it("falls back to a generic graph when payload is not graph-shaped", () => {
+    const out = formatOutput(objectData, "mermaid", "summary");
+    expect(out).toContain("graph TD");
+    expect(out).toContain("summary");
+    expect(out).toContain("state");
+  });
+
+  it("applies generic fallback to primitive payloads", () => {
+    const out = formatOutput("done", "mermaid", "scan");
+    expect(out).toContain("graph TD");
+    expect(out).toContain("done");
+  });
+
+  it("strips control characters from Mermaid node labels", () => {
+    const graphData = {
+      nodes: [
+        { id: "a", name: "a\nwith\nnewlines.ts" },
+        { id: "b", name: "b\twith\ttabs.ts" },
+      ],
+      edges: [{ source: "a", target: "b" }],
+    };
+    const out = formatOutput(graphData, "mermaid", "path");
+    // Raw newlines/tabs must not appear inside the quoted label strings
+    // (the overall diagram has legitimate newlines between statements — that's fine).
+    expect(out).not.toMatch(/"\w*\n\w*"/);  // no newline inside a quoted label
+    expect(out).not.toContain("\t");
+    expect(out).toContain("graph LR");
+  });
+
+  it("escapes double-quotes in Mermaid node labels", () => {
+    const graphData = {
+      nodes: [{ id: "a", name: 'he said "hello"' }],
+      edges: [],
+    };
+    const out = formatOutput(graphData, "mermaid", "path");
+    expect(out).not.toContain('"he said "');
+    expect(out).toContain("he said 'hello'");
+  });
+
+  it('truncates oversized graph payloads with an explicit marker', () => {
+    const nodes = Array.from({ length: 400 }, (_, i) => ({
+      id: `node-${i}`,
+      name: `node-${i}.ts`,
+    }));
+    const edges = Array.from({ length: 900 }, (_, i) => ({
+      source: `node-${i % 399}`,
+      target: `node-${(i + 1) % 399}`,
+    }));
+
+    const out = formatOutput({ nodes, edges }, 'mermaid', 'architecture');
+    expect(out).toContain('graph LR');
+    expect(out).toContain('more node(s)');
+    expect(out).not.toContain('output truncated');
+    expect(out.split('\n').length).toBeLessThanOrEqual(700);
+  });
+
+  it('truncates oversized dependency-check payloads silently within output budget', () => {
+    const outgoing = Array.from({ length: 600 }, (_, i) => ({ path: `src/out-${i}.ts` }));
+    const incoming = Array.from({ length: 650 }, (_, i) => ({ path: `src/in-${i}.ts` }));
+
+    const out = formatOutput({
+      filePath: '/workspace/src/index.ts',
+      relativePath: 'src/index.ts',
+      outgoing: { dependencyCount: outgoing.length, dependencies: outgoing },
+      incoming: { referencingFileCount: incoming.length, referencingFiles: incoming },
+    }, 'mermaid', 'check-dependencies');
+
+    expect(out).toContain('graph LR');
+    expect(out).not.toContain('output truncated');
+    expect(out.split('\n').length).toBeLessThanOrEqual(700);
   });
 });

--- a/tests/cli/pathIn.test.ts
+++ b/tests/cli/pathIn.test.ts
@@ -1,0 +1,58 @@
+import * as path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  executeFindReferencingFiles: vi.fn(),
+}));
+
+vi.mock('../../src/mcp/tools', () => ({
+  executeFindReferencingFiles: mocks.executeFindReferencingFiles,
+}));
+
+import { run } from '../../src/cli/commands/pathIn.js';
+
+describe('path-in command', () => {
+  beforeEach(() => {
+    mocks.executeFindReferencingFiles.mockReset();
+  });
+
+  it('returns incoming dependencies with graph nodes/edges', async () => {
+    const workspaceRoot = '/workspace';
+    const target = path.resolve(workspaceRoot, 'src/index.ts');
+    const refA = path.resolve(workspaceRoot, 'src/app.ts');
+
+    mocks.executeFindReferencingFiles.mockResolvedValueOnce({
+      targetPath: target,
+      referencingFileCount: 1,
+      referencingFiles: [
+        {
+          path: refA,
+          relativePath: 'src/app.ts',
+          type: 'import',
+          line: 2,
+          module: './index',
+        },
+      ],
+    });
+
+    const runtime = {
+      workspaceRoot,
+      ensureIndexed: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const output = await run(['src/index.ts'], runtime as never, 'json');
+    const parsed = JSON.parse(output) as {
+      nodeCount: number;
+      edgeCount: number;
+      nodes: Array<{ path: string }>;
+      edges: Array<{ source: string; target: string }>;
+    };
+
+    expect(parsed.nodeCount).toBe(2);
+    expect(parsed.edgeCount).toBe(1);
+    expect(parsed.nodes.map((node) => node.path)).toEqual(
+      expect.arrayContaining([target, refA]),
+    );
+    expect(parsed.edges[0]).toEqual({ source: refA, target });
+  });
+});

--- a/tests/cli/repl.e2e.test.ts
+++ b/tests/cli/repl.e2e.test.ts
@@ -13,15 +13,20 @@ const mocks = vi.hoisted(() => ({
   selectPostResultAction: vi.fn(),
   searchDirectory: vi.fn(),
   searchFile: vi.fn(),
-  inputSymbol: vi.fn(),
+  selectOrInputSymbol: vi.fn(),
+  askTraceOptions: vi.fn(),
+  askCheckDepsOptions: vi.fn(),
+  askArchitectureOptions: vi.fn(),
   inputCommandLine: vi.fn(),
   inputSavePath: vi.fn(),
   selectExportFormat: vi.fn(),
   selectPreferredFormat: vi.fn(),
   confirmScan: vi.fn(),
+  buildContextualPostResultEntries: vi.fn().mockReturnValue([]),
 
   traceRun: vi.fn(),
   pathRun: vi.fn(),
+  pathInRun: vi.fn(),
   explainRun: vi.fn(),
   summaryRun: vi.fn(),
   architectureRun: vi.fn(),
@@ -36,11 +41,15 @@ vi.mock('../../src/cli/repl/prompts.js', () => ({
   searchDirectory: mocks.searchDirectory,
   searchFile: mocks.searchFile,
   inputSavePath: mocks.inputSavePath,
-  inputSymbol: mocks.inputSymbol,
+  selectOrInputSymbol: mocks.selectOrInputSymbol,
+  askTraceOptions: mocks.askTraceOptions,
+  askCheckDepsOptions: mocks.askCheckDepsOptions,
+  askArchitectureOptions: mocks.askArchitectureOptions,
   inputCommandLine: mocks.inputCommandLine,
   selectExportFormat: mocks.selectExportFormat,
   selectPreferredFormat: mocks.selectPreferredFormat,
   confirmScan: mocks.confirmScan,
+  buildContextualPostResultEntries: mocks.buildContextualPostResultEntries,
 }));
 
 vi.mock('../../src/analyzer/SourceFileCollector.js', () => ({
@@ -54,6 +63,7 @@ vi.mock('../../src/analyzer/SourceFileCollector.js', () => ({
 
 vi.mock('../../src/cli/commands/trace.js', () => ({ run: mocks.traceRun }));
 vi.mock('../../src/cli/commands/path.js', () => ({ run: mocks.pathRun }));
+vi.mock('../../src/cli/commands/pathIn.js', () => ({ run: mocks.pathInRun }));
 vi.mock('../../src/cli/commands/explain.js', () => ({ run: mocks.explainRun }));
 vi.mock('../../src/cli/commands/summary.js', () => ({ run: mocks.summaryRun }));
 vi.mock('../../src/cli/commands/architecture.js', () => ({ run: mocks.architectureRun }));
@@ -94,6 +104,10 @@ describe('REPL command chaining e2e', () => {
     mocks.inputCommandLine.mockResolvedValue('');
     mocks.searchDirectory.mockResolvedValue('src');
     mocks.confirmScan.mockResolvedValue(true);
+    mocks.selectOrInputSymbol.mockResolvedValue('');
+    mocks.askTraceOptions.mockResolvedValue({ maxDepth: 10 });
+    mocks.askCheckDepsOptions.mockResolvedValue({ direction: 'both' });
+    mocks.askArchitectureOptions.mockResolvedValue({ maxFiles: undefined });
 
     mocks.traceRun.mockResolvedValue('{"trace":"ok"}');
     mocks.pathRun.mockResolvedValue('{"path":"ok"}');
@@ -120,7 +134,7 @@ describe('REPL command chaining e2e', () => {
       .mockResolvedValueOnce('quit');
 
     mocks.searchFile.mockResolvedValueOnce('src/index.ts');
-    mocks.inputSymbol.mockResolvedValueOnce('main');
+    mocks.selectOrInputSymbol.mockResolvedValueOnce('main');
 
     const runtime = createRuntimeStub();
     await run(runtime as never);
@@ -128,7 +142,7 @@ describe('REPL command chaining e2e', () => {
     const expectedFile = path.resolve('/workspace', 'src/index.ts');
 
     expect(mocks.traceRun).toHaveBeenCalledWith(
-      [`${expectedFile}#main`],
+      [`${expectedFile}#main`, '--maxDepth=10'],
       runtime,
       'json',
     );
@@ -146,7 +160,7 @@ describe('REPL command chaining e2e', () => {
       .mockResolvedValueOnce('quit');
 
     mocks.searchFile.mockResolvedValueOnce('src/index.ts');
-    mocks.inputSymbol.mockResolvedValueOnce('handler');
+    mocks.selectOrInputSymbol.mockResolvedValueOnce('handler');
 
     const runtime = createRuntimeStub();
     await run(runtime as never);
@@ -181,7 +195,7 @@ describe('REPL command chaining e2e', () => {
     mocks.selectPostResultAction.mockResolvedValueOnce('drillDown');
 
     mocks.searchFile.mockResolvedValueOnce('src/utils.ts');
-    mocks.inputSymbol.mockResolvedValueOnce('');
+    mocks.selectOrInputSymbol.mockResolvedValueOnce('');
 
     const runtime = createRuntimeStub();
     await run(runtime as never);
@@ -200,7 +214,7 @@ describe('REPL command chaining e2e', () => {
     mocks.selectPostResultAction.mockResolvedValueOnce('drillDown');
 
     mocks.searchFile.mockResolvedValueOnce('src/index.ts');
-    mocks.inputSymbol
+    mocks.selectOrInputSymbol
       .mockResolvedValueOnce('handler')
       .mockResolvedValueOnce('');
 
@@ -210,8 +224,20 @@ describe('REPL command chaining e2e', () => {
     const expectedFile = path.resolve('/workspace', 'src/index.ts');
     const expectedRelative = path.relative('/workspace', expectedFile);
 
-    expect(mocks.inputSymbol).toHaveBeenNthCalledWith(1, 'src/index.ts');
-    expect(mocks.inputSymbol).toHaveBeenNthCalledWith(2, expectedRelative, 'handler');
+    expect(mocks.selectOrInputSymbol).toHaveBeenNthCalledWith(
+      1,
+      'src/index.ts',
+      expect.any(Array),
+      expect.any(Number),
+      expect.any(String),
+    );
+    expect(mocks.selectOrInputSymbol).toHaveBeenNthCalledWith(
+      2,
+      expectedRelative,
+      expect.any(Array),
+      expect.any(Number),
+      'handler',
+    );
     expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
   });
 
@@ -226,7 +252,7 @@ describe('REPL command chaining e2e', () => {
       .mockResolvedValueOnce('quit');
 
     mocks.searchFile.mockResolvedValueOnce('src/utils.ts');
-    mocks.inputSymbol.mockResolvedValueOnce('');
+    mocks.selectOrInputSymbol.mockResolvedValueOnce('');
 
     const runtime = createRuntimeStub();
     await run(runtime as never);
@@ -247,7 +273,21 @@ describe('REPL command chaining e2e', () => {
     const runtime = createRuntimeStub();
     await run(runtime as never);
 
+    // Architecture called with no args when unlimited (no maxFiles)
     expect(mocks.architectureRun).toHaveBeenCalledWith([], runtime, 'json');
+  });
+
+  it('passes --maxFiles arg to architecture when cap is configured', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('architecture')
+      .mockResolvedValueOnce('quit');
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+    mocks.askArchitectureOptions.mockResolvedValueOnce({ maxFiles: 100 });
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.architectureRun).toHaveBeenCalledWith(['--maxFiles=100'], runtime, 'json');
   });
 
   it('does not print the header as standalone scrollback before the prompt loop', async () => {
@@ -404,6 +444,79 @@ describe('REPL command chaining e2e', () => {
     );
   });
 
+  it('check-dependencies uses path command when direction is outgoing-only', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('checkDependencies')
+      .mockResolvedValueOnce('quit');
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+    mocks.searchFile.mockResolvedValueOnce('src/index.ts');
+    mocks.askCheckDepsOptions.mockResolvedValueOnce({ direction: 'outgoing' });
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.pathRun).toHaveBeenCalledWith(
+      [path.resolve('/workspace', 'src/index.ts')],
+      runtime,
+      'json',
+    );
+    expect(mocks.checkDependenciesRun).not.toHaveBeenCalled();
+  });
+
+  it('check-dependencies uses pathIn command when direction is incoming-only', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('checkDependencies')
+      .mockResolvedValueOnce('quit');
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+    mocks.searchFile.mockResolvedValueOnce('src/utils.ts');
+    mocks.askCheckDepsOptions.mockResolvedValueOnce({ direction: 'incoming' });
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.pathInRun).toHaveBeenCalledWith(
+      [path.resolve('/workspace', 'src/utils.ts')],
+      runtime,
+      'json',
+    );
+    expect(mocks.checkDependenciesRun).not.toHaveBeenCalled();
+  });
+
+  it('post-result followUpDeps runs check-dependencies on last context file', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('trace')
+      .mockResolvedValueOnce('quit');
+    mocks.selectPostResultAction.mockResolvedValueOnce('followUpDeps');
+    mocks.searchFile.mockResolvedValueOnce('src/index.ts');
+    mocks.selectOrInputSymbol.mockResolvedValueOnce('myFn');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    const expectedFile = path.resolve('/workspace', 'src/index.ts');
+    expect(mocks.traceRun).toHaveBeenCalledWith(
+      [`${expectedFile}#myFn`, '--maxDepth=10'],
+      runtime,
+      'json',
+    );
+    expect(mocks.checkDependenciesRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
+  });
+
+  it('post-result followUpCycles runs cycles on last context file', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('trace')
+      .mockResolvedValueOnce('quit');
+    mocks.selectPostResultAction.mockResolvedValueOnce('followUpCycles');
+    mocks.searchFile.mockResolvedValueOnce('src/utils.ts');
+    mocks.selectOrInputSymbol.mockResolvedValueOnce('parse');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    const expectedFile = path.resolve('/workspace', 'src/utils.ts');
+    expect(mocks.cyclesRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
+  });
+
   it('sets current file context with /file and reuses it for summary', async () => {
     mocks.selectMainAction
       .mockResolvedValueOnce({ kind: 'typed', commandLine: '/file src/index.ts' })
@@ -481,8 +594,10 @@ describe('REPL command chaining e2e', () => {
     const runtime = createRuntimeStub();
     await run(runtime as never);
 
+    const exportDir = path.join('.graph-it', 'exports', '');
+    const escapedDir = exportDir.replaceAll('\\', '\\\\');
     expect(mocks.inputSavePath).toHaveBeenCalledWith(
-      expect.stringMatching(/\.graph-it\/exports\/.*-architecture\.mmd$/),
+      expect.stringMatching(new RegExp(String.raw`${escapedDir}.*-architecture\.mmd$`)),
     );
   });
 });

--- a/tests/cli/repl.e2e.test.ts
+++ b/tests/cli/repl.e2e.test.ts
@@ -1,0 +1,218 @@
+/**
+ * REPL end-to-end chaining tests.
+ *
+ * These tests execute the real REPL loop with mocked prompts/runtime/commands
+ * to validate command chaining and input propagation between cycles.
+ */
+
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  selectMainAction: vi.fn(),
+  selectPostResultAction: vi.fn(),
+  searchFile: vi.fn(),
+  inputSymbol: vi.fn(),
+  selectExportFormat: vi.fn(),
+  confirmScan: vi.fn(),
+
+  traceRun: vi.fn(),
+  pathRun: vi.fn(),
+  explainRun: vi.fn(),
+  summaryRun: vi.fn(),
+  checkRun: vi.fn(),
+}));
+
+vi.mock('../../src/cli/repl/prompts.js', () => ({
+  selectMainAction: mocks.selectMainAction,
+  selectPostResultAction: mocks.selectPostResultAction,
+  searchFile: mocks.searchFile,
+  inputSymbol: mocks.inputSymbol,
+  selectExportFormat: mocks.selectExportFormat,
+  confirmScan: mocks.confirmScan,
+}));
+
+vi.mock('../../src/analyzer/SourceFileCollector.js', () => ({
+  SourceFileCollector: class {
+    collectAllSourceFiles = vi.fn().mockResolvedValue([
+      path.resolve('/workspace', 'src/index.ts'),
+      path.resolve('/workspace', 'src/utils.ts'),
+    ]);
+  },
+}));
+
+vi.mock('../../src/cli/commands/trace.js', () => ({ run: mocks.traceRun }));
+vi.mock('../../src/cli/commands/path.js', () => ({ run: mocks.pathRun }));
+vi.mock('../../src/cli/commands/explain.js', () => ({ run: mocks.explainRun }));
+vi.mock('../../src/cli/commands/summary.js', () => ({ run: mocks.summaryRun }));
+vi.mock('../../src/cli/commands/check.js', () => ({ run: mocks.checkRun }));
+
+import { run } from '../../src/cli/commands/repl.js';
+
+function createRuntimeStub() {
+  return {
+    workspaceRoot: '/workspace',
+    init: vi.fn().mockResolvedValue(undefined),
+    ensureIndexed: vi.fn().mockResolvedValue({ filesIndexed: 2, durationMs: 1 }),
+  };
+}
+
+describe('REPL command chaining e2e', () => {
+  const stdoutSpy = vi.spyOn(process.stdout, 'write');
+  const stderrSpy = vi.spyOn(process.stderr, 'write');
+
+  beforeEach(() => {
+    Object.values(mocks).forEach((mockFn) => mockFn.mockReset());
+    stdoutSpy.mockReset();
+    stderrSpy.mockReset();
+
+    Object.defineProperty(process.stdin, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+
+    stdoutSpy.mockImplementation(() => true);
+    stderrSpy.mockImplementation(() => true);
+
+    mocks.selectExportFormat.mockResolvedValue('json');
+    mocks.confirmScan.mockResolvedValue(true);
+
+    mocks.traceRun.mockResolvedValue('{"trace":"ok"}');
+    mocks.pathRun.mockResolvedValue('{"path":"ok"}');
+    mocks.explainRun.mockResolvedValue('{"explain":"ok"}');
+    mocks.summaryRun.mockResolvedValue('{"summary":"ok"}');
+    mocks.checkRun.mockResolvedValue('{"check":"ok"}');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('chains selected file from trace into check input', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('trace')
+      .mockResolvedValueOnce('check')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction
+      .mockResolvedValueOnce('newAnalysis')
+      .mockResolvedValueOnce('quit');
+
+    mocks.searchFile.mockResolvedValueOnce('src/index.ts');
+    mocks.inputSymbol.mockResolvedValueOnce('main');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    const expectedFile = path.resolve('/workspace', 'src/index.ts');
+
+    expect(mocks.traceRun).toHaveBeenCalledWith(
+      [`${expectedFile}#main`],
+      runtime,
+      'text',
+    );
+    expect(mocks.checkRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+  });
+
+  it('chains selected file from trace into summary codemap input', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('trace')
+      .mockResolvedValueOnce('summary')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction
+      .mockResolvedValueOnce('newAnalysis')
+      .mockResolvedValueOnce('quit');
+
+    mocks.searchFile.mockResolvedValueOnce('src/index.ts');
+    mocks.inputSymbol.mockResolvedValueOnce('handler');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    const expectedFile = path.resolve('/workspace', 'src/index.ts');
+    expect(mocks.summaryRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+  });
+
+  it('does not execute drill-down when there is no file context', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('summary')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('drillDown');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.summaryRun).toHaveBeenCalledWith([], runtime, 'text');
+    expect(mocks.traceRun).not.toHaveBeenCalled();
+    expect(mocks.explainRun).not.toHaveBeenCalled();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      'Drill-down unavailable for this result (no file context).\n',
+    );
+  });
+
+  it('drill-down on path result reuses current file context and allows empty symbol fallback', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('path')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('drillDown');
+
+    mocks.searchFile.mockResolvedValueOnce('src/utils.ts');
+    mocks.inputSymbol.mockResolvedValueOnce('');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    const expectedFile = path.resolve('/workspace', 'src/utils.ts');
+
+    expect(mocks.pathRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+  });
+
+  it('reuses previous symbol as drill-down default input', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('trace')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('drillDown');
+
+    mocks.searchFile.mockResolvedValueOnce('src/index.ts');
+    mocks.inputSymbol
+      .mockResolvedValueOnce('handler')
+      .mockResolvedValueOnce('');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    const expectedFile = path.resolve('/workspace', 'src/index.ts');
+    const expectedRelative = path.relative('/workspace', expectedFile);
+
+    expect(mocks.inputSymbol).toHaveBeenNthCalledWith(1, 'src/index.ts');
+    expect(mocks.inputSymbol).toHaveBeenNthCalledWith(2, expectedRelative, 'handler');
+    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+  });
+
+  it('chains file context from explain fallback into check when trace symbol is empty', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('trace')
+      .mockResolvedValueOnce('check')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction
+      .mockResolvedValueOnce('newAnalysis')
+      .mockResolvedValueOnce('quit');
+
+    mocks.searchFile.mockResolvedValueOnce('src/utils.ts');
+    mocks.inputSymbol.mockResolvedValueOnce('');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    const expectedFile = path.resolve('/workspace', 'src/utils.ts');
+
+    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+    expect(mocks.checkRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+  });
+});

--- a/tests/cli/repl.e2e.test.ts
+++ b/tests/cli/repl.e2e.test.ts
@@ -11,24 +11,35 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   selectMainAction: vi.fn(),
   selectPostResultAction: vi.fn(),
+  searchDirectory: vi.fn(),
   searchFile: vi.fn(),
   inputSymbol: vi.fn(),
+  inputCommandLine: vi.fn(),
+  inputSavePath: vi.fn(),
   selectExportFormat: vi.fn(),
+  selectPreferredFormat: vi.fn(),
   confirmScan: vi.fn(),
 
   traceRun: vi.fn(),
   pathRun: vi.fn(),
   explainRun: vi.fn(),
   summaryRun: vi.fn(),
+  architectureRun: vi.fn(),
+  checkDependenciesRun: vi.fn(),
+  cyclesRun: vi.fn(),
   checkRun: vi.fn(),
 }));
 
 vi.mock('../../src/cli/repl/prompts.js', () => ({
   selectMainAction: mocks.selectMainAction,
   selectPostResultAction: mocks.selectPostResultAction,
+  searchDirectory: mocks.searchDirectory,
   searchFile: mocks.searchFile,
+  inputSavePath: mocks.inputSavePath,
   inputSymbol: mocks.inputSymbol,
+  inputCommandLine: mocks.inputCommandLine,
   selectExportFormat: mocks.selectExportFormat,
+  selectPreferredFormat: mocks.selectPreferredFormat,
   confirmScan: mocks.confirmScan,
 }));
 
@@ -45,9 +56,12 @@ vi.mock('../../src/cli/commands/trace.js', () => ({ run: mocks.traceRun }));
 vi.mock('../../src/cli/commands/path.js', () => ({ run: mocks.pathRun }));
 vi.mock('../../src/cli/commands/explain.js', () => ({ run: mocks.explainRun }));
 vi.mock('../../src/cli/commands/summary.js', () => ({ run: mocks.summaryRun }));
+vi.mock('../../src/cli/commands/architecture.js', () => ({ run: mocks.architectureRun }));
+vi.mock('../../src/cli/commands/checkDependencies.js', () => ({ run: mocks.checkDependenciesRun }));
+vi.mock('../../src/cli/commands/cycles.js', () => ({ run: mocks.cyclesRun }));
 vi.mock('../../src/cli/commands/check.js', () => ({ run: mocks.checkRun }));
 
-import { run } from '../../src/cli/commands/repl.js';
+import { run } from '@/cli/commands/repl';
 
 function createRuntimeStub() {
   return {
@@ -75,12 +89,19 @@ describe('REPL command chaining e2e', () => {
     stderrSpy.mockImplementation(() => true);
 
     mocks.selectExportFormat.mockResolvedValue('json');
+    mocks.selectPreferredFormat.mockResolvedValue('json');
+    mocks.inputSavePath.mockResolvedValue('.graph-it/exports/repl-output.txt');
+    mocks.inputCommandLine.mockResolvedValue('');
+    mocks.searchDirectory.mockResolvedValue('src');
     mocks.confirmScan.mockResolvedValue(true);
 
     mocks.traceRun.mockResolvedValue('{"trace":"ok"}');
     mocks.pathRun.mockResolvedValue('{"path":"ok"}');
     mocks.explainRun.mockResolvedValue('{"explain":"ok"}');
     mocks.summaryRun.mockResolvedValue('{"summary":"ok"}');
+    mocks.architectureRun.mockResolvedValue('{"architecture":"ok"}');
+    mocks.checkDependenciesRun.mockResolvedValue('{"outgoing":{},"incoming":{}}');
+    mocks.cyclesRun.mockResolvedValue('{"cycleCount":0,"confirmedCycles":[]}');
     mocks.checkRun.mockResolvedValue('{"check":"ok"}');
   });
 
@@ -109,9 +130,9 @@ describe('REPL command chaining e2e', () => {
     expect(mocks.traceRun).toHaveBeenCalledWith(
       [`${expectedFile}#main`],
       runtime,
-      'text',
+      'json',
     );
-    expect(mocks.checkRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+    expect(mocks.checkRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
   });
 
   it('chains selected file from trace into summary codemap input', async () => {
@@ -131,7 +152,7 @@ describe('REPL command chaining e2e', () => {
     await run(runtime as never);
 
     const expectedFile = path.resolve('/workspace', 'src/index.ts');
-    expect(mocks.summaryRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+    expect(mocks.summaryRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
   });
 
   it('does not execute drill-down when there is no file context', async () => {
@@ -144,7 +165,7 @@ describe('REPL command chaining e2e', () => {
     const runtime = createRuntimeStub();
     await run(runtime as never);
 
-    expect(mocks.summaryRun).toHaveBeenCalledWith([], runtime, 'text');
+    expect(mocks.summaryRun).toHaveBeenCalledWith([], runtime, 'json');
     expect(mocks.traceRun).not.toHaveBeenCalled();
     expect(mocks.explainRun).not.toHaveBeenCalled();
     expect(stdoutSpy).toHaveBeenCalledWith(
@@ -152,9 +173,9 @@ describe('REPL command chaining e2e', () => {
     );
   });
 
-  it('drill-down on path result reuses current file context and allows empty symbol fallback', async () => {
+  it('drill-down on dependency result reuses current file context and allows empty symbol fallback', async () => {
     mocks.selectMainAction
-      .mockResolvedValueOnce('path')
+      .mockResolvedValueOnce('checkDependencies')
       .mockResolvedValueOnce('quit');
 
     mocks.selectPostResultAction.mockResolvedValueOnce('drillDown');
@@ -167,8 +188,8 @@ describe('REPL command chaining e2e', () => {
 
     const expectedFile = path.resolve('/workspace', 'src/utils.ts');
 
-    expect(mocks.pathRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
-    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+    expect(mocks.checkDependenciesRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
+    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
   });
 
   it('reuses previous symbol as drill-down default input', async () => {
@@ -191,7 +212,7 @@ describe('REPL command chaining e2e', () => {
 
     expect(mocks.inputSymbol).toHaveBeenNthCalledWith(1, 'src/index.ts');
     expect(mocks.inputSymbol).toHaveBeenNthCalledWith(2, expectedRelative, 'handler');
-    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
   });
 
   it('chains file context from explain fallback into check when trace symbol is empty', async () => {
@@ -212,7 +233,256 @@ describe('REPL command chaining e2e', () => {
 
     const expectedFile = path.resolve('/workspace', 'src/utils.ts');
 
-    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
-    expect(mocks.checkRun).toHaveBeenCalledWith([expectedFile], runtime, 'text');
+    expect(mocks.explainRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
+    expect(mocks.checkRun).toHaveBeenCalledWith([expectedFile], runtime, 'json');
+  });
+
+  it('runs full architecture action from REPL main menu', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('architecture')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.architectureRun).toHaveBeenCalledWith([], runtime, 'json');
+  });
+
+  it('does not print the header as standalone scrollback before the prompt loop', async () => {
+    mocks.selectMainAction.mockResolvedValueOnce({ kind: 'quit' });
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(stdoutSpy).not.toHaveBeenCalledWith(expect.stringContaining('Type / to browse commands'));
+    expect(stdoutSpy).toHaveBeenCalledWith('\nGoodbye!\n');
+  });
+
+  it('changes preferred format and uses it on next command', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('summary')
+      .mockResolvedValueOnce('summary')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction
+      .mockResolvedValueOnce('setFormat')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPreferredFormat.mockResolvedValueOnce('json');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.summaryRun).toHaveBeenNthCalledWith(1, [], runtime, 'json');
+    expect(mocks.summaryRun).toHaveBeenNthCalledWith(2, [], runtime, 'json');
+  });
+
+  it('exports using structured raw data even when display format is text', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('checkDependencies')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('export');
+    mocks.selectExportFormat.mockResolvedValueOnce('json');
+    mocks.searchFile.mockResolvedValueOnce('src/utils.ts');
+    mocks.checkDependenciesRun.mockResolvedValueOnce('{"outgoing":{"dependencyCount":1},"incoming":{"referencingFileCount":2}}');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('"outgoing"'));
+  });
+
+  it('keeps mermaid output when preferred format is mermaid', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('summary')
+      .mockResolvedValueOnce('summary')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction
+      .mockResolvedValueOnce('setFormat')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPreferredFormat.mockResolvedValueOnce('mermaid');
+    mocks.summaryRun
+      .mockResolvedValueOnce('{"filesIndexed":2}')
+      .mockResolvedValueOnce('{"filesIndexed":2}');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('graph TD'));
+    expect(stdoutSpy).not.toHaveBeenCalledWith(
+      'Rendered in text (default mermaid unsupported for this command).\n',
+    );
+  });
+
+  it('executes a free-form command from REPL command input', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('command')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+    mocks.inputCommandLine.mockResolvedValueOnce('architecture --format mermaid');
+    mocks.architectureRun.mockResolvedValueOnce(
+      '{"nodes":[{"id":"a","relativePath":"src/a.ts"}],"edges":[]}',
+    );
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.architectureRun).toHaveBeenCalledWith([], runtime, 'json');
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('graph LR'));
+  });
+
+  it('warns user when an unknown --format value is given in free-form command', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce('command')
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+    mocks.inputCommandLine.mockResolvedValueOnce('architecture --format banana');
+    mocks.architectureRun.mockResolvedValueOnce('{"nodes":[],"edges":[]}');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown format "banana"'),
+    );
+  });
+
+  it('warns user when --format is provided without a value', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'typed', commandLine: '/architecture --format' })
+      .mockResolvedValueOnce({ kind: 'quit' });
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+    mocks.architectureRun.mockResolvedValueOnce('{"nodes":[],"edges":[]}');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown format "(missing value)"'),
+    );
+  });
+
+  it('supports quoted file paths in typed slash commands', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'typed', commandLine: '/check-dependencies "src/my file.ts"' })
+      .mockResolvedValueOnce({ kind: 'quit' });
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.checkDependenciesRun).toHaveBeenCalledWith(
+      [path.resolve('/workspace', 'src/my file.ts')],
+      runtime,
+      'json',
+    );
+  });
+
+  it('executes cycles slash command', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'typed', commandLine: '/cycles src/index.ts' })
+      .mockResolvedValueOnce({ kind: 'quit' });
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.cyclesRun).toHaveBeenCalledWith(
+      [path.resolve('/workspace', 'src/index.ts')],
+      runtime,
+      'json',
+    );
+  });
+
+  it('sets current file context with /file and reuses it for summary', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'typed', commandLine: '/file src/index.ts' })
+      .mockResolvedValueOnce({ kind: 'typed', commandLine: '/summary' })
+      .mockResolvedValueOnce({ kind: 'quit' });
+
+    mocks.selectPostResultAction
+      .mockResolvedValueOnce('newAnalysis')
+      .mockResolvedValueOnce('quit');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.summaryRun).toHaveBeenCalledWith(
+      [path.resolve('/workspace', 'src/index.ts')],
+      runtime,
+      'json',
+    );
+  });
+
+  it('executes a typed slash command selected directly from the palette', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'typed', commandLine: '/architecture --format mermaid' })
+      .mockResolvedValueOnce({ kind: 'quit' });
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('quit');
+    mocks.architectureRun.mockResolvedValueOnce(
+      '{"nodes":[{"id":"a","relativePath":"src/a.ts"}],"edges":[]}',
+    );
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.architectureRun).toHaveBeenCalledWith([], runtime, 'json');
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('graph LR'));
+  });
+
+  it('shows slash help without opening a post-result menu', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'action', action: 'help' })
+      .mockResolvedValueOnce({ kind: 'quit' });
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('Slash commands'));
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringContaining('/trace'));
+    expect(mocks.selectPostResultAction).not.toHaveBeenCalled();
+  });
+
+  it('changes the default format from the slash palette action', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'action', action: 'format' })
+      .mockResolvedValueOnce('quit');
+
+    mocks.selectPreferredFormat.mockResolvedValueOnce('markdown');
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.selectPreferredFormat).toHaveBeenCalledWith('text');
+    expect(stdoutSpy).toHaveBeenCalledWith('Default format set to markdown.\n');
+  });
+
+  it('uses .mmd as default save extension for mermaid results', async () => {
+    mocks.selectMainAction
+      .mockResolvedValueOnce({ kind: 'typed', commandLine: '/architecture --format mermaid' })
+      .mockResolvedValueOnce({ kind: 'quit' });
+
+    mocks.selectPostResultAction.mockResolvedValueOnce('saveToFile');
+    mocks.architectureRun.mockResolvedValueOnce(
+      '{"nodes":[{"id":"a","relativePath":"src/a.ts"}],"edges":[]}',
+    );
+
+    const runtime = createRuntimeStub();
+    await run(runtime as never);
+
+    expect(mocks.inputSavePath).toHaveBeenCalledWith(
+      expect.stringMatching(/\.graph-it\/exports\/.*-architecture\.mmd$/),
+    );
   });
 });

--- a/tests/cli/repl.prompts.test.ts
+++ b/tests/cli/repl.prompts.test.ts
@@ -4,10 +4,12 @@ import {
   buildDirectoryBrowserChoices,
   buildPostResultChoices,
   buildFileBrowserChoices,
+  buildContextualPostResultEntries,
   handleDirectorySelection,
   resolveJumpTarget,
 } from '../../src/cli/repl/prompts';
 import { sanitizeTerminalText } from '../../src/cli/repl/terminal';
+import { getTip, getPersonaTip } from '../../src/cli/repl/tips';
 
 describe('buildMainActionChoices', () => {
   it('stays quiet for empty input until the user types slash', () => {
@@ -185,5 +187,139 @@ describe('resolveJumpTarget', () => {
       throw new Error('Expected not-found resolution');
     }
     expect(resolution.suggestions.length).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// Tips
+// ============================================================================
+
+describe('getTip', () => {
+  it('returns a non-empty string for known keys', () => {
+    expect(getTip('trace.file', 0)).toBeTruthy();
+    expect(getTip('general', 0)).toBeTruthy();
+  });
+
+  it('rotates deterministically via counter', () => {
+    const a = getTip('general', 0);
+    const b = getTip('general', 1);
+    // Different counter → different tip (general has multiple entries)
+    expect(typeof a).toBe('string');
+    expect(typeof b).toBe('string');
+    // Wraps around: counter % length should be consistent
+    expect(getTip('trace.file', 3)).toBe(getTip('trace.file', 3));
+  });
+
+  it('returns empty string for unknown key', () => {
+    expect(getTip('unknown.key.xyz', 0)).toBe('');
+  });
+});
+
+describe('getPersonaTip', () => {
+  it('returns a non-empty string', () => {
+    expect(getPersonaTip(0)).toBeTruthy();
+  });
+
+  it('rotates over persona tips deterministically', () => {
+    const tip0 = getPersonaTip(0);
+    const tip1 = getPersonaTip(1);
+    expect(tip0).not.toBe(tip1);
+    expect(getPersonaTip(0)).toBe(tip0);
+  });
+});
+
+// ============================================================================
+// buildPostResultChoices — contextual follow-up
+// ============================================================================
+
+describe('buildPostResultChoices with contextual command', () => {
+  it('prepends follow-up entries for trace command', () => {
+    const choices = buildPostResultChoices('/', 'trace');
+    const names = choices.map((c) => c.name);
+    expect(names.some((n) => n.includes('check-dependencies'))).toBe(true);
+    expect(names.some((n) => n.includes('cycles'))).toBe(true);
+  });
+
+  it('prepends follow-up entries for cycles command', () => {
+    const choices = buildPostResultChoices('/', 'cycles');
+    const names = choices.map((c) => c.name);
+    expect(names.some((n) => n.includes('check'))).toBe(true);
+  });
+
+  it('shows standard entries even without a command', () => {
+    const choices = buildPostResultChoices('/');
+    expect(choices.some((c) => c.name.includes('/save'))).toBe(true);
+    expect(choices.some((c) => c.name.includes('/export'))).toBe(true);
+  });
+});
+
+// ============================================================================
+// buildContextualPostResultEntries
+// ============================================================================
+
+describe('buildContextualPostResultEntries', () => {
+  it('returns follow-ups for known commands', () => {
+    expect(buildContextualPostResultEntries('trace').length).toBeGreaterThan(0);
+    expect(buildContextualPostResultEntries('architecture').length).toBeGreaterThan(0);
+    expect(buildContextualPostResultEntries('check').length).toBeGreaterThan(0);
+  });
+
+  it('returns empty array for unknown commands', () => {
+    expect(buildContextualPostResultEntries('unknown-cmd')).toEqual([]);
+  });
+});
+
+// ============================================================================
+// buildFileBrowserChoices — recent files
+// ============================================================================
+
+describe('buildFileBrowserChoices with recent files', () => {
+  it('prepends a recent section when recentFiles is non-empty and at root', () => {
+    const choices = buildFileBrowserChoices(
+      ['src/index.ts', 'src/utils.ts', 'README.md'],
+      '',
+      ['src/index.ts'],
+    );
+
+    const names = choices.map((c) => c.name);
+    const recentIdx = names.findIndex((n) => n.includes('★'));
+    const separatorIdx = names.findIndex((n) => n.includes('Recent'));
+
+    expect(separatorIdx).toBeGreaterThan(-1);
+    expect(recentIdx).toBeGreaterThan(separatorIdx);
+  });
+
+  it('shows no recent section when recentFiles is empty', () => {
+    const choices = buildFileBrowserChoices(['src/index.ts'], '', []);
+    expect(choices.some((c) => c.name.includes('Recent'))).toBe(false);
+  });
+
+  it('shows no recent section when inside a subdirectory', () => {
+    const choices = buildFileBrowserChoices(['src/index.ts'], 'src', ['src/index.ts']);
+    expect(choices.some((c) => c.name.includes('Recent'))).toBe(false);
+  });
+});
+
+// ============================================================================
+// buildMainActionChoices — group separators and persona keywords
+// ============================================================================
+
+describe('buildMainActionChoices — groups and persona keywords', () => {
+  it('inserts group separators when showing the full palette', () => {
+    const choices = buildMainActionChoices('/');
+    const groupHeaders = choices.filter((c) => c.disabled);
+    expect(groupHeaders.length).toBeGreaterThan(0);
+  });
+
+  it('matches "security" keyword to cycles or check entries', () => {
+    const choices = buildMainActionChoices('/security');
+    const names = choices.map((c) => c.name);
+    // Either /cycles or /check must appear since they have 'security' keyword
+    expect(names.some((n) => n.includes('/cycles') || n.includes('/check'))).toBe(true);
+  });
+
+  it('matches "architect" keyword to architecture entry', () => {
+    const choices = buildMainActionChoices('/architect');
+    expect(choices.some((c) => c.name.includes('/architecture'))).toBe(true);
   });
 });

--- a/tests/cli/repl.prompts.test.ts
+++ b/tests/cli/repl.prompts.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildMainActionChoices,
+  buildDirectoryBrowserChoices,
+  buildPostResultChoices,
+  buildFileBrowserChoices,
+  handleDirectorySelection,
+  resolveJumpTarget,
+} from '../../src/cli/repl/prompts';
+import { sanitizeTerminalText } from '../../src/cli/repl/terminal';
+
+describe('buildMainActionChoices', () => {
+  it('stays quiet for empty input until the user types slash', () => {
+    const choices = buildMainActionChoices('');
+    expect(choices).toEqual([]);
+  });
+
+  it('prepends a typed command action when the user enters a command line', () => {
+    const choices = buildMainActionChoices('/architecture --format mermaid');
+    expect(choices[0]).toMatchObject({
+      name: expect.stringContaining('Run typed command'),
+      value: { kind: 'typed', commandLine: '/architecture --format mermaid' },
+    });
+  });
+
+  it('sanitizes control characters in the typed command preview', () => {
+    const choices = buildMainActionChoices('/trace \u001b]8;;https://evil.test\u0007boom');
+    expect(choices[0]?.name).not.toContain('\u001b');
+    expect(choices[0]?.name).not.toContain('\u0007');
+    expect(choices[0]?.name).toContain('/trace');
+  });
+
+  it('stays quiet for plain text queries without slash', () => {
+    const choices = buildMainActionChoices('arch');
+    expect(choices).toEqual([]);
+  });
+
+  it('shows slash suggestions when slash is typed', () => {
+    const choices = buildMainActionChoices('/a');
+    expect(choices.some((choice) => choice.name.includes('/architecture'))).toBe(true);
+  });
+
+  it('includes check-dependencies slash entry', () => {
+    const choices = buildMainActionChoices('/check-d');
+    expect(choices.some((choice) => choice.name.includes('/check-dependencies'))).toBe(true);
+  });
+});
+
+describe('buildPostResultChoices', () => {
+  it('stays quiet for follow-up actions until slash is typed', () => {
+    const choices = buildPostResultChoices('');
+    expect(choices).toEqual([]);
+  });
+
+  it('shows slash-style follow-up actions once slash is typed', () => {
+    const choices = buildPostResultChoices('/');
+    expect(choices.some((choice) => choice.name.includes('/save'))).toBe(true);
+    expect(choices.some((choice) => choice.name.includes('/export'))).toBe(true);
+  });
+});
+
+describe('buildFileBrowserChoices', () => {
+  it('shows top-level directories and files', () => {
+    const choices = buildFileBrowserChoices(
+      [
+        'src/index.ts',
+        'src/cli/repl.ts',
+        'README.md',
+      ],
+      '',
+    );
+
+    expect(choices[0]).toMatchObject({ value: '__jump__' });
+    expect(choices.some((choice) => choice.value === 'dir:src')).toBe(true);
+    expect(choices.some((choice) => choice.value === 'file:README.md')).toBe(true);
+  });
+
+  it('shows parent navigation and nested entries in subdirectories', () => {
+    const choices = buildFileBrowserChoices(
+      [
+        'src/index.ts',
+        'src/cli/repl.ts',
+        'src/cli/prompts.ts',
+        'src/shared/path.ts',
+      ],
+      'src',
+    );
+
+    expect(choices[0]).toMatchObject({ value: '__jump__' });
+    expect(choices[1]).toMatchObject({ value: '__up__' });
+    expect(choices.some((choice) => choice.value === 'dir:src/cli')).toBe(true);
+    expect(choices.some((choice) => choice.value === 'file:src/index.ts')).toBe(true);
+  });
+
+  it('shows an empty-state message for directories without files', () => {
+    const choices = buildFileBrowserChoices(['src/index.ts'], 'docs');
+    expect(choices).toEqual([
+      {
+        name: '⌨ Jump to path…',
+        value: '__jump__',
+      },
+      {
+        name: '↩ Go to parent directory',
+        value: '__up__',
+      },
+      {
+        name: 'No files found in this directory',
+        value: '__empty__',
+        disabled: true,
+      },
+    ]);
+  });
+});
+
+describe('buildDirectoryBrowserChoices', () => {
+  it('shows select-current first for fast Enter validation', () => {
+    const choices = buildDirectoryBrowserChoices(['src/index.ts', 'src/cli/repl.ts'], 'src');
+    expect(choices[0]).toMatchObject({ value: '__select_current__' });
+    expect(choices[1]).toMatchObject({ value: '__jump__' });
+  });
+});
+
+describe('handleDirectorySelection', () => {
+  it('selects a directory when choosing a directory entry', async () => {
+    const result = await handleDirectorySelection(
+      'dir:src/cli',
+      ['src/index.ts', 'src/cli/repl.ts'],
+      'src',
+    );
+
+    expect(result).toEqual({ selectedDirectory: 'src/cli' });
+  });
+
+  it('keeps support for selecting current directory quickly', async () => {
+    const result = await handleDirectorySelection(
+      '__select_current__',
+      ['src/index.ts'],
+      'src',
+    );
+
+    expect(result).toEqual({ selectedDirectory: 'src' });
+  });
+});
+
+describe('sanitizeTerminalText', () => {
+  it('removes ANSI, control and bidi characters', () => {
+    const raw = 'hello\u001b[31m world\u202Eevil\u009bboom';
+    expect(sanitizeTerminalText(raw)).toBe('hello [31m world evil boom');
+  });
+});
+
+describe('resolveJumpTarget', () => {
+  const relativeFiles = [
+    'src/index.ts',
+    'src/cli/repl.ts',
+    'src/shared/path.ts',
+    'README.md',
+  ];
+
+  it('resolves exact file from workspace-relative input', () => {
+    expect(resolveJumpTarget(relativeFiles, '', 'src/index.ts')).toEqual({
+      kind: 'file',
+      value: 'src/index.ts',
+    });
+  });
+
+  it('resolves file relative to current directory', () => {
+    expect(resolveJumpTarget(relativeFiles, 'src', 'cli/repl.ts')).toEqual({
+      kind: 'file',
+      value: 'src/cli/repl.ts',
+    });
+  });
+
+  it('resolves directory target for quick navigation', () => {
+    expect(resolveJumpTarget(relativeFiles, '', 'src/cli')).toEqual({
+      kind: 'directory',
+      value: 'src/cli',
+    });
+  });
+
+  it('returns suggestions when path does not exist', () => {
+    const resolution = resolveJumpTarget(relativeFiles, '', 'path');
+    expect(resolution.kind).toBe('none');
+    if (resolution.kind !== 'none') {
+      throw new Error('Expected not-found resolution');
+    }
+    expect(resolution.suggestions.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/cli/repl.test.ts
+++ b/tests/cli/repl.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for REPL utilities: sessionState and fileSearch.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  createSessionState,
+  type SessionState,
+} from '../../src/cli/repl/sessionState.js';
+
+describe('createSessionState', () => {
+  it('sets workspaceRoot from argument', () => {
+    const state = createSessionState('/home/user/project');
+    expect(state.workspaceRoot).toBe('/home/user/project');
+  });
+
+  it('defaults preferredFormat to text', () => {
+    const state = createSessionState('/tmp/ws');
+    expect(state.preferredFormat).toBe('text');
+  });
+
+  it('has no lastFile or lastResult initially', () => {
+    const state = createSessionState('/tmp/ws');
+    expect(state.lastFile).toBeUndefined();
+    expect(state.lastResult).toBeUndefined();
+  });
+
+  it('allows mutating lastFile on the returned object', () => {
+    const state: SessionState = createSessionState('/tmp/ws');
+    state.lastFile = '/tmp/ws/src/index.ts';
+    expect(state.lastFile).toBe('/tmp/ws/src/index.ts');
+  });
+});

--- a/tests/cli/repl.test.ts
+++ b/tests/cli/repl.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createSessionState,
   type SessionState,
-} from '../../src/cli/repl/sessionState.js';
+} from '../../src/cli/repl/sessionState';
 
 describe('createSessionState', () => {
   it('sets workspaceRoot from argument', () => {
@@ -31,7 +31,7 @@ describe('createSessionState', () => {
   });
 });
 
-import { filterFiles } from '../../src/cli/repl/fileSearch.js';
+import { filterFiles } from '../../src/cli/repl/fileSearch';
 
 describe('filterFiles', () => {
   const workspaceRoot = '/home/user/project';

--- a/tests/cli/repl.test.ts
+++ b/tests/cli/repl.test.ts
@@ -1,6 +1,7 @@
 /**
  * Tests for REPL utilities: sessionState and fileSearch.
  */
+import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   createSessionState,
@@ -34,12 +35,12 @@ describe('createSessionState', () => {
 import { filterFiles } from '../../src/cli/repl/fileSearch';
 
 describe('filterFiles', () => {
-  const workspaceRoot = '/home/user/project';
+  const workspaceRoot = path.join('home', 'user', 'project');
   const files = [
-    '/home/user/project/src/index.ts',
-    '/home/user/project/src/utils/helpers.ts',
-    '/home/user/project/src/cli/commands/scan.ts',
-    '/home/user/project/tests/cli/repl.test.ts',
+    path.join(workspaceRoot, 'src', 'index.ts'),
+    path.join(workspaceRoot, 'src', 'utils', 'helpers.ts'),
+    path.join(workspaceRoot, 'src', 'cli', 'commands', 'scan.ts'),
+    path.join(workspaceRoot, 'tests', 'cli', 'repl.test.ts'),
   ];
 
   it('returns all files when query is empty', () => {
@@ -57,7 +58,7 @@ describe('filterFiles', () => {
   it('returns relative paths (not absolute)', () => {
     const result = filterFiles(files, 'index', workspaceRoot);
     expect(result).toContain('src/index.ts');
-    expect(result.every((r: string) => !r.startsWith('/'))).toBe(true);
+    expect(result.every((r: string) => !path.isAbsolute(r))).toBe(true);
   });
 
   it('returns results sorted alphabetically', () => {

--- a/tests/cli/repl.test.ts
+++ b/tests/cli/repl.test.ts
@@ -19,9 +19,10 @@ describe('createSessionState', () => {
     expect(state.preferredFormat).toBe('text');
   });
 
-  it('has no lastFile or lastResult initially', () => {
+  it('has no lastFile, lastSymbol, or lastResult initially', () => {
     const state = createSessionState('/tmp/ws');
     expect(state.lastFile).toBeUndefined();
+    expect(state.lastSymbol).toBeUndefined();
     expect(state.lastResult).toBeUndefined();
   });
 

--- a/tests/cli/repl.test.ts
+++ b/tests/cli/repl.test.ts
@@ -30,3 +30,49 @@ describe('createSessionState', () => {
     expect(state.lastFile).toBe('/tmp/ws/src/index.ts');
   });
 });
+
+import { filterFiles } from '../../src/cli/repl/fileSearch.js';
+
+describe('filterFiles', () => {
+  const workspaceRoot = '/home/user/project';
+  const files = [
+    '/home/user/project/src/index.ts',
+    '/home/user/project/src/utils/helpers.ts',
+    '/home/user/project/src/cli/commands/scan.ts',
+    '/home/user/project/tests/cli/repl.test.ts',
+  ];
+
+  it('returns all files when query is empty', () => {
+    const result = filterFiles(files, '', workspaceRoot);
+    expect(result).toHaveLength(4);
+  });
+
+  it('filters by substring (case-insensitive)', () => {
+    const result = filterFiles(files, 'cli', workspaceRoot);
+    expect(result).toContain('src/cli/commands/scan.ts');
+    expect(result).toContain('tests/cli/repl.test.ts');
+    expect(result).not.toContain('src/index.ts');
+  });
+
+  it('returns relative paths (not absolute)', () => {
+    const result = filterFiles(files, 'index', workspaceRoot);
+    expect(result).toContain('src/index.ts');
+    expect(result.every((r: string) => !r.startsWith('/'))).toBe(true);
+  });
+
+  it('returns results sorted alphabetically', () => {
+    const result = filterFiles(files, '', workspaceRoot);
+    const sorted = [...result].sort((a, b) => a.localeCompare(b));
+    expect(result).toEqual(sorted);
+  });
+
+  it('returns empty array when nothing matches', () => {
+    const result = filterFiles(files, 'zzznomatch', workspaceRoot);
+    expect(result).toHaveLength(0);
+  });
+
+  it('matches against uppercase input', () => {
+    const result = filterFiles(files, 'INDEX', workspaceRoot);
+    expect(result).toContain('src/index.ts');
+  });
+});

--- a/tests/cli/repl.tokenize.test.ts
+++ b/tests/cli/repl.tokenize.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { tokenizeCommandLine } from '../../src/cli/repl/tokenize';
+
+describe('tokenizeCommandLine', () => {
+  it('supports quoted arguments with spaces', () => {
+    expect(tokenizeCommandLine('/trace "src/my file.ts#main"')).toEqual({
+      tokens: ['/trace', 'src/my file.ts#main'],
+    });
+  });
+
+  it('supports escaped spaces without shelling out', () => {
+    expect(tokenizeCommandLine(String.raw`/path src/my\ file.ts`)).toEqual({
+      tokens: ['/path', 'src/my file.ts'],
+    });
+  });
+
+  it('returns an error for unterminated quotes', () => {
+    expect(tokenizeCommandLine('/trace "src/file.ts')).toEqual({
+      tokens: [],
+      error: 'unterminated " quote',
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,11 +29,6 @@
       ]
     }
   },
-  "references": [
-    {
-      "path": "./tsconfig.test.node.json"
-    }
-  ],
   "include": [
     "src/**/*.ts"
   ],


### PR DESCRIPTION
- Enhanced SessionState to include recentFiles and tipCounter for tracking recently visited files and managing tip rotation.
- Introduced tips module with step-specific and persona-tagged tips to guide users through the REPL commands.
- Updated REPL prompts to utilize new tips and contextual follow-up actions based on user commands.
- Modified end-to-end tests to cover new functionality, including checks for recent files and command-specific follow-ups.
- Improved file browser choices to display recent files when applicable.