### PR TITLE
feat: graph-it query — natural language codebase queries (S-1/S-2/S-3)

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -110,6 +110,7 @@ test.log
 # AI/Agent configuration directories (may contain large files or binaries)
 .agent/**
 .agents/**
+.claude/**
 .codex/**
 .continue/**
 .cursor/**
@@ -117,6 +118,10 @@ test.log
 .roo/**
 .kiro/**
 plan/**
+
+# Knowledge graph & analysis output (dev-only, never ship)
+graphify-out/**
+.serena/**
 
 # OS files
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ VS Code extension + standalone CLI + MCP server for AI-friendly dependency visua
 
 2. **`extension/`** — VS Code host. GraphProvider orchestrates 8+ services in `extension/services/`: BackgroundIndexingManager, CallGraphViewService, CommandRegistrationService, EditorEventsService, GraphViewService, SymbolViewService, WebviewMessageRouter, etc.
 
-3. **`mcp/`** — MCP server (stdio transport). **NO vscode imports**. 22 tools for LLM clients (Copilot, Claude, Cursor). Standalone Node.js process.
+3. **`mcp/`** — MCP server (stdio transport). **NO vscode imports**. 23 tools for LLM clients (Copilot, Claude, Cursor). Standalone Node.js process.
 
 4. **`webview/`** — React 19 browser context. ReactFlow for file/symbol graphs (`webview/components/reactflow/`), Cytoscape.js for live call graph (`webview/components/cytoscape/`). Entry points: `webview/index.tsx` → `dist/webview.js` and `webview/callgraph/index.tsx` → `dist/callgraph.js`.
 
@@ -84,6 +84,13 @@ For broad tasks spanning multiple folders, bootstrap with:
 graph-it architecture --format toon
 ```
 Returns a TOON-format token-optimized snapshot (`nodes`, `edges`, `nodeCount`, `edgeCount`). Then use targeted MCP tools (`generate_codemap`, `query_call_graph`, `analyze_file_logic`) on specific files/symbols.
+
+For natural language questions about the codebase:
+```bash
+graph-it query "how does Spider crawl files" --format text
+graph-it query "what calls CallGraphIndexer" --depth 3
+```
+Requires `ANTHROPIC_API_KEY` (uses `claude-haiku-4-5`) or `OPENAI_API_KEY` + `OPENAI_BASE_URL` + `OPENAI_MODEL`. Falls back to heuristic analysis when no key is set (stderr warning).
 
 ## Key Docs
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ All three layers are also exposed to AI via a **22-tool MCP server**, so your as
 
 ## 🤖 Supercharge Your AI Assistant
 
-Stop pasting file paths and explaining your project structure. Graph-It-Live exposes **22 powerful dependency analysis tools** directly to your AI assistant via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), and **21 native LM Tools** directly in Copilot Agent mode (no MCP setup required).
+Stop pasting file paths and explaining your project structure. Graph-It-Live exposes **23 powerful dependency analysis tools** directly to your AI assistant via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io), and **22 native LM Tools** directly in Copilot Agent mode (no MCP setup required).
 
 **Works with:** GitHub Copilot, Claude (Desktop & Code), Cursor, Windsurf, Antigravity, and any MCP-compatible client.
 
@@ -118,6 +118,7 @@ Stop pasting file paths and explaining your project structure. Graph-It-Live exp
 | *"Analyze the impact of changing calculateTotal's signature"* | `get_impact_analysis` | Breaking change detection + all affected callers |
 | *"Find unused exports in the codebase"* | `find_unused_symbols` | Dead code detection |
 | *"Are there circular dependencies?"* | `crawl_dependency_graph` | Cycle detection built in |
+| *"How does Spider crawl files?"* | `query_natural_language` | Natural language answer synthesised from the call graph |
 
 <div align="center">
   <img src="media/graph-it-live-tools-in-copilot.gif" alt="Using Graph-It-Live tools with GitHub Copilot" width="800"/>
@@ -401,8 +402,9 @@ graph-it path <file>            # Full dependency graph from a file
 graph-it check                  # Scan whole workspace for dead code (unused exports)
 graph-it check <dir>            # Scan a subdirectory for dead code
 graph-it check <file>           # Detect unused exported symbols in a single file
+graph-it query "<question>"     # Natural language query over the call graph (LLM or heuristic fallback)
 graph-it serve                  # Launch MCP stdio server (for AI clients)
-graph-it tool --list            # List all 21 CLI analysis tools
+graph-it tool --list            # List all 22 CLI analysis tools
 graph-it tool <mcp-tool> [args] # Run any MCP tool directly from the terminal
 graph-it update                 # Update graph-it to the latest version
 graph-it install                # Symlink the binary into your system PATH (opt-in)
@@ -481,7 +483,7 @@ Graph-It-Live includes an optional **MCP server** that exposes its full analysis
 
 ### Available Tools
 
-The MCP server exposes **22 tools** for AI/LLM consumption. The 21 analysis tools, excluding the server-management-only `set_workspace`, are also available as **native LM Tools** (`#graphResolve`, `#graphBreaking`, `#graphCallGraph`, etc.) directly in Copilot Agent mode — no MCP server required for those.
+The MCP server exposes **23 tools** for AI/LLM consumption. The 22 analysis tools, excluding the server-management-only `set_workspace`, are also available as **native LM Tools** (`#graphResolve`, `#graphBreaking`, `#graphCallGraph`, etc.) directly in Copilot Agent mode — no MCP server required for those.
 
 | Tool | Description |
 | :--- | :---------- |
@@ -507,6 +509,7 @@ The MCP server exposes **22 tools** for AI/LLM consumption. The 21 analysis tool
 | `graphitlive_generate_codemap` | Generate a comprehensive structured overview of any source file |
 | `graphitlive_query_call_graph` | Query cross-file callers/callees via BFS on the call graph SQLite database |
 | `graphitlive_scan_dead_code` | Scan the entire workspace (or a directory) for unused exported symbols in one call |
+| `query_natural_language` | Answer a natural language question about the codebase using the call graph (LLM or heuristic fallback) |
 
 ### TOON Format (Token-Optimized Output)
 
@@ -557,6 +560,7 @@ All 21 analysis tools are also available **natively in GitHub Copilot** — no M
 | `#graphBreaking` | `analyze_breaking_changes` | Detect breaking changes between two file versions |
 | `#graphCallGraph` | `query_call_graph` | BFS callers/callees via the SQLite call graph index |
 | `#graphDeadCode` | `scan_dead_code` | Workspace-wide dead code scan — all unused exported symbols |
+| `#graphQuery` | `query_natural_language` | Natural language question over the call graph (LLM or heuristic fallback) |
 
 > **Note:** `#graphCallGraph` requires the Call Graph panel (`graph-it-live.showCallGraph`) to be opened at least once to build the index.
 

--- a/README.md
+++ b/README.md
@@ -441,6 +441,8 @@ This output can be pasted directly into any Markdown renderer (GitHub, Notion, V
 
 **Use as MCP server (no VS Code):** Run `graph-it serve` and point your AI client at it — see [Manual MCP Server Configuration](#manual-mcp-server-configuration).
 
+**Interactive REPL:** Run `graph-it` with no arguments to enter interactive mode. Type `/query how does X work` to ask natural language questions about your codebase (no quotes needed). Other slash commands: `/trace`, `/summary`, `/architecture`, `/check`, `/cycles`, `/format`, `/help`.
+
 **Full CLI reference:** See **[docs/CLI.md](docs/CLI.md)** for complete documentation on every command, all options, output format examples, advanced workflows, and the full MCP tools reference.
 
 ---

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,26 @@
 # Changelog
 je confirme par contre je vzais 
+## [Unreleased] — graph-it query
+
+### Added
+
+- **QueryEngine** (`analyzer/`): BFS multi-seeds over the call graph SQLite index, FTS5 full-text search, TOON output support. Heuristic fallback when no LLM key is configured.
+- **LLM client layer**: `AnthropicLlmClient` (ANTHROPIC_API_KEY → `claude-haiku-4-5`) and `OpenAiCompatibleLlmClient` (OPENAI_API_KEY + OPENAI_BASE_URL + OPENAI_MODEL). Automatic selection at runtime; stderr warning when falling back to heuristic mode.
+- **MCP tool `query_natural_language`** (`mcp/`): Zod-validated tool exposing natural language queries over the call graph. Returns a TOON subgraph. Available as `#graphQuery` in Copilot Agent mode.
+- **CLI command `graph-it query "<question>"`** (`cli/`): Top-level command with `--depth` and `--format` flags. Supports `json`, `toon`, and `text` output formats.
+- **REPL `/query` slash command**: Natural language query available interactively inside the `graph-it repl` session.
+
+### Fixed
+
+- **`--format` flag ignored on `query` command**: Top-level CLI argument parser was consuming `--format` before the `query` sub-command handler could read it. Flag now correctly forwarded.
+- **`/query` absent from REPL help display**: `SLASH_COMMANDS` visual table did not include `/query`; entry added.
+- **`parseQuestion` returning only first word**: Function was splitting on whitespace and returning `tokens[0]`; now joins all positional arguments as the full question string.
+
+### Notes
+
+- S-4 (VS Code inline query panel) is out of scope for this branch — tracked separately.
+- No breaking changes. Existing MCP tools, CLI commands, and extension behaviour are unchanged.
+
 ## v1.9.8
 
 ### Bug Fixes

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,6 +18,7 @@ The `graph-it` CLI gives you full access to the dependency analysis engine of Gr
   - [path](#path)
   - [check](#check)
   - [trace](#trace)
+  - [query](#query)
   - [tool](#tool)
   - [serve](#serve)
   - [install](#install)
@@ -128,13 +129,13 @@ All analysis commands support multiple output formats via `--format`:
 
 **Format availability per command:**
 
-| Format | scan | summary | explain | path | check | trace | tool |
-|--------|:----:|:-------:|:-------:|:----:|:-----:|:-----:|:----:|
-| `text` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `json` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `toon` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `markdown` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| `mermaid` | — | — | — | ✓ | — | ✓ | — |
+| Format | scan | summary | explain | path | check | trace | query | tool |
+|--------|:----:|:-------:|:-------:|:----:|:-----:|:-----:|:-----:|:----:|
+| `text` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `json` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `toon` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `markdown` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ |
+| `mermaid` | — | — | — | ✓ | — | ✓ | — | — |
 
 **Examples:**
 
@@ -609,9 +610,57 @@ graph-it trace src/mcp/mcpServer.ts#initializeServer --format json
 
 ---
 
+### query
+
+Answer a natural language question about the codebase using the call graph. When an LLM API key is configured the answer is synthesised by the model; otherwise a heuristic fallback is used and a warning is printed to stderr.
+
+```
+graph-it query "<question>" [options]
+```
+
+**Arguments:**
+
+| Argument | Description |
+|----------|-------------|
+| `<question>` | Natural language question about the codebase (max 1024 characters) |
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--workspace, -w` | auto-detected | Project root |
+| `--depth <N>` | `2` | BFS depth for call graph traversal (1–5) |
+| `--token-budget <N>` | `4000` | Max tokens for the subgraph context (500–16000) |
+| `--format <fmt>` | `text` | Output format: `text`, `json`, `toon` |
+
+**LLM configuration (environment variables):**
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Use Anthropic (`claude-haiku-4-5`) |
+| `OPENAI_API_KEY` | Use OpenAI-compatible provider |
+| `OPENAI_BASE_URL` | Base URL for OpenAI-compatible endpoint |
+| `OPENAI_MODEL` | Model name for OpenAI-compatible provider |
+
+When neither key is set, the command falls back to a heuristic analysis and prints a notice to stderr.
+
+**Examples:**
+
+```bash
+graph-it query "how does Spider crawl files"
+graph-it query "how does Spider crawl files" --format text
+graph-it query "what calls CallGraphIndexer" --depth 3
+graph-it query "explain the MCP server architecture" --token-budget 8000
+graph-it query "what is the entry point for the CLI" --format json
+```
+
+> **Breaking change:** `CallGraphIndexer` SCHEMA_VERSION was bumped from 2 to 3 alongside this feature. The index is automatically rebuilt on first use after upgrading.
+
+---
+
 ### tool
 
-Invoke any of the 21 MCP analysis tools directly from the terminal — full MCP parity without a running server.
+Invoke any of the 22 MCP analysis tools directly from the terminal — full MCP parity without a running server.
 
 ```
 graph-it tool <name> [--<param>=<value>...] [options]
@@ -624,7 +673,7 @@ graph-it tool --args '<json>' <name>
 | Argument | Description |
 |----------|-------------|
 | `<name>` | MCP tool name (see `--list`) |
-| `--list` | Print all 21 available tools with one-line descriptions |
+| `--list` | Print all 22 available tools with one-line descriptions |
 
 **Options:**
 
@@ -666,6 +715,7 @@ Available MCP tools:
   generate_codemap               AI-friendly structural overview of a file (TOON)
   query_call_graph               BFS callers/callees via the SQLite call graph index
   scan_dead_code                 Workspace-wide scan for unused exported symbols
+  query_natural_language         Answer a natural language question about the codebase (LLM or heuristic)
 ```
 
 **Calling a tool with parameters:**
@@ -1103,6 +1153,35 @@ graph-it tool scan_dead_code --scopePath=/abs/path/to/src/utils/
 
 ---
 
+#### `query_natural_language`
+
+**What it returns:** A natural language answer to a question about the codebase, grounded in a call graph subgraph. When an LLM key is configured the model synthesises the answer; otherwise a heuristic summary is returned.
+
+**Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `question` | string | — | Natural language question (max 1024 characters) |
+| `depth` | number | `2` | BFS depth for call graph traversal (1–5) |
+| `tokenBudget` | number | `4000` | Max tokens for subgraph context (500–16000) |
+| `fileFilter` | string | — | Glob pattern to restrict which files are included |
+| `outputFormat` | string | `toon` | Subgraph format passed to the LLM: `toon` or `json` |
+
+```bash
+graph-it tool query_natural_language --question="how does Spider crawl files"
+graph-it tool query_natural_language --question="what calls CallGraphIndexer" --depth=3
+graph-it tool query_natural_language --question="explain the MCP server" --tokenBudget=8000
+```
+
+**LLM configuration:**
+- `ANTHROPIC_API_KEY` → uses `claude-haiku-4-5`
+- `OPENAI_API_KEY` + `OPENAI_BASE_URL` + `OPENAI_MODEL` → uses OpenAI-compatible provider
+- No key set → heuristic fallback (warning printed to stderr)
+
+> **Note:** The LLM calling this tool performs the synthesis — the tool returns a structured subgraph that the model interprets.
+
+---
+
 ## Advanced Analysis Workflows
 
 ### Pre-Refactor Safety Check
@@ -1233,12 +1312,12 @@ graph-it tool verify_dependency_usage \
 
 ## Tool Count: CLI vs MCP
 
-The CLI exposes **21 tools** via `graph-it tool --list`, while the MCP server provides **22 tools** in total. This is by design:
+The CLI exposes **22 tools** via `graph-it tool --list`, while the MCP server provides **23 tools** in total. This is by design:
 
 | Context | Tool count | Notes |
 |---------|-----------|-------|
-| `graph-it tool --list` | 21 | All analysis tools |
-| MCP server (`graph-it serve`) | 22 | Same 21 + `set_workspace` |
+| `graph-it tool --list` | 22 | All analysis tools |
+| MCP server (`graph-it serve`) | 23 | Same 22 + `set_workspace` |
 
 The extra tool, `set_workspace`, is a **server management tool** — it tells a running MCP server instance which directory to analyze. In CLI context this is handled by the `--workspace` flag (or auto-detection from `cwd`), so it is intentionally excluded from the CLI tool list.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -168,6 +168,7 @@ graph-it [options]
 
 | Command | Description |
 |--------|-------------|
+| `/query` | Query the codebase with natural language (no quotes needed for multi-word questions) |
 | `/trace` | Run trace flow for a selected file and optional symbol |
 | `/path` | Set session workspace scope (directory) |
 | `/file` | Set active file context for context-aware commands |

--- a/src/analyzer/QueryEngine.ts
+++ b/src/analyzer/QueryEngine.ts
@@ -1,0 +1,414 @@
+/**
+ * QueryEngine — natural-language query over the call graph index.
+ *
+ * NO vscode import — pure Node.js analyzer layer.
+ *
+ * Flow:
+ *   1. extractKeywords(question) — LLM or heuristic
+ *   2. scoreSeedNodes(keywords) — FTS5 SQL query
+ *   3. bfsFromSeeds(db, seeds, depth) — multi-seed BFS traversal
+ *   4. fetchEdges between visited nodes
+ *   5. toToon(nodes, edges, budget) — compact serialization
+ */
+
+import { normalizePath } from '@/shared/path';
+import type { QueryRequest, QueryResult, QueryResultEdge, QueryResultNode } from '@/shared/query-types';
+import { estimateTokenSavings } from '@/shared/toon';
+import type { Database } from 'sql.js';
+import { bfsFromSeeds, splitIdentifier } from './callgraph/CallGraphQuery';
+import type { LlmClient } from './llm/LlmClient';
+
+// ---------------------------------------------------------------------------
+// Stop words (EN + FR + code noise)
+// ---------------------------------------------------------------------------
+
+const STOPWORDS = new Set([
+  'the','and','for','with','from','that','this','have','not','how','does','what','where','why','when',
+  'les','des','une','dans','pour','avec','sur','par','qui','comment','est','sont','fait',
+  'src','dist','index','utils','types','test','spec','impl',
+  'function','class','method','interface','export','import','default','const','return','async','await',
+]);
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+export interface QueryEngineConfig {
+  defaultDepth: number;         // 2
+  defaultTokenBudget: number;   // 4000
+  maxSeedNodes: number;         // 20
+  maxResultNodes: number;       // 200
+}
+
+export const DEFAULT_QUERY_ENGINE_CONFIG: QueryEngineConfig = {
+  defaultDepth: 2,
+  defaultTokenBudget: 4000,
+  maxSeedNodes: 20,
+  maxResultNodes: 200,
+};
+
+// ---------------------------------------------------------------------------
+// Internal raw types from SQL result
+// ---------------------------------------------------------------------------
+
+interface RawNodeRow {
+  id: string;
+  name: string;
+  type: string;
+  path: string;
+  start_line: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// QueryEngine
+// ---------------------------------------------------------------------------
+
+export class QueryEngine {
+  constructor(
+    private readonly db: Database,
+    private readonly llmClient: LlmClient | null,
+    private readonly config: QueryEngineConfig = DEFAULT_QUERY_ENGINE_CONFIG,
+  ) {}
+
+  // -------------------------------------------------------------------------
+  // Main entry point
+  // -------------------------------------------------------------------------
+
+  async query(request: QueryRequest): Promise<QueryResult> {
+    const t0 = Date.now();
+    const depth = request.depth ?? this.config.defaultDepth;
+    const tokenBudget = request.tokenBudget ?? this.config.defaultTokenBudget;
+
+    // 1. Extract keywords
+    const t1 = Date.now();
+    const keywords = await this.extractKeywords(request.question);
+    const keywordExtractionMs = Date.now() - t1;
+
+    const llmProvider = this.llmClient?.providerName ?? 'none';
+
+    // 2. Score seed nodes via FTS5
+    const t2 = Date.now();
+    const seedNodes = this.scoreSeedNodes(keywords);
+    const seeds = seedNodes
+      .slice(0, this.config.maxSeedNodes)
+      .map(n => ({ id: n.id, score: n.relevanceScore }));
+
+    // 3. BFS expansion
+    const visitedIds = bfsFromSeeds(this.db, seeds, depth, this.config.maxResultNodes);
+    const bfsMs = Date.now() - t2;
+
+    // 4. Fetch full node data for visited IDs
+    const nodes = this.fetchNodes(visitedIds, seedNodes);
+
+    // 5. Fetch edges between visited nodes
+    const edges = this.fetchEdges(visitedIds);
+
+    // 6. Serialize to TOON if requested
+    const { toon, truncated, tokenEstimate } = this.toToon(nodes, edges, tokenBudget);
+
+    const totalMs = Date.now() - t0;
+
+    return {
+      question: request.question,
+      extractedKeywords: keywords,
+      seedNodeIds: seeds.map(s => s.id),
+      nodes,
+      edges,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      toon,
+      meta: {
+        llmProvider,
+        keywordExtractionMs,
+        bfsMs,
+        totalMs,
+        tokenEstimate,
+        truncated,
+      },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Keyword extraction
+  // -------------------------------------------------------------------------
+
+  async extractKeywords(question: string): Promise<string[]> {
+    if (this.llmClient !== null) {
+      try {
+        const result = await this.llmClient.complete(
+          [
+            {
+              role: 'system',
+              content:
+                'You are a code search assistant. Extract technical keywords from the user\'s question. Return a JSON array of strings only, no explanation.',
+            },
+            {
+              role: 'user',
+              content: `Question: ${question}\n\nReturn 3-7 technical keywords as a JSON array.`,
+            },
+          ],
+          { maxTokens: 256, temperature: 0.0 },
+        );
+
+        const text = result.text.trim();
+        // Parse the JSON array from the LLM response
+        const match = /\[[\s\S]*\]/.exec(text);
+        if (match) {
+          const parsed: unknown = JSON.parse(match[0]);
+          if (Array.isArray(parsed) && parsed.every(k => typeof k === 'string')) {
+            return (parsed as string[]).filter(k => k.length > 0);
+          }
+        }
+      } catch {
+        // Fall through to heuristic
+      }
+    }
+
+    // Heuristic fallback: split identifiers, remove stopwords
+    return splitIdentifier(question).filter(t => !STOPWORDS.has(t));
+  }
+
+  // -------------------------------------------------------------------------
+  // FTS5 availability cache
+  // -------------------------------------------------------------------------
+
+  private _fts5Available: boolean | undefined;
+
+  private hasFts5(): boolean {
+    if (this._fts5Available !== undefined) return this._fts5Available;
+    try {
+      this.db.exec(`SELECT name FROM nodes_fts LIMIT 1`);
+      this._fts5Available = true;
+    } catch {
+      this._fts5Available = false;
+    }
+    return this._fts5Available;
+  }
+
+  // -------------------------------------------------------------------------
+  // FTS5 seed scoring (with LIKE fallback)
+  // -------------------------------------------------------------------------
+
+  scoreSeedNodes(keywords: string[]): QueryResultNode[] {
+    if (keywords.length === 0) return [];
+
+    const results = new Map<string, QueryResultNode>();
+
+    for (const keyword of keywords) {
+      const tokens = splitIdentifier(keyword);
+      if (tokens.length === 0) continue;
+
+      if (this.hasFts5()) {
+        // FTS5 prefix search
+        const ftsQuery = tokens.map(t => `${t}*`).join(' ');
+        try {
+          const rows = this.db.exec(
+            `SELECT n.id, n.name, n.type, n.path, n.start_line
+             FROM nodes n
+             JOIN nodes_fts f ON n.rowid = f.rowid
+             WHERE nodes_fts MATCH ?
+             LIMIT 50`,
+            [ftsQuery],
+          );
+          for (const row of rows[0]?.values ?? []) {
+            this._accumulateNode(results, row);
+          }
+        } catch {
+          // Unexpected error — fall back to LIKE for this keyword
+          this._scoreBySingleLike(results, keyword);
+        }
+      } else {
+        // LIKE fallback — case-insensitive prefix match on each token
+        this._scoreBySingleLike(results, keyword);
+      }
+    }
+
+    return [...results.values()].sort((a, b) => b.relevanceScore - a.relevanceScore);
+  }
+
+  private _scoreBySingleLike(results: Map<string, QueryResultNode>, keyword: string): void {
+    const tokens = splitIdentifier(keyword);
+    if (tokens.length === 0) return;
+    // Use the first token (most specific) for LIKE match to keep result set small
+    const pattern = `%${tokens[0]}%`;
+    try {
+      const rows = this.db.exec(
+        `SELECT id, name, type, path, start_line
+         FROM nodes
+         WHERE name LIKE ? COLLATE NOCASE
+         LIMIT 50`,
+        [pattern],
+      );
+      for (const row of rows[0]?.values ?? []) {
+        this._accumulateNode(results, row);
+      }
+    } catch {
+      // DB error — skip
+    }
+  }
+
+  private _accumulateNode(
+    results: Map<string, QueryResultNode>,
+    // sql.js SqlValue = string | number | null | Uint8Array — we only use string/number cols
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    row: any[],
+  ): void {
+    const id = row[0] as string;
+    const existing = results.get(id);
+    const score = (existing?.relevanceScore ?? 0) + 1;
+    results.set(id, {
+      id,
+      name: row[1] as string,
+      type: row[2] as string,
+      path: normalizePath(row[3] as string),
+      startLine: (row[4] as number | null) ?? undefined,
+      relevanceScore: score,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // DB fetch helpers
+  // -------------------------------------------------------------------------
+
+  private fetchNodes(
+    visitedIds: Set<string>,
+    seedNodes: QueryResultNode[],
+  ): QueryResultNode[] {
+    if (visitedIds.size === 0) return [];
+
+    // Build a score map from seeds
+    const scoreMap = new Map<string, number>(
+      seedNodes.map(n => [n.id, n.relevanceScore]),
+    );
+
+    const ids = [...visitedIds];
+    const placeholders = ids.map(() => '?').join(', ');
+
+    const rows = this.db.exec(
+      `SELECT id, name, type, path, start_line
+       FROM nodes
+       WHERE id IN (${placeholders})`,
+      ids,
+    );
+
+    if (!rows[0]) return [];
+
+    return rows[0].values.map((row): QueryResultNode => {
+      const id = row[0] as string;
+      return {
+        id,
+        name: row[1] as string,
+        type: row[2] as string,
+        path: normalizePath(row[3] as string),
+        startLine: (row[4] as number | null) ?? undefined,
+        relevanceScore: scoreMap.get(id) ?? 0,
+      };
+    });
+  }
+
+  private fetchEdges(visitedIds: Set<string>): QueryResultEdge[] {
+    if (visitedIds.size === 0) return [];
+
+    const ids = [...visitedIds];
+    const placeholders = ids.map(() => '?').join(', ');
+    const args = [...ids, ...ids];
+
+    const rows = this.db.exec(
+      `SELECT source_id, target_id, type_relation, is_cyclic
+       FROM edges
+       WHERE source_id IN (${placeholders})
+         AND target_id IN (${placeholders})`,
+      args,
+    );
+
+    if (!rows[0]) return [];
+
+    return rows[0].values.map((row): QueryResultEdge => ({
+      source: row[0] as string,
+      target: row[1] as string,
+      relation: row[2] as QueryResultEdge['relation'],
+      isCyclic: (row[3] as number) === 1,
+    }));
+  }
+
+  // -------------------------------------------------------------------------
+  // TOON serialization
+  // -------------------------------------------------------------------------
+
+  /**
+   * Serialize nodes and edges to a compact JSON string with short keys.
+   * Estimates token usage and truncates if budget is exceeded.
+   *
+   * Format: {nodes:[{id,n,t,p,l,r},...],edges:[{src,tgt,rel},...],
+   *          nodeCount,edgeCount,question,keywords,truncated}
+   */
+  toToon(
+    nodes: QueryResultNode[],
+    edges: QueryResultEdge[],
+    tokenBudget: number,
+  ): { toon: string; truncated: boolean; tokenEstimate: number } {
+    const compactNodes = nodes.map(n => ({
+      id: n.id,
+      n: n.name,
+      t: n.type,
+      p: n.path,
+      l: n.startLine,
+      r: n.relevanceScore,
+    }));
+
+    const compactEdges = edges.map(e => ({
+      src: e.source,
+      tgt: e.target,
+      rel: e.relation,
+    }));
+
+    const payload = {
+      nodes: compactNodes,
+      edges: compactEdges,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      truncated: false,
+    };
+
+    const fullJson = JSON.stringify(payload);
+    const { jsonTokens } = estimateTokenSavings(fullJson, fullJson);
+
+    if (jsonTokens <= tokenBudget) {
+      return { toon: fullJson, truncated: false, tokenEstimate: jsonTokens };
+    }
+
+    // Truncate nodes to fit within budget
+    const overhead = JSON.stringify({ ...payload, nodes: [], edges: [], truncated: true }).length;
+    const budgetChars = tokenBudget * 4 - overhead;
+
+    let nodeChars = 0;
+    const fittingNodes: typeof compactNodes = [];
+    for (const n of compactNodes) {
+      const s = JSON.stringify(n);
+      if (nodeChars + s.length > budgetChars) break;
+      fittingNodes.push(n);
+      nodeChars += s.length + 1; // +1 for comma
+    }
+
+    const fittingNodeIds = new Set(fittingNodes.map(n => n.id));
+    const fittingEdges = compactEdges.filter(
+      e => fittingNodeIds.has(e.src) && fittingNodeIds.has(e.tgt),
+    );
+
+    const truncatedPayload = {
+      nodes: fittingNodes,
+      edges: fittingEdges,
+      nodeCount: nodes.length,
+      edgeCount: edges.length,
+      truncated: true,
+    };
+
+    const truncatedJson = JSON.stringify(truncatedPayload);
+    const { jsonTokens: truncTokens } = estimateTokenSavings(truncatedJson, truncatedJson);
+
+    return { toon: truncatedJson, truncated: true, tokenEstimate: truncTokens };
+  }
+}
+
+// Re-export RawNodeRow for test use
+export type { RawNodeRow };

--- a/src/analyzer/callgraph/CallGraphIndexer.ts
+++ b/src/analyzer/callgraph/CallGraphIndexer.ts
@@ -101,6 +101,10 @@ CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
 CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_edges_cyclic ON edges(is_cyclic) WHERE is_cyclic = 1;
 
+-- FTS5 virtual table for fast symbol name search (requires FTS5 WASM build).
+-- Applied separately via tryApplyFts5Schema() — skipped gracefully if FTS5 unavailable.
+-- SCHEMA_FTS5_SQL constant defined below.
+
 CREATE TABLE IF NOT EXISTS metadata (
     key   TEXT PRIMARY KEY,
     value TEXT NOT NULL
@@ -108,7 +112,30 @@ CREATE TABLE IF NOT EXISTS metadata (
 `;
 
 /** Bump when the schema changes — forces a full rebuild on load. */
-const CURRENT_SCHEMA_VERSION = 2;
+const CURRENT_SCHEMA_VERSION = 3;
+
+/**
+ * Optional FTS5 schema for fast symbol name search.
+ * Applied after the main schema via tryApplyFts5Schema().
+ * Silently skipped when the sql.js WASM build does not include FTS5.
+ */
+const SCHEMA_FTS5_SQL = `
+CREATE VIRTUAL TABLE IF NOT EXISTS nodes_fts USING fts5(
+    name,
+    content='nodes',
+    content_rowid='rowid'
+);
+CREATE TRIGGER IF NOT EXISTS nodes_fts_ai AFTER INSERT ON nodes BEGIN
+    INSERT INTO nodes_fts(rowid, name) VALUES (new.rowid, new.name);
+END;
+CREATE TRIGGER IF NOT EXISTS nodes_fts_ad AFTER DELETE ON nodes BEGIN
+    INSERT INTO nodes_fts(nodes_fts, rowid, name) VALUES ('delete', old.rowid, old.name);
+END;
+CREATE TRIGGER IF NOT EXISTS nodes_fts_au AFTER UPDATE ON nodes BEGIN
+    INSERT INTO nodes_fts(nodes_fts, rowid, name) VALUES ('delete', old.rowid, old.name);
+    INSERT INTO nodes_fts(rowid, name) VALUES (new.rowid, new.name);
+END;
+`;
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -163,6 +190,12 @@ export class CallGraphIndexer {
       this.SQL = await initSqlJs({ wasmBinary });
       this.db = new this.SQL.Database();
       this.db.run(SCHEMA_SQL);
+      // FTS5 is optional — silently skip if the WASM build does not include it
+      try {
+        this.db.run(SCHEMA_FTS5_SQL);
+      } catch {
+        // FTS5 not available in this WASM build — keyword search falls back to LIKE
+      }
       this.db.run(
         "INSERT OR REPLACE INTO metadata (key, value) VALUES ('schema_version', ?)",
         [String(CURRENT_SCHEMA_VERSION)],

--- a/src/analyzer/callgraph/CallGraphQuery.ts
+++ b/src/analyzer/callgraph/CallGraphQuery.ts
@@ -353,3 +353,120 @@ function buildCompounds(nodes: SerializedCallNode[]): SerializedCompoundNode[] {
 
   return [...folderMap.values(), ...fileMap.values()];
 }
+
+// ---------------------------------------------------------------------------
+// Multi-seed BFS helpers for QueryEngine
+// ---------------------------------------------------------------------------
+
+/**
+ * Splits a camelCase/PascalCase/snake_case/dot-separated identifier
+ * into lowercase tokens of length > 1.
+ *
+ * Examples:
+ *   "callGraph"    → ["call", "graph"]
+ *   "PathResolver" → ["path", "resolver"]
+ *   "src/utils.ts" → ["src", "utils", "ts"]
+ */
+export function splitIdentifier(identifier: string): string[] {
+  return identifier
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/[_\-./]/g, ' ')
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(t => t.length > 1);
+}
+
+/**
+ * Returns outgoing + incoming neighbour IDs for a single node.
+ * Filters out @@external: prefixed IDs (stubs for external packages).
+ */
+function collectNeighbourIds(db: Database, nodeId: string): string[] {
+  const ids: string[] = [];
+
+  const outgoing = db.exec(
+    `SELECT target_id FROM edges WHERE source_id = ?`,
+    [nodeId],
+  );
+  for (const row of outgoing[0]?.values ?? []) {
+    const id = row[0] as string;
+    if (id && !id.startsWith('@@external:')) {
+      ids.push(id);
+    }
+  }
+
+  const incoming = db.exec(
+    `SELECT source_id FROM edges WHERE target_id = ?`,
+    [nodeId],
+  );
+  for (const row of incoming[0]?.values ?? []) {
+    const id = row[0] as string;
+    if (id && !id.startsWith('@@external:')) {
+      ids.push(id);
+    }
+  }
+
+  return ids;
+}
+
+/**
+ * Multi-seed BFS. Starts from all seed node IDs simultaneously.
+ *
+ * Seeds are sorted by score DESC before expanding each hop, so
+ * higher-relevance branches are explored first.
+ *
+ * Truncation: when `maxNodes` is reached mid-hop, the hop is interrupted.
+ *
+ * @param db        Initialized sql.js Database.
+ * @param seeds     Array of { id, score } pairs (score used for hop ordering).
+ * @param depth     Maximum BFS hop count.
+ * @param maxNodes  Maximum total nodes to return (default: 200).
+ * @returns         Set of visited node IDs (includes seed nodes).
+ */
+export function bfsFromSeeds(
+  db: Database,
+  seeds: Array<{ id: string; score: number }>,
+  depth: number,
+  maxNodes = 200,
+): Set<string> {
+  const visited = new Set<string>();
+
+  // Add all valid seeds first
+  for (const seed of seeds) {
+    if (seed.id && !seed.id.startsWith('@@external:')) {
+      visited.add(seed.id);
+    }
+  }
+
+  if (depth === 0 || visited.size === 0) {
+    return visited;
+  }
+
+  // Frontier: sorted by score DESC for priority expansion
+  let frontier = [...seeds]
+    .filter(s => s.id && !s.id.startsWith('@@external:'))
+    .sort((a, b) => b.score - a.score)
+    .map(s => s.id);
+
+  for (let hop = 0; hop < depth; hop++) {
+    if (frontier.length === 0) break;
+
+    const nextFrontier: string[] = [];
+
+    for (const nodeId of frontier) {
+      if (visited.size >= maxNodes) break;
+
+      const neighbours = collectNeighbourIds(db, nodeId);
+      for (const neighbourId of neighbours) {
+        if (!visited.has(neighbourId)) {
+          visited.add(neighbourId);
+          nextFrontier.push(neighbourId);
+          if (visited.size >= maxNodes) break;
+        }
+      }
+    }
+
+    frontier = nextFrontier;
+  }
+
+  return visited;
+}

--- a/src/analyzer/llm/AnthropicLlmClient.ts
+++ b/src/analyzer/llm/AnthropicLlmClient.ts
@@ -1,0 +1,82 @@
+/**
+ * AnthropicLlmClient — uses native fetch to call Anthropic Messages API.
+ *
+ * NO vscode import — pure Node.js analyzer layer.
+ * Uses fetch (Node 22 native) — no SDK dependency required.
+ */
+
+import type { LlmClient, LlmCompletionOptions, LlmCompletionResult, LlmMessage } from './LlmClient';
+
+const DEFAULT_MODEL = 'claude-haiku-4-5-20251001';
+const API_URL = 'https://api.anthropic.com/v1/messages';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+interface AnthropicResponseBody {
+  content: Array<{ type: string; text?: string }>;
+  usage?: { input_tokens: number; output_tokens: number };
+  error?: { message: string };
+}
+
+export class AnthropicLlmClient implements LlmClient {
+  readonly providerName = 'anthropic' as const;
+
+  private readonly apiKey: string;
+  private readonly model: string;
+
+  constructor(apiKey?: string, model?: string) {
+    this.apiKey = apiKey ?? process.env.ANTHROPIC_API_KEY ?? '';
+    this.model = model ?? DEFAULT_MODEL;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.apiKey.length > 0;
+  }
+
+  async complete(
+    messages: LlmMessage[],
+    options?: LlmCompletionOptions,
+  ): Promise<LlmCompletionResult> {
+    const maxTokens = options?.maxTokens ?? 256;
+    const temperature = options?.temperature ?? 0.0;
+
+    // Separate system message from user/assistant messages
+    const systemMessages = messages.filter(m => m.role === 'system');
+    const chatMessages = messages.filter(m => m.role !== 'system');
+
+    const body: Record<string, unknown> = {
+      model: this.model,
+      max_tokens: maxTokens,
+      temperature,
+      messages: chatMessages.map(m => ({ role: m.role, content: m.content })),
+    };
+
+    if (systemMessages.length > 0) {
+      body.system = systemMessages.map(m => m.content).join('\n');
+    }
+
+    const response = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': this.apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => String(response.status));
+      throw new Error(`Anthropic API error ${response.status}: ${errText}`);
+    }
+
+    const data = (await response.json()) as AnthropicResponseBody;
+
+    const textBlock = data.content?.find(c => c.type === 'text' && c.text);
+    const text = textBlock?.text ?? '';
+    const tokensUsed = data.usage
+      ? data.usage.input_tokens + data.usage.output_tokens
+      : undefined;
+
+    return { text, tokensUsed };
+  }
+}

--- a/src/analyzer/llm/LlmClient.ts
+++ b/src/analyzer/llm/LlmClient.ts
@@ -1,0 +1,28 @@
+/**
+ * LlmClient — abstract interface for LLM completions.
+ *
+ * NO vscode import — pure Node.js analyzer layer.
+ */
+
+import type { LlmProviderName } from '@/shared/query-types';
+
+export interface LlmMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface LlmCompletionOptions {
+  maxTokens?: number;    // default: 256
+  temperature?: number;  // default: 0.0
+}
+
+export interface LlmCompletionResult {
+  text: string;
+  tokensUsed?: number;
+}
+
+export interface LlmClient {
+  readonly providerName: LlmProviderName;
+  isAvailable(): Promise<boolean>;
+  complete(messages: LlmMessage[], options?: LlmCompletionOptions): Promise<LlmCompletionResult>;
+}

--- a/src/analyzer/llm/LlmClientFactory.ts
+++ b/src/analyzer/llm/LlmClientFactory.ts
@@ -1,0 +1,80 @@
+/**
+ * LlmClientFactory — resolves the best available LlmClient per-request.
+ *
+ * NO vscode import — pure Node.js analyzer layer.
+ *
+ * Resolution order:
+ *   1. options.override (if provided)
+ *   2. AnthropicLlmClient if ANTHROPIC_API_KEY is set and isAvailable() = true
+ *   3. OpenAiCompatibleLlmClient if OPENAI_API_KEY is set and isAvailable() = true
+ *   4. null (fallback heuristic mode)
+ *
+ * Logs a WARN once per session when fallback is triggered.
+ */
+
+import { getLogger } from '@/shared/logger';
+import { AnthropicLlmClient } from './AnthropicLlmClient';
+import type { LlmClient } from './LlmClient';
+import { OpenAiCompatibleLlmClient } from './OpenAiCompatibleLlmClient';
+
+const logger = getLogger('LlmClientFactory');
+
+// Module-level flag — log fallback warning only once per session
+let _fallbackWarned = false;
+
+export interface LlmClientFactoryOptions {
+  override?: LlmClient;
+}
+
+/**
+ * Resolves the best available LlmClient.
+ * Called per-query (lazy, not at startup).
+ * Returns null when no LLM is available → heuristic keyword extraction is used.
+ */
+export async function resolveLlmClient(
+  options?: LlmClientFactoryOptions,
+): Promise<LlmClient | null> {
+  // 1. Explicit override
+  if (options?.override) {
+    return options.override;
+  }
+
+  // 2. Anthropic
+  try {
+    const anthropic = new AnthropicLlmClient();
+    if (await anthropic.isAvailable()) {
+      return anthropic;
+    }
+  } catch {
+    // Network or config error — fall through
+  }
+
+  // 3. OpenAI-compatible
+  try {
+    const openai = new OpenAiCompatibleLlmClient();
+    if (await openai.isAvailable()) {
+      return openai;
+    }
+  } catch {
+    // Network or config error — fall through
+  }
+
+  // 4. No LLM available
+  if (!_fallbackWarned) {
+    _fallbackWarned = true;
+    logger.warn(
+      'No LLM provider configured (ANTHROPIC_API_KEY / OPENAI_API_KEY). ' +
+      'Falling back to heuristic keyword extraction.',
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Reset the fallback-warned flag (for testing only).
+ * @internal
+ */
+export function _resetFallbackWarned(): void {
+  _fallbackWarned = false;
+}

--- a/src/analyzer/llm/OpenAiCompatibleLlmClient.ts
+++ b/src/analyzer/llm/OpenAiCompatibleLlmClient.ts
@@ -1,0 +1,73 @@
+/**
+ * OpenAiCompatibleLlmClient — uses native fetch to call OpenAI-compatible chat API.
+ *
+ * NO vscode import — pure Node.js analyzer layer.
+ * Uses fetch (Node 22 native) — no SDK dependency required.
+ * Compatible with OpenAI, Azure OpenAI, LM Studio, Ollama, etc.
+ */
+
+import type { LlmClient, LlmCompletionOptions, LlmCompletionResult, LlmMessage } from './LlmClient';
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const DEFAULT_MODEL = 'gpt-4o-mini';
+
+interface OpenAiResponseBody {
+  choices: Array<{
+    message?: { content?: string };
+    finish_reason?: string;
+  }>;
+  usage?: { total_tokens: number };
+  error?: { message: string };
+}
+
+export class OpenAiCompatibleLlmClient implements LlmClient {
+  readonly providerName = 'openai-compatible' as const;
+
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly model: string;
+
+  constructor(apiKey?: string, baseUrl?: string, model?: string) {
+    this.apiKey = apiKey ?? process.env.OPENAI_API_KEY ?? '';
+    this.baseUrl = (baseUrl ?? process.env.OPENAI_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+    this.model = model ?? process.env.OPENAI_MODEL ?? DEFAULT_MODEL;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.apiKey.length > 0;
+  }
+
+  async complete(
+    messages: LlmMessage[],
+    options?: LlmCompletionOptions,
+  ): Promise<LlmCompletionResult> {
+    const maxTokens = options?.maxTokens ?? 256;
+    const temperature = options?.temperature ?? 0.0;
+
+    const response = await fetch(`${this.baseUrl}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: this.model,
+        max_tokens: maxTokens,
+        temperature,
+        messages: messages.map(m => ({ role: m.role, content: m.content })),
+      }),
+    });
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => String(response.status));
+      throw new Error(`OpenAI API error ${response.status}: ${errText}`);
+    }
+
+    const data = (await response.json()) as OpenAiResponseBody;
+
+    const text = data.choices?.[0]?.message?.content ?? '';
+    const tokensUsed = data.usage?.total_tokens;
+
+    return { text, tokensUsed };
+  }
+}

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -47,10 +47,10 @@ function parseTokenBudget(args: string[]): number {
 
 /**
  * Parse --format from command args.
- * Returns "toon" | "json" | "text" — overrides the top-level CLI format for
- * this command because query has its own output logic.
+ * Returns "toon" | "json" | "text" when the flag is present, undefined otherwise.
+ * This allows the caller to fall back to the top-level CLI format when absent.
  */
-function parseQueryFormat(args: string[]): "toon" | "json" | "text" {
+function parseQueryFormatFromArgs(args: string[]): "toon" | "json" | "text" | undefined {
   const idx = args.indexOf("--format");
   if (idx >= 0 && args[idx + 1]) {
     const val = args[idx + 1];
@@ -58,7 +58,7 @@ function parseQueryFormat(args: string[]): "toon" | "json" | "text" {
       return val;
     }
   }
-  return "toon";
+  return undefined;
 }
 
 /** Flags that consume the next argument as their value. */
@@ -138,8 +138,9 @@ export async function run(
 
   const depth = parseDepth(args);
   const tokenBudget = parseTokenBudget(args);
+  // --format in args overrides the top-level CLI format (e.g. REPL session default)
   const queryFormat: 'toon' | 'json' | 'text' =
-    format === 'json' ? 'json' : format === 'toon' ? 'toon' : 'text';
+    parseQueryFormatFromArgs(args) ?? (format === 'json' ? 'json' : format === 'toon' ? 'toon' : 'toon');
 
   await runtime.ensureIndexed();
 

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -125,7 +125,7 @@ function formatTextOutput(
 export async function run(
   args: string[],
   runtime: CliRuntime,
-  _format: CliOutputFormat,
+  format: CliOutputFormat,
 ): Promise<string> {
   const question = parseQuestion(args);
 
@@ -138,7 +138,8 @@ export async function run(
 
   const depth = parseDepth(args);
   const tokenBudget = parseTokenBudget(args);
-  const queryFormat = parseQueryFormat(args);
+  const queryFormat: 'toon' | 'json' | 'text' =
+    format === 'json' ? 'json' : format === 'toon' ? 'toon' : 'text';
 
   await runtime.ensureIndexed();
 

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -65,25 +65,29 @@ function parseQueryFormatFromArgs(args: string[]): "toon" | "json" | "text" | un
 const FLAG_WITH_VALUE = new Set(["--depth", "--token-budget", "--format"]);
 
 /**
- * Extract the question: first positional non-flag argument.
+ * Extract the question: all positional non-flag arguments joined as a sentence.
+ * Supports both quoted single-arg form ("how does X work") and unquoted multi-word
+ * form (how does X work) so REPL users don't need quotes.
  * Skips values that belong to known flags (e.g. --depth 3 → skip "3").
  */
 function parseQuestion(args: string[]): string | undefined {
+  const parts: string[] = [];
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
     if (arg.startsWith("-")) {
-      // Skip this flag and its value if it consumes one
       if (FLAG_WITH_VALUE.has(arg)) {
         i += 2;
       } else {
         i += 1;
       }
     } else {
-      return arg;
+      parts.push(arg);
+      i += 1;
     }
   }
-  return undefined;
+  const joined = parts.join(" ").trim();
+  return joined.length > 0 ? joined : undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -1,0 +1,175 @@
+/**
+ * CLI Command: query
+ *
+ * Query the codebase with natural language using the call graph index.
+ * Returns a TOON-format subgraph by default, JSON, or human-readable text.
+ *
+ * Usage: graph-it query "<question>" [--depth N] [--token-budget N] [--format toon|json|text]
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ * NO import * as vscode from 'vscode' allowed!
+ */
+
+import * as path from "node:path";
+import { resolveLlmClient } from "../../analyzer/llm/LlmClientFactory.js";
+import { executeQueryNaturalLanguage } from "../../mcp/tools";
+import type { QueryNaturalLanguageParams } from "../../mcp/tools/query.js";
+import { normalizePath } from "../../shared/path.js";
+import { CliError, ExitCode } from "../errors.js";
+import type { CliOutputFormat } from "../formatter.js";
+import type { CliRuntime } from "../runtime.js";
+
+// ---------------------------------------------------------------------------
+// Arg parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseDepth(args: string[]): number {
+  const idx = args.indexOf("--depth");
+  if (idx >= 0 && args[idx + 1]) {
+    const parsed = Number.parseInt(args[idx + 1], 10);
+    if (!Number.isNaN(parsed) && parsed >= 1 && parsed <= 5) {
+      return parsed;
+    }
+  }
+  return 2;
+}
+
+function parseTokenBudget(args: string[]): number {
+  const idx = args.indexOf("--token-budget");
+  if (idx >= 0 && args[idx + 1]) {
+    const parsed = Number.parseInt(args[idx + 1], 10);
+    if (!Number.isNaN(parsed) && parsed >= 500 && parsed <= 16000) {
+      return parsed;
+    }
+  }
+  return 4000;
+}
+
+/**
+ * Parse --format from command args.
+ * Returns "toon" | "json" | "text" — overrides the top-level CLI format for
+ * this command because query has its own output logic.
+ */
+function parseQueryFormat(args: string[]): "toon" | "json" | "text" {
+  const idx = args.indexOf("--format");
+  if (idx >= 0 && args[idx + 1]) {
+    const val = args[idx + 1];
+    if (val === "toon" || val === "json" || val === "text") {
+      return val;
+    }
+  }
+  return "toon";
+}
+
+/** Flags that consume the next argument as their value. */
+const FLAG_WITH_VALUE = new Set(["--depth", "--token-budget", "--format"]);
+
+/**
+ * Extract the question: first positional non-flag argument.
+ * Skips values that belong to known flags (e.g. --depth 3 → skip "3").
+ */
+function parseQuestion(args: string[]): string | undefined {
+  let i = 0;
+  while (i < args.length) {
+    const arg = args[i];
+    if (arg.startsWith("-")) {
+      // Skip this flag and its value if it consumes one
+      if (FLAG_WITH_VALUE.has(arg)) {
+        i += 2;
+      } else {
+        i += 1;
+      }
+    } else {
+      return arg;
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Output formatting
+// ---------------------------------------------------------------------------
+
+function formatTextOutput(
+  result: Awaited<ReturnType<typeof executeQueryNaturalLanguage>>,
+  workspaceRoot: string,
+): string {
+  const lines: string[] = [];
+  lines.push(`Question: ${result.question}`);
+  lines.push(`Keywords: ${result.extractedKeywords.join(", ") || "(none)"}`);
+  lines.push(`Nodes: ${result.nodeCount}  Edges: ${result.edgeCount}`);
+  if (result.meta.truncated) {
+    lines.push("(result truncated — increase --token-budget for more)");
+  }
+  lines.push("");
+
+  if (result.nodes && result.nodes.length > 0) {
+    lines.push("Matching nodes:");
+    for (const node of result.nodes) {
+      const rel = normalizePath(path.relative(workspaceRoot, node.path));
+      lines.push(`  - ${node.name} (${rel})`);
+    }
+  } else if (result.toon) {
+    lines.push(result.toon);
+  } else {
+    lines.push("(no nodes returned)");
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Command entry point
+// ---------------------------------------------------------------------------
+
+export async function run(
+  args: string[],
+  runtime: CliRuntime,
+  _format: CliOutputFormat,
+): Promise<string> {
+  const question = parseQuestion(args);
+
+  if (!question) {
+    throw new CliError(
+      'Usage: graph-it query "<question>" [--depth N] [--token-budget N] [--format toon|json|text]',
+      ExitCode.GENERAL_ERROR,
+    );
+  }
+
+  const depth = parseDepth(args);
+  const tokenBudget = parseTokenBudget(args);
+  const queryFormat = parseQueryFormat(args);
+
+  await runtime.ensureIndexed();
+
+  // Normalize workspaceRoot for cross-platform path usage
+  const normalizedRoot = normalizePath(runtime.workspaceRoot);
+
+  // Check LLM availability and hint if unavailable
+  const llmClient = await resolveLlmClient();
+  if (llmClient === null) {
+    process.stderr.write(
+      "No LLM configured. Using keyword heuristic. " +
+        "Set ANTHROPIC_API_KEY or OPENAI_API_KEY for better results.\n",
+    );
+  }
+
+  const params: QueryNaturalLanguageParams = {
+    question,
+    depth,
+    tokenBudget,
+    outputFormat: queryFormat === "text" ? "json" : queryFormat,
+  };
+
+  const result = await executeQueryNaturalLanguage(params);
+
+  switch (queryFormat) {
+    case "json":
+      return JSON.stringify(result, null, 2);
+    case "text":
+      return formatTextOutput(result, normalizedRoot);
+    case "toon":
+    default:
+      return result.toon ?? JSON.stringify(result, null, 2);
+  }
+}

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -21,6 +21,7 @@ import { parseSymbolRef } from '../symbols.js';
 import {
   confirmScan,
   inputCommandLine,
+  inputQueryQuestion,
   inputSavePath,
   searchDirectory,
   searchFile,
@@ -74,7 +75,7 @@ const LEGACY_TYPED_COMMAND_OPTIONS: TypedCommandOptions = { uiMode: 'legacy' };
 const INK_TYPED_COMMAND_OPTIONS: TypedCommandOptions = { uiMode: 'ink' };
 type DependencyDirection = 'both' | 'outgoing' | 'incoming';
 
-type ReplMainAction = 'trace' | 'command' | 'setPath' | 'checkDependencies' | 'cycles' | 'check' | 'summary' | 'architecture' | 'format' | 'help';
+type ReplMainAction = 'trace' | 'command' | 'setPath' | 'checkDependencies' | 'cycles' | 'check' | 'summary' | 'architecture' | 'query' | 'format' | 'help';
 type ReplStickyAction = 'architecture' | 'summary' | 'check';
 type ReplFileAction = 'trace' | 'checkDependencies' | 'cycles';
 type ReplRunner = (args: string[], runtime: CliRuntime, format: CliOutputFormat) => Promise<string>;
@@ -90,6 +91,7 @@ const REPL_TYPED_RUNNER_LOADERS = {
   trace: () => import('./trace.js'),
   explain: () => import('./explain.js'),
   scan: () => import('./scan.js'),
+  query: () => import('./query.js'),
 } satisfies Record<string, () => Promise<{ run: ReplRunner }>>;
 
 function resolveTypedRunnerKey(command: string): keyof typeof REPL_TYPED_RUNNER_LOADERS | undefined {
@@ -101,6 +103,9 @@ function resolveTypedRunnerKey(command: string): keyof typeof REPL_TYPED_RUNNER_
   }
   if (command === 'cycles' || command === 'cycle') {
     return 'cycles';
+  }
+  if (command === 'q' || command === 'search') {
+    return 'query';
   }
   if (command in REPL_TYPED_RUNNER_LOADERS) {
     return command as keyof typeof REPL_TYPED_RUNNER_LOADERS;
@@ -130,6 +135,7 @@ function buildReplHelpText(state: ReturnType<typeof createSessionState>): string
     '  /summary        Summarize the current file or whole workspace',
     '  /architecture   Build the workspace graph',
     '  /check          Find unused exports',
+    '  /query          Query the codebase with natural language',
     '  /format         Change the default display format',
     '  /command        Run a raw CLI command line',
     '  /help           Show this help',
@@ -528,7 +534,7 @@ async function runTypedCommandLine(
 
   return {
     command: normalizedCommand,
-    output: `Unknown REPL command "${sanitizeTerminalText(normalizedCommand)}". Try: /path, /file, /check-dependencies, /cycles, /summary, /check, /trace, /format, /help.`,
+    output: `Unknown REPL command "${sanitizeTerminalText(normalizedCommand)}". Try: /path, /file, /check-dependencies, /cycles, /summary, /check, /trace, /query, /format, /help.`,
     skipPostAction: true,
   };
 }
@@ -1197,6 +1203,18 @@ async function runAction(
       output: buildReplHelpText(state),
       skipPostAction: true,
     };
+  }
+
+  if (action === 'query') {
+    const question = await inputQueryQuestion();
+    if (!question.trim()) {
+      return {
+        command: 'query',
+        output: 'No question provided. Try: /query "how does Spider crawl files"',
+        skipPostAction: true,
+      };
+    }
+    return executeCommandForRepl('query', [question], runtime, preferredFormat, (await import('./query.js')).run);
   }
 
   if (action === 'architecture' || action === 'summary' || action === 'check') {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -64,6 +64,7 @@ Commands:
   tool <name>       Invoke any MCP tool: graph-it tool get_index_status
   install           Install CLI to system PATH (VS Code opt-in)
   update            Update graph-it to the latest version on npm
+  query <question>   Query the codebase with natural language
 
 Options:
   --workspace, -w   Workspace root directory (default: auto-detected)
@@ -342,6 +343,10 @@ async function dispatch(
     }
     case "update": {
       const { run } = await import("./commands/update.js");
+      return run(args, runtime, format);
+    }
+    case "query": {
+      const { run } = await import("./commands/query.js");
       return run(args, runtime, format);
     }
     default:

--- a/src/cli/repl/ink/ReplInkApp.ts
+++ b/src/cli/repl/ink/ReplInkApp.ts
@@ -84,6 +84,7 @@ const SLASH_COMMANDS: SlashCommandEntry[] = [
   { command: '/architecture', description: 'Build workspace graph', argsHint: '/architecture [--maxFiles N]' },
   { command: '/check', description: 'Find dead code' },
   { command: '/scan', description: 'Force indexing scan' },
+  { command: '/query', description: 'Query the codebase with natural language', argsHint: '/query "<question>" [--depth N] [--token-budget N]' },
   { command: '/command', description: 'Run raw command line', argsHint: '/command <graph-it command...>' },
   { command: '/format', description: 'Set default output format', argsHint: '/format <text|json|toon|markdown|mermaid>' },
   { command: '/help', description: 'Show REPL help' },

--- a/src/cli/repl/prompts.ts
+++ b/src/cli/repl/prompts.ts
@@ -28,6 +28,7 @@ export type MainAction =
   | 'check'
   | 'summary'
   | 'architecture'
+  | 'query'
   | 'format'
   | 'help'
   | 'quit';
@@ -147,6 +148,15 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     aliases: ['check', 'unused'],
     keywords: ['dead', 'unused', 'analysis', 'security', 'qa'],
     value: 'check',
+    group: '🔍 Code Analysis',
+  },
+  {
+    slash: '/query',
+    title: 'Query with natural language',
+    description: 'Ask a question about the codebase and get a subgraph answer.',
+    aliases: ['query', 'q', 'search'],
+    keywords: ['query', 'search', 'ask', 'natural language', 'question'],
+    value: 'query',
     group: '🔍 Code Analysis',
   },
   {
@@ -286,6 +296,10 @@ const FOLLOW_UP_ENTRIES: Record<string, PaletteEntry<PostResultAction>[]> = {
   'path': [
     { slash: '/→ check-dependencies', title: 'Check full deps (in + out)', description: 'See both import directions for the entry file.', aliases: [], keywords: [], value: 'followUpDeps',   group: '🔍 Follow-up' },
     { slash: '/→ cycles',             title: 'Find circular dependencies', description: 'Detect cycles in the dependency graph.',       aliases: [], keywords: [], value: 'followUpCycles', group: '🔍 Follow-up' },
+  ],
+  'query': [
+    { slash: '/→ trace',              title: 'Trace a matching symbol',    description: 'Follow the execution flow from a key result.', aliases: [], keywords: [], value: 'followUpTrace',  group: '🔍 Follow-up' },
+    { slash: '/→ architecture',       title: 'Build workspace architecture', description: 'Map the full dependency graph.',              aliases: [], keywords: [], value: 'followUpArchitecture', group: '🔍 Follow-up' },
   ],
 };
 
@@ -1020,6 +1034,14 @@ export async function selectPreferredFormat(
       { name: 'Mermaid (diagram output)', value: 'mermaid' },
     ],
     default: currentFormat,
+  });
+}
+
+/** Prompt for a natural language question for the query command. */
+export async function inputQueryQuestion(defaultValue = ''): Promise<string> {
+  return input({
+    message: 'Ask a question about the codebase (e.g. "how does Spider crawl files")',
+    default: defaultValue,
   });
 }
 

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -142,6 +142,7 @@ import {
   ResolveModulePathParamsSchema,
   type ResolveModulePathResult,
   ScanDeadCodeParamsSchema,
+  QueryNaturalLanguageParamsSchema,
   // Import all parameter schemas with payload limits
   SetWorkspaceParamsSchema,
   type SetWorkspaceResult,
@@ -1827,6 +1828,67 @@ RETURNS:
     const response = await invokeToolWithResponse(
       "scan_dead_code",
       { scopePath, maxFiles },
+    );
+
+    return formatToolResponse(response, responseFormat);
+  },
+);
+
+// Tool: graphitlive_query_natural_language
+server.registerTool(
+  "graphitlive_query_natural_language",
+  {
+    title: "Query Codebase with Natural Language",
+    description: `Query the codebase graph with a natural language question. Returns a TOON-format subgraph (token-optimized) representing the relevant nodes and edges. The LLM caller should synthesize the subgraph into a human-readable answer.
+
+WHEN TO USE:
+- User asks an open-ended question about the codebase ("How does authentication work?")
+- User wants to explore relationships around a concept without knowing exact file/symbol names
+- User asks "What calls X?" or "Where is Y defined?" when they only know the concept, not the path
+- Codebase exploration before targeted analysis (precedes more specific tools)
+
+EXAMPLES:
+- "How does the MCP server handle tool invocations?"
+- "What are the entry points for call graph indexing?"
+- "Where is workspace configuration stored?"
+- "How does the TOON format get generated?"
+
+WHY YOU NEED THIS:
+This tool performs keyword extraction from the question, scores seed nodes in the call graph index using FTS5 full-text search, then runs BFS traversal to return a relevant subgraph.
+Unlike graphitlive_query_call_graph (which requires exact file+symbol), this tool works from natural language alone.
+The returned subgraph lets the calling LLM synthesize a precise answer grounded in the actual code graph.
+
+IMPORTANT: This tool returns the subgraph data only. YOU (the calling LLM) must synthesize the answer from that data.
+
+First invocation indexes the entire workspace (3-8s). Subsequent queries are instant.
+
+RETURNS:
+- question: The original question
+- extractedKeywords: Keywords used to seed the graph search
+- toon/nodes+edges: The relevant subgraph in requested format
+- meta: Performance metadata (timing, token estimate, truncation flag)`,
+    inputSchema: QueryNaturalLanguageParamsSchema.extend({
+      response_format: ResponseFormatSchema.describe(
+        "Output format: 'json', 'markdown', or 'toon' (default: toon - RECOMMENDED for 30-60% token savings)",
+      ),
+    }),
+    outputSchema: McpToolResponseSchema,
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async ({ question, depth, tokenBudget, fileFilter, outputFormat, response_format }) => {
+    const workerCheck = await ensureWorkerReady();
+    const responseFormat = response_format ?? "toon";
+    if (workerCheck.error)
+      return formatToolResponse(workerCheck.response, responseFormat);
+
+    const response = await invokeToolWithResponse(
+      "query_natural_language",
+      { question, depth, tokenBudget, fileFilter, outputFormat },
     );
 
     return formatToolResponse(response, responseFormat);

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -41,3 +41,7 @@ export {
     executeInvalidateFiles,
     executeRebuildIndex
 } from "./workspace";
+export {
+    executeQueryNaturalLanguage,
+    QueryNaturalLanguageSchema
+} from "./query";

--- a/src/mcp/tools/query.ts
+++ b/src/mcp/tools/query.ts
@@ -1,0 +1,173 @@
+/**
+ * MCP Natural Language Query Tool — query_natural_language
+ *
+ * Converts a natural language question into a TOON-format subgraph by:
+ *   1. Reusing the call graph index already built by callgraph.ts (ensureCallGraphReady)
+ *   2. Instantiating QueryEngine with the sql.js Database and llmClient = null
+ *   3. Delegating synthesis to the LLM caller — this tool only returns the subgraph
+ *
+ * NO vscode imports — this module is VS Code agnostic.
+ */
+
+import { QueryEngine } from "../../analyzer/QueryEngine";
+import type { QueryRequest, QueryResultEdge, QueryResultNode } from "../../shared/query-types";
+import { z } from "zod/v4";
+import { workerState } from "../shared/state";
+
+// ---------------------------------------------------------------------------
+// Zod schema (exported for mcpServer registration)
+// ---------------------------------------------------------------------------
+
+export const QueryNaturalLanguageSchema = z.object({
+  question: z
+    .string()
+    .max(1024)
+    .describe("Natural language question about the codebase"),
+  depth: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .default(2)
+    .optional()
+    .describe("BFS traversal depth from seed nodes (default: 2, min: 1, max: 5)"),
+  tokenBudget: z
+    .number()
+    .int()
+    .min(500)
+    .max(16000)
+    .default(4000)
+    .optional()
+    .describe("Maximum token budget for the output subgraph (default: 4000, min: 500, max: 16000)"),
+  fileFilter: z
+    .string()
+    .max(256)
+    .optional()
+    .describe("Glob pattern to restrict search scope (e.g. 'src/analyzer/**')"),
+  outputFormat: z
+    .enum(["toon", "json"])
+    .default("toon")
+    .optional()
+    .describe("Output format: 'toon' (token-optimized, default) or 'json'"),
+});
+
+export type QueryNaturalLanguageParams = z.infer<typeof QueryNaturalLanguageSchema>;
+
+// ---------------------------------------------------------------------------
+// Result type
+// ---------------------------------------------------------------------------
+
+export interface QueryNaturalLanguageResult {
+  question: string;
+  extractedKeywords: string[];
+  nodeCount: number;
+  edgeCount: number;
+  /** TOON-format string when outputFormat='toon' */
+  toon?: string;
+  /** Full JSON payload when outputFormat='json' */
+  nodes?: QueryResultNode[];
+  edges?: QueryResultEdge[];
+  meta: {
+    llmProvider: string;
+    keywordExtractionMs: number;
+    bfsMs: number;
+    totalMs: number;
+    tokenEstimate: number;
+    truncated: boolean;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Lazy call graph initialization (delegates to callgraph.ts)
+// This avoids duplicating the indexing logic — if callgraph was already indexed
+// by a prior query_call_graph call, we reuse the same indexer in workerState.
+// ---------------------------------------------------------------------------
+
+async function ensureCallGraphReadyForQuery(): Promise<void> {
+  const config = workerState.getConfig();
+  const workspaceRoot = config.rootDir;
+
+  // Already indexed for this workspace — reuse
+  if (
+    workerState.callGraphIndexer &&
+    workerState.callGraphIndexedRoot === workspaceRoot
+  ) {
+    return;
+  }
+
+  // Not indexed yet — trigger it via the callgraph tool's lazy init
+  // callgraph.ts manages the singleton indexPromise to prevent double-indexing
+  const { executeQueryCallGraph } = await import("./callgraph.js");
+
+  // A dummy query to force initialization — we only care about side-effects
+  try {
+    await executeQueryCallGraph({
+      filePath: workspaceRoot,
+      symbolName: "__init_only__",
+      direction: "both",
+      depth: 1,
+    });
+  } catch {
+    // Ignore errors — we only wanted the indexer to be initialized.
+    // If it truly failed, workerState.callGraphIndexer will still be null
+    // and we surface the error below in executeQueryNaturalLanguage.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool execution
+// ---------------------------------------------------------------------------
+
+export async function executeQueryNaturalLanguage(
+  params: QueryNaturalLanguageParams,
+): Promise<QueryNaturalLanguageResult> {
+  const config = workerState.getConfig();
+  const workspaceRoot = config.rootDir;
+
+  // Ensure call graph index is available
+  await ensureCallGraphReadyForQuery();
+
+  const indexer = workerState.callGraphIndexer;
+  if (!indexer) {
+    throw new Error(
+      "Call graph indexer not initialized. The workspace may not have any supported source files.",
+    );
+  }
+
+  const db = indexer.getDb();
+
+  // Build QueryRequest — llmClient is null: the LLM caller synthesizes the answer
+  const request: QueryRequest = {
+    question: params.question,
+    workspaceRoot,
+    depth: params.depth ?? 2,
+    tokenBudget: params.tokenBudget ?? 4000,
+    fileFilter: params.fileFilter,
+    outputFormat: params.outputFormat === "json" ? "json" : "toon",
+  };
+
+  const engine = new QueryEngine(db, null);
+  const result = await engine.query(request);
+
+  if (params.outputFormat === "json") {
+    return {
+      question: result.question,
+      extractedKeywords: result.extractedKeywords,
+      nodeCount: result.nodeCount,
+      edgeCount: result.edgeCount,
+      nodes: result.nodes,
+      edges: result.edges,
+      meta: result.meta,
+    };
+  }
+
+  // Default: toon
+  return {
+    question: result.question,
+    extractedKeywords: result.extractedKeywords,
+    nodeCount: result.nodeCount,
+    edgeCount: result.edgeCount,
+    toon: result.toon,
+    meta: result.meta,
+  };
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -107,7 +107,8 @@ export type McpToolName =
   | "analyze_file_logic" // NEW: LSP-based intra-file call hierarchy
   | "generate_codemap" // NEW: Full codemap generation for a single file
   | "query_call_graph" // NEW: Cross-file call graph query (callers/callees via SQLite)
-  | "scan_dead_code"; // NEW: Workspace-wide dead code scan
+  | "scan_dead_code" // NEW: Workspace-wide dead code scan
+  | "query_natural_language"; // NEW: Natural language query over the call graph
 
 // ============================================================================
 // Zod Schemas for Tool Parameters
@@ -505,6 +506,41 @@ export type QueryCallGraphParams = z.infer<
   typeof QueryCallGraphParamsSchema
 >;
 
+// NEW: Schema for query_natural_language (natural language query over call graph)
+export const QueryNaturalLanguageParamsSchema = z.object({
+  question: z
+    .string()
+    .max(1024)
+    .describe("Natural language question about the codebase"),
+  depth: z
+    .number()
+    .int()
+    .min(1)
+    .max(5)
+    .default(2)
+    .optional()
+    .describe("BFS traversal depth from seed nodes (default: 2, min: 1, max: 5)"),
+  tokenBudget: z
+    .number()
+    .int()
+    .min(500)
+    .max(16000)
+    .default(4000)
+    .optional()
+    .describe("Maximum token budget for the output subgraph (default: 4000)"),
+  fileFilter: z
+    .string()
+    .max(256)
+    .optional()
+    .describe("Glob pattern to restrict search scope"),
+  outputFormat: z
+    .enum(["toon", "json"])
+    .default("toon")
+    .optional()
+    .describe("Output format: 'toon' (default) or 'json'"),
+});
+export type QueryNaturalLanguageParams = z.infer<typeof QueryNaturalLanguageParamsSchema>;
+
 // NEW: Schema for scan_dead_code (workspace-wide dead code scan)
 export const ScanDeadCodeParamsSchema = z.object({
   scopePath: FilePathSchema.optional().describe(
@@ -554,6 +590,7 @@ export const toolSchemas: Record<McpToolName, z.ZodType<unknown>> = {
   generate_codemap: GenerateCodemapParamsSchema,
   query_call_graph: QueryCallGraphParamsSchema,
   scan_dead_code: ScanDeadCodeParamsSchema,
+  query_natural_language: QueryNaturalLanguageParamsSchema,
 };
 
 /**

--- a/src/mcp/worker/invokeTool.ts
+++ b/src/mcp/worker/invokeTool.ts
@@ -21,6 +21,7 @@ import {
   executeScanDeadCode,
   executeTraceFunctionExecution,
   executeVerifyDependencyUsage,
+  executeQueryNaturalLanguage,
 } from "../tools";
 import type {
   AnalyzeBreakingChangesParams,
@@ -44,6 +45,7 @@ import type {
   ScanDeadCodeParams,
   TraceFunctionExecutionParams,
   VerifyDependencyUsageParams,
+  QueryNaturalLanguageParams,
 } from "../types";
 import {
   validateFilePath,
@@ -212,6 +214,11 @@ export async function invokeTool(
       case "scan_dead_code": {
         const p = validatedParams as ScanDeadCodeParams;
         result = await executeScanDeadCode(p);
+        break;
+      }
+      case "query_natural_language": {
+        const p = validatedParams as QueryNaturalLanguageParams;
+        result = await executeQueryNaturalLanguage(p);
         break;
       }
       default:

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -21,3 +21,6 @@ export type * from './types';
 // TOON (Token-Oriented Object Notation) format
 export { jsonToToon, toonToJson, estimateTokenSavings } from './toon';
 export type { ToonOptions } from './toon';
+
+// Query types
+export * from './query-types';

--- a/src/shared/query-types.ts
+++ b/src/shared/query-types.ts
@@ -1,0 +1,54 @@
+/**
+ * Query types for the `graph-it query` feature.
+ *
+ * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
+ * NO import * as vscode from 'vscode' allowed!
+ */
+
+import type { RelationType } from './callgraph-types';
+
+export interface QueryRequest {
+  question: string;
+  workspaceRoot: string;
+  depth?: number;          // default: 2
+  tokenBudget?: number;    // default: 4000
+  fileFilter?: string;
+  outputFormat?: 'toon' | 'json' | 'text';
+}
+
+export interface QueryResultNode {
+  id: string;
+  name: string;
+  type: string;
+  path: string;
+  startLine?: number;
+  relevanceScore: number;
+}
+
+export interface QueryResultEdge {
+  source: string;       // 'source' not 'sourceId' — compatible cycleUtils
+  target: string;       // 'target' not 'targetId'
+  relation: RelationType;
+  isCyclic?: boolean;
+}
+
+export interface QueryResult {
+  question: string;
+  extractedKeywords: string[];
+  seedNodeIds: string[];
+  nodes: QueryResultNode[];
+  edges: QueryResultEdge[];
+  nodeCount: number;
+  edgeCount: number;
+  toon?: string;
+  meta: {
+    llmProvider: 'anthropic' | 'openai-compatible' | 'vscode-lm' | 'none';
+    keywordExtractionMs: number;
+    bfsMs: number;
+    totalMs: number;
+    tokenEstimate: number;
+    truncated: boolean;
+  };
+}
+
+export type LlmProviderName = 'anthropic' | 'openai-compatible' | 'vscode-lm';

--- a/tests/analyzer/QueryEngine.test.ts
+++ b/tests/analyzer/QueryEngine.test.ts
@@ -1,0 +1,405 @@
+/// <reference types="node" />
+
+/**
+ * Unit tests for QueryEngine.
+ *
+ * Uses real sql.js WASM (works in Node.js 22) and mock LlmClient.
+ * FTS5 is available in the bundled sql.js WASM.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Real sql.js WASM — resolve via Node module resolution so it works in
+// both the main project and git worktrees (which share the root node_modules)
+// ---------------------------------------------------------------------------
+
+import { createRequire } from 'node:module';
+const _require = createRequire(import.meta.url);
+const SQL_WASM_PATH: string = _require.resolve('sql.js/dist/sql-wasm.wasm');
+
+import initSqlJs from 'sql.js';
+import type { Database } from 'sql.js';
+import { bfsFromSeeds, splitIdentifier } from '../../src/analyzer/callgraph/CallGraphQuery';
+import { QueryEngine } from '../../src/analyzer/QueryEngine';
+import type { LlmClient } from '../../src/analyzer/llm/LlmClient';
+import type { LlmCompletionOptions, LlmCompletionResult, LlmMessage } from '../../src/analyzer/llm/LlmClient';
+
+// ---------------------------------------------------------------------------
+// Test DB helpers
+// ---------------------------------------------------------------------------
+
+const SCHEMA_SQL = `
+PRAGMA journal_mode=MEMORY;
+PRAGMA synchronous=OFF;
+
+CREATE TABLE IF NOT EXISTS nodes (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    type        TEXT NOT NULL,
+    lang        TEXT NOT NULL DEFAULT 'typescript',
+    path        TEXT NOT NULL,
+    folder      TEXT NOT NULL DEFAULT '',
+    start_line  INTEGER,
+    end_line    INTEGER,
+    start_col   INTEGER DEFAULT 0,
+    is_exported INTEGER DEFAULT 0,
+    indexed_at  INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_nodes_path ON nodes(path);
+CREATE INDEX IF NOT EXISTS idx_nodes_name ON nodes(name);
+
+CREATE TABLE IF NOT EXISTS edges (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id     TEXT NOT NULL,
+    target_id     TEXT NOT NULL,
+    type_relation TEXT NOT NULL DEFAULT 'CALLS',
+    is_cyclic     INTEGER DEFAULT 0,
+    source_line   INTEGER DEFAULT 0,
+    FOREIGN KEY (source_id) REFERENCES nodes(id),
+    FOREIGN KEY (target_id) REFERENCES nodes(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_edges_source ON edges(source_id);
+CREATE INDEX IF NOT EXISTS idx_edges_target ON edges(target_id);
+-- Note: FTS5 is not available in standard sql.js WASM build.
+-- QueryEngine falls back to LIKE queries when nodes_fts table is absent.
+`;
+
+async function createTestDb(): Promise<Database> {
+  const { readFile } = await import('node:fs/promises');
+  const wasmBinary = await readFile(SQL_WASM_PATH);
+  const SQL = await initSqlJs({ wasmBinary });
+  const db = new SQL.Database();
+  db.run(SCHEMA_SQL);
+  return db;
+}
+
+function insertNode(
+  db: Database,
+  id: string,
+  name: string,
+  type = 'function',
+  filePath = '/workspace/src/main.ts',
+): void {
+  db.run(
+    `INSERT INTO nodes (id, name, type, lang, path, folder, start_line, is_exported)
+     VALUES (?, ?, ?, 'typescript', ?, 'src', 10, 1)`,
+    [id, name, type, filePath],
+  );
+}
+
+function insertEdge(db: Database, sourceId: string, targetId: string): void {
+  db.run(
+    `INSERT INTO edges (source_id, target_id, type_relation, is_cyclic, source_line)
+     VALUES (?, ?, 'CALLS', 0, 1)`,
+    [sourceId, targetId],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mock LlmClient
+// ---------------------------------------------------------------------------
+
+class MockLlmClient implements LlmClient {
+  readonly providerName = 'anthropic' as const;
+
+  constructor(private readonly response: string) {}
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async complete(
+    _messages: LlmMessage[],
+    _options?: LlmCompletionOptions,
+  ): Promise<LlmCompletionResult> {
+    return { text: this.response };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// splitIdentifier tests (from CallGraphQuery)
+// ---------------------------------------------------------------------------
+
+describe('splitIdentifier', () => {
+  it('splits camelCase', () => {
+    expect(splitIdentifier('callGraph')).toEqual(['call', 'graph']);
+  });
+
+  it('splits PascalCase', () => {
+    expect(splitIdentifier('PathResolver')).toEqual(['path', 'resolver']);
+  });
+
+  it('splits snake_case', () => {
+    expect(splitIdentifier('my_func_name')).toEqual(['my', 'func', 'name']);
+  });
+
+  it('splits dot-separated paths', () => {
+    const result = splitIdentifier('src/utils.ts');
+    expect(result).toContain('src');
+    expect(result).toContain('utils');
+  });
+
+  it('filters tokens of length <= 1', () => {
+    expect(splitIdentifier('a_b')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bfsFromSeeds tests
+// ---------------------------------------------------------------------------
+
+describe('bfsFromSeeds', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    // nodes: A → B → C, D (isolated), E (@@external)
+    insertNode(db, 'A', 'nodeA');
+    insertNode(db, 'B', 'nodeB');
+    insertNode(db, 'C', 'nodeC');
+    insertNode(db, 'D', 'nodeD');
+    insertEdge(db, 'A', 'B');
+    insertEdge(db, 'B', 'C');
+  });
+
+  afterEach(() => db.close());
+
+  it('depth=0 returns seed nodes only', () => {
+    const result = bfsFromSeeds(db, [{ id: 'A', score: 1 }], 0);
+    expect([...result]).toEqual(['A']);
+  });
+
+  it('depth=1 expands one hop', () => {
+    const result = bfsFromSeeds(db, [{ id: 'A', score: 1 }], 1);
+    expect(result.has('A')).toBe(true);
+    expect(result.has('B')).toBe(true);
+    expect(result.has('C')).toBe(false);
+  });
+
+  it('depth=2 expands two hops', () => {
+    const result = bfsFromSeeds(db, [{ id: 'A', score: 1 }], 2);
+    expect(result.has('A')).toBe(true);
+    expect(result.has('B')).toBe(true);
+    expect(result.has('C')).toBe(true);
+  });
+
+  it('maxNodes=1 truncates to seed only', () => {
+    const result = bfsFromSeeds(db, [{ id: 'A', score: 1 }], 2, 1);
+    expect(result.size).toBe(1);
+    expect(result.has('A')).toBe(true);
+  });
+
+  it('maxNodes=3 limits total nodes when more available', () => {
+    // Insert more nodes to exceed limit
+    for (let i = 0; i < 10; i++) {
+      insertNode(db, `N${i}`, `node${i}`);
+      insertEdge(db, 'C', `N${i}`);
+    }
+    const result = bfsFromSeeds(db, [{ id: 'A', score: 1 }], 3, 3);
+    expect(result.size).toBeLessThanOrEqual(3);
+  });
+
+  it('filters @@external: prefixed seed IDs', () => {
+    const result = bfsFromSeeds(
+      db,
+      [
+        { id: '@@external:lodash', score: 5 },
+        { id: 'A', score: 1 },
+      ],
+      0,
+    );
+    expect(result.has('@@external:lodash')).toBe(false);
+    expect(result.has('A')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QueryEngine.extractKeywords tests
+// ---------------------------------------------------------------------------
+
+describe('QueryEngine.extractKeywords', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(() => db.close());
+
+  it('uses LLM when available and returns parsed keywords', async () => {
+    const mockLlm = new MockLlmClient('["Spider","crawl"]');
+    const engine = new QueryEngine(db, mockLlm);
+    const keywords = await engine.extractKeywords('How does Spider crawl files?');
+    expect(keywords).toEqual(['Spider', 'crawl']);
+  });
+
+  it('falls back to heuristic when llmClient is null', async () => {
+    const engine = new QueryEngine(db, null);
+    const keywords = await engine.extractKeywords('comment Spider parcourt les fichiers');
+    // stopwords filtered: 'comment', 'les' removed
+    expect(keywords).not.toContain('comment');
+    expect(keywords).not.toContain('les');
+    // meaningful tokens kept
+    expect(keywords.some(k => k.length > 1)).toBe(true);
+  });
+
+  it('falls back to heuristic when LLM returns invalid JSON', async () => {
+    const mockLlm = new MockLlmClient('not valid json at all');
+    const engine = new QueryEngine(db, mockLlm);
+    const keywords = await engine.extractKeywords('Spider crawl files');
+    // Should return heuristic result, not throw
+    expect(Array.isArray(keywords)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QueryEngine.scoreSeedNodes tests
+// ---------------------------------------------------------------------------
+
+describe('QueryEngine.scoreSeedNodes', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    // Insert 3 nodes: spider, resolver, helper
+    insertNode(db, 'id-spider', 'Spider', 'class', '/workspace/src/Spider.ts');
+    insertNode(db, 'id-resolver', 'PathResolver', 'class', '/workspace/src/PathResolver.ts');
+    insertNode(db, 'id-helper', 'helper', 'function', '/workspace/src/utils.ts');
+  });
+
+  afterEach(() => db.close());
+
+  it('returns nodes matching keyword with score > 0', () => {
+    const engine = new QueryEngine(db, null);
+    const results = engine.scoreSeedNodes(['Spider']);
+    const spider = results.find(n => n.id === 'id-spider');
+    expect(spider).toBeDefined();
+    expect(spider!.relevanceScore).toBeGreaterThan(0);
+  });
+
+  it('does not return non-matching nodes', () => {
+    const engine = new QueryEngine(db, null);
+    const results = engine.scoreSeedNodes(['Spider']);
+    const ids = results.map(n => n.id);
+    // helper and PathResolver should not be in results
+    expect(ids).not.toContain('id-helper');
+  });
+
+  it('returns empty array for empty keywords', () => {
+    const engine = new QueryEngine(db, null);
+    const results = engine.scoreSeedNodes([]);
+    expect(results).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QueryEngine.toToon tests
+// ---------------------------------------------------------------------------
+
+describe('QueryEngine.toToon', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+  });
+
+  afterEach(() => db.close());
+
+  it('returns valid JSON output with short keys', () => {
+    const engine = new QueryEngine(db, null);
+    const nodes = [
+      { id: 'a', name: 'funcA', type: 'function', path: '/src/a.ts', relevanceScore: 1 },
+    ];
+    const edges = [{ source: 'a', target: 'b', relation: 'CALLS' as const }];
+
+    const { toon } = engine.toToon(nodes, edges, 4000);
+    const parsed = JSON.parse(toon) as Record<string, unknown>;
+
+    expect(parsed).toHaveProperty('nodes');
+    expect(parsed).toHaveProperty('edges');
+    expect(parsed).toHaveProperty('nodeCount');
+    expect(parsed).toHaveProperty('edgeCount');
+
+    const firstNode = (parsed.nodes as Record<string, unknown>[])[0];
+    expect(firstNode).toHaveProperty('n');  // short key for name
+    expect(firstNode).toHaveProperty('t');  // short key for type
+    expect(firstNode).toHaveProperty('p');  // short key for path
+  });
+
+  it('sets truncated=false when within budget', () => {
+    const engine = new QueryEngine(db, null);
+    const nodes = [
+      { id: 'a', name: 'funcA', type: 'function', path: '/src/a.ts', relevanceScore: 1 },
+    ];
+
+    const { truncated } = engine.toToon(nodes, [], 4000);
+    expect(truncated).toBe(false);
+  });
+
+  it('sets truncated=true when budget is exceeded', () => {
+    const engine = new QueryEngine(db, null);
+    // Create many nodes to exceed a tiny budget
+    const nodes = Array.from({ length: 100 }, (_, i) => ({
+      id: `node-${i}`,
+      name: `someVeryLongFunctionNameThatTakesUpSpace${i}`,
+      type: 'function',
+      path: `/workspace/src/very/long/path/to/file${i}.ts`,
+      startLine: i * 10,
+      relevanceScore: i,
+    }));
+
+    const { truncated } = engine.toToon(nodes, [], 10); // tiny budget
+    expect(truncated).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QueryEngine.query end-to-end test
+// ---------------------------------------------------------------------------
+
+describe('QueryEngine.query (end-to-end)', () => {
+  let db: Database;
+
+  beforeEach(async () => {
+    db = await createTestDb();
+    insertNode(db, 'spider-id', 'Spider', 'class', '/workspace/src/Spider.ts');
+    insertNode(db, 'crawl-id', 'crawlFiles', 'function', '/workspace/src/Spider.ts');
+    insertEdge(db, 'spider-id', 'crawl-id');
+  });
+
+  afterEach(() => db.close());
+
+  it('returns a QueryResult with correct meta.llmProvider for mock LLM', async () => {
+    const mockLlm = new MockLlmClient('["Spider","crawl"]');
+    const engine = new QueryEngine(db, mockLlm);
+
+    const result = await engine.query({
+      question: 'How does Spider crawl files?',
+      workspaceRoot: '/workspace',
+      depth: 1,
+      tokenBudget: 4000,
+    });
+
+    expect(result.meta.llmProvider).toBe('anthropic');
+    expect(result.extractedKeywords).toContain('Spider');
+    expect(result.meta.totalMs).toBeGreaterThanOrEqual(0);
+    expect(result.nodeCount).toBeGreaterThanOrEqual(0);
+    expect(result.toon).toBeDefined();
+  });
+
+  it('returns a QueryResult with llmProvider=none when no LLM', async () => {
+    const engine = new QueryEngine(db, null);
+
+    const result = await engine.query({
+      question: 'Spider class methods',
+      workspaceRoot: '/workspace',
+      depth: 1,
+    });
+
+    expect(result.meta.llmProvider).toBe('none');
+    expect(Array.isArray(result.extractedKeywords)).toBe(true);
+  });
+});

--- a/tests/analyzer/callgraph/CallGraphIndexer.test.ts
+++ b/tests/analyzer/callgraph/CallGraphIndexer.test.ts
@@ -337,6 +337,307 @@ describe("CallGraphIndexer", () => {
   });
 
   // -------------------------------------------------------------------------
+  // evictOldestFiles
+  // -------------------------------------------------------------------------
+
+  it("evictOldestFiles(0) is a no-op and returns empty array", () => {
+    indexer.indexFile([makeNode()], [], FILE_A, "typescript", Date.now());
+    const result = indexer.evictOldestFiles(0);
+    expect(result).toEqual([]);
+
+    const db = indexer.getDb();
+    const rows = db.exec("SELECT path FROM file_index WHERE path = ?", [FILE_A]);
+    expect(rows[0]?.values.length).toBe(1);
+  });
+
+  it("evictOldestFiles(1) removes the oldest indexed file and its nodes", () => {
+    const FILE_B = "/workspace/src/newer.ts";
+    const nodeA = makeNode({ id: `${FILE_A}:a:1`, name: "a", startLine: 1 });
+    const nodeB = makeNode({
+      id: `${FILE_B}:b:1`, name: "b", startLine: 1,
+      path: FILE_B, folder: "/workspace/src",
+    });
+
+    // Index A first (older indexed_at), then B
+    indexer.indexFile([nodeA], [], FILE_A, "typescript", 1000);
+    indexer.indexFile([nodeB], [], FILE_B, "typescript", 2000);
+
+    const result = indexer.evictOldestFiles(1);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(FILE_A);
+
+    const db = indexer.getDb();
+    const evictedFile = db.exec("SELECT path FROM file_index WHERE path = ?", [FILE_A]);
+    expect(evictedFile.length).toBe(0);
+
+    const evictedNode = db.exec("SELECT id FROM nodes WHERE path = ?", [FILE_A]);
+    expect(evictedNode.length).toBe(0);
+
+    // FILE_B must still be present
+    const keptFile = db.exec("SELECT path FROM file_index WHERE path = ?", [FILE_B]);
+    expect(keptFile[0]?.values.length).toBe(1);
+  });
+
+  it("evictOldestFiles(2) removes the two oldest files in order", () => {
+    const FILE_B = "/workspace/src/b.ts";
+    const FILE_C = "/workspace/src/c.ts";
+    indexer.indexFile([], [], FILE_A, "typescript", 1000);
+    indexer.indexFile([], [], FILE_B, "typescript", 2000);
+    indexer.indexFile([], [], FILE_C, "typescript", 3000);
+
+    const result = indexer.evictOldestFiles(2);
+    expect(result).toHaveLength(2);
+    expect(result).toContain(FILE_A);
+    expect(result).toContain(FILE_B);
+
+    const db = indexer.getDb();
+    const remaining = db.exec("SELECT path FROM file_index");
+    expect(remaining[0]?.values.length).toBe(1);
+    expect(remaining[0]?.values[0][0]).toBe(FILE_C);
+  });
+
+  it("evictOldestFiles() on empty DB returns empty array", () => {
+    const result = indexer.evictOldestFiles(5);
+    expect(result).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // checkAndEvict
+  // -------------------------------------------------------------------------
+
+  it("checkAndEvict() with maxSizeMB=0 disables eviction (no-op)", () => {
+    indexer.indexFile([makeNode()], [], FILE_A, "typescript", Date.now());
+    // maxSizeMB=0 disables eviction regardless of DB size
+    indexer.checkAndEvict(0);
+
+    const db = indexer.getDb();
+    const rows = db.exec("SELECT path FROM file_index WHERE path = ?", [FILE_A]);
+    expect(rows[0]?.values.length).toBe(1);
+  });
+
+  it("checkAndEvict() does not evict when DB is below the threshold", () => {
+    indexer.indexFile([makeNode()], [], FILE_A, "typescript", Date.now());
+    // Very high limit — DB is in-memory with a few rows, never reaches 999 MB
+    indexer.checkAndEvict(999);
+
+    const db = indexer.getDb();
+    const rows = db.exec("SELECT path FROM file_index WHERE path = ?", [FILE_A]);
+    expect(rows[0]?.values.length).toBe(1);
+  });
+
+  it("checkAndEvict() evicts ~10% of files when DB exceeds threshold", () => {
+    // Index 10 files
+    for (let i = 0; i < 10; i++) {
+      const filePath = `/workspace/src/file${i}.ts`;
+      const node = makeNode({
+        id: `${filePath}:fn${i}:1`, name: `fn${i}`, startLine: 1,
+        path: filePath, folder: "/workspace/src",
+      });
+      indexer.indexFile([node], [], filePath, "typescript", i * 1000);
+    }
+
+    const db = indexer.getDb();
+    const beforeRows = db.exec("SELECT COUNT(*) FROM file_index");
+    const countBefore = beforeRows[0]?.values[0]?.[0] as number;
+    expect(countBefore).toBe(10);
+
+    // Force eviction: override getDatabaseSizeMB on the prototype temporarily via
+    // a property override on the instance (TypeScript cast to any for test spy).
+    const instanceAny = indexer as unknown as { getDatabaseSizeMB: () => number };
+    const realGetSize = instanceAny.getDatabaseSizeMB;
+    instanceAny.getDatabaseSizeMB = () => 100; // pretend DB is 100 MB
+    indexer.checkAndEvict(1); // limit = 1 MB → triggers eviction
+    instanceAny.getDatabaseSizeMB = realGetSize; // restore
+
+    const afterRows = db.exec("SELECT COUNT(*) FROM file_index");
+    const countAfter = afterRows[0]?.values[0]?.[0] as number;
+    // Should have evicted ceil(10 * 0.1) = 1 file
+    expect(countAfter).toBeLessThan(countBefore);
+    expect(countAfter).toBe(9);
+  });
+
+  it("checkAndEvict() created with maxDbSizeMB=0 config never evicts", async () => {
+    const noEvictIndexer = new CallGraphIndexer(SQL_WASM_PATH, { maxDbSizeMB: 0 });
+    await noEvictIndexer.init();
+
+    noEvictIndexer.indexFile([makeNode()], [], FILE_A, "typescript", Date.now());
+    noEvictIndexer.checkAndEvict(); // no arg → uses config maxDbSizeMB = 0
+
+    const db = noEvictIndexer.getDb();
+    const rows = db.exec("SELECT path FROM file_index WHERE path = ?", [FILE_A]);
+    expect(rows[0]?.values.length).toBe(1);
+
+    noEvictIndexer.dispose();
+  });
+
+  // -------------------------------------------------------------------------
+  // sharedPathSegments + pickBestCandidate (tested indirectly via resolveExternalEdges)
+  // -------------------------------------------------------------------------
+
+  it("resolveExternalEdges() resolves stub to the candidate in the closest directory (sharedPathSegments)", () => {
+    // Two files both export `compute()`. One is in /workspace/src/utils/ (close to caller),
+    // the other in /workspace/lib/ (further away). The stub should resolve to the closer one.
+    const CALLER_FILE  = "/workspace/src/main.ts";
+    const NEAR_FILE    = "/workspace/src/utils/compute.ts";
+    const FAR_FILE     = "/workspace/lib/compute.ts";
+
+    const callerNode = makeNode({
+      id: `${CALLER_FILE}:main:1`, name: "main", startLine: 1,
+      path: CALLER_FILE, folder: "/workspace/src",
+    });
+    const nearNode = makeNode({
+      id: `${NEAR_FILE}:compute:1`, name: "compute", startLine: 1,
+      path: NEAR_FILE, folder: "/workspace/src/utils",
+      lang: "typescript", isExported: true,
+    });
+    const farNode = makeNode({
+      id: `${FAR_FILE}:compute:1`, name: "compute", startLine: 1,
+      path: FAR_FILE, folder: "/workspace/lib",
+      lang: "typescript", isExported: true,
+    });
+
+    const stubEdge = makeEdge({
+      sourceId: callerNode.id,
+      targetId: "@@external:compute",
+      typeRelation: "CALLS",
+      sourceLine: 5,
+    });
+
+    indexer.indexFile([callerNode], [stubEdge], CALLER_FILE, "typescript", Date.now());
+    indexer.indexFile([nearNode], [], NEAR_FILE, "typescript", Date.now());
+    indexer.indexFile([farNode], [], FAR_FILE, "typescript", Date.now());
+
+    const result = indexer.resolveExternalEdges();
+    expect(result.resolved).toBeGreaterThanOrEqual(1);
+
+    const db = indexer.getDb();
+
+    // Must resolve to nearNode (closer directory)
+    const edgeToNear = db.exec(
+      "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
+      [callerNode.id, nearNode.id],
+    );
+    expect(edgeToNear[0]?.values.length).toBe(1);
+
+    // Must NOT resolve to farNode
+    const edgeToFar = db.exec(
+      "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
+      [callerNode.id, farNode.id],
+    );
+    expect(edgeToFar.length).toBe(0);
+  });
+
+  it("resolveExternalEdges() prefers exported candidate over unexported when similarity ties (pickBestCandidate)", () => {
+    // Two candidates in the exact same directory, same similarity score.
+    // One is exported, the other is not. Exported wins.
+    const CALLER_FILE     = "/workspace/src/a.ts";
+    const EXPORTED_FILE   = "/workspace/src/b.ts";
+    const UNEXPORTED_FILE = "/workspace/src/c.ts";
+
+    const callerNode = makeNode({
+      id: `${CALLER_FILE}:caller:1`, name: "caller", startLine: 1,
+      path: CALLER_FILE, folder: "/workspace/src",
+    });
+    const exportedNode = makeNode({
+      id: `${EXPORTED_FILE}:helper:1`, name: "helper", startLine: 1,
+      path: EXPORTED_FILE, folder: "/workspace/src",
+      lang: "typescript", isExported: true,
+    });
+    const unexportedNode = makeNode({
+      id: `${UNEXPORTED_FILE}:helper:1`, name: "helper", startLine: 1,
+      path: UNEXPORTED_FILE, folder: "/workspace/src",
+      lang: "typescript", isExported: false,
+    });
+
+    const stubEdge = makeEdge({
+      sourceId: callerNode.id,
+      targetId: "@@external:helper",
+      typeRelation: "CALLS",
+      sourceLine: 3,
+    });
+
+    indexer.indexFile([callerNode], [stubEdge], CALLER_FILE, "typescript", 1000);
+    indexer.indexFile([unexportedNode], [], UNEXPORTED_FILE, "typescript", 2000);
+    indexer.indexFile([exportedNode], [], EXPORTED_FILE, "typescript", 1000);
+
+    const result = indexer.resolveExternalEdges();
+    expect(result.resolved).toBeGreaterThanOrEqual(1);
+
+    const db = indexer.getDb();
+
+    // Must resolve to exported node
+    const edgeToExported = db.exec(
+      "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
+      [callerNode.id, exportedNode.id],
+    );
+    expect(edgeToExported[0]?.values.length).toBe(1);
+
+    // Must NOT resolve to unexported node
+    const edgeToUnexported = db.exec(
+      "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
+      [callerNode.id, unexportedNode.id],
+    );
+    expect(edgeToUnexported.length).toBe(0);
+  });
+
+  it("resolveExternalEdges() picks most-recently-indexed candidate when exported/similarity tie (pickBestCandidate)", () => {
+    // Two exported candidates in the same directory — tie in both similarity and export.
+    // The more recently indexed one must win.
+    // We force distinct indexed_at values by updating the DB directly after indexFile().
+    const CALLER_FILE = "/workspace/src/caller.ts";
+    const OLDER_FILE  = "/workspace/src/older.ts";
+    const NEWER_FILE  = "/workspace/src/newer.ts";
+
+    const callerNode = makeNode({
+      id: `${CALLER_FILE}:caller:1`, name: "caller", startLine: 1,
+      path: CALLER_FILE, folder: "/workspace/src",
+    });
+    const olderNode = makeNode({
+      id: `${OLDER_FILE}:doWork:1`, name: "doWork", startLine: 1,
+      path: OLDER_FILE, folder: "/workspace/src",
+      lang: "typescript", isExported: true,
+    });
+    const newerNode = makeNode({
+      id: `${NEWER_FILE}:doWork:1`, name: "doWork", startLine: 1,
+      path: NEWER_FILE, folder: "/workspace/src",
+      lang: "typescript", isExported: true,
+    });
+
+    const stubEdge = makeEdge({
+      sourceId: callerNode.id,
+      targetId: "@@external:doWork",
+      typeRelation: "CALLS",
+      sourceLine: 7,
+    });
+
+    indexer.indexFile([callerNode], [stubEdge], CALLER_FILE, "typescript", 1000);
+    indexer.indexFile([olderNode], [], OLDER_FILE, "typescript", 1000);
+    indexer.indexFile([newerNode], [], NEWER_FILE, "typescript", 9999);
+
+    // Force distinct indexed_at values so the tie-breaker is deterministic.
+    const db = indexer.getDb();
+    db.run("UPDATE nodes SET indexed_at = 1000 WHERE id = ?", [olderNode.id]);
+    db.run("UPDATE nodes SET indexed_at = 9999 WHERE id = ?", [newerNode.id]);
+
+    const result = indexer.resolveExternalEdges();
+    expect(result.resolved).toBeGreaterThanOrEqual(1);
+
+    // Must resolve to newer (higher indexed_at) node
+    const edgeToNewer = db.exec(
+      "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
+      [callerNode.id, newerNode.id],
+    );
+    expect(edgeToNewer[0]?.values.length).toBe(1);
+
+    // Must NOT resolve to older node
+    const edgeToOlder = db.exec(
+      "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
+      [callerNode.id, olderNode.id],
+    );
+    expect(edgeToOlder.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
   // resolveExternalEdges — cross-language isolation
   // -------------------------------------------------------------------------
 

--- a/tests/analyzer/llm/AnthropicLlmClient.test.ts
+++ b/tests/analyzer/llm/AnthropicLlmClient.test.ts
@@ -1,0 +1,251 @@
+/// <reference types="node" />
+
+/**
+ * Unit tests for AnthropicLlmClient.
+ *
+ * All network calls are mocked via vi.stubGlobal('fetch', ...) — no real HTTP.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AnthropicLlmClient } from '../../../src/analyzer/llm/AnthropicLlmClient';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOkResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function makeErrorResponse(status: number, text: string): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => { throw new Error('not json'); },
+    text: async () => text,
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AnthropicLlmClient', () => {
+  let originalKey: string | undefined;
+
+  beforeEach(() => {
+    originalKey = process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalKey !== undefined) {
+      process.env.ANTHROPIC_API_KEY = originalKey;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // providerName
+  // -------------------------------------------------------------------------
+
+  it('has providerName "anthropic"', () => {
+    const client = new AnthropicLlmClient('sk-key');
+    expect(client.providerName).toBe('anthropic');
+  });
+
+  // -------------------------------------------------------------------------
+  // isAvailable
+  // -------------------------------------------------------------------------
+
+  it('isAvailable() returns true when apiKey passed in constructor', async () => {
+    const client = new AnthropicLlmClient('sk-ant-test-key');
+    expect(await client.isAvailable()).toBe(true);
+  });
+
+  it('isAvailable() returns true when ANTHROPIC_API_KEY env is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-env-key';
+    const client = new AnthropicLlmClient();
+    expect(await client.isAvailable()).toBe(true);
+  });
+
+  it('isAvailable() returns false when no key provided and env not set', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const client = new AnthropicLlmClient('');
+    expect(await client.isAvailable()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // complete() — nominal path
+  // -------------------------------------------------------------------------
+
+  it('complete() returns parsed text and tokensUsed from Anthropic response', async () => {
+    const fakeBody = {
+      content: [{ type: 'text', text: 'Hello from Anthropic' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.text).toBe('Hello from Anthropic');
+    expect(result.tokensUsed).toBe(15);
+  });
+
+  it('complete() sends correct URL, headers and body structure', async () => {
+    const fakeBody = {
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 2, output_tokens: 1 },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse(fakeBody));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new AnthropicLlmClient('sk-ant-key', 'claude-test-model');
+    await client.complete(
+      [{ role: 'user', content: 'hello' }],
+      { maxTokens: 128, temperature: 0.5 },
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.anthropic.com/v1/messages');
+
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe('sk-ant-key');
+    expect(headers['anthropic-version']).toBe('2023-06-01');
+    expect(headers['Content-Type']).toBe('application/json');
+
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.model).toBe('claude-test-model');
+    expect(sentBody.max_tokens).toBe(128);
+    expect(sentBody.temperature).toBe(0.5);
+    expect(sentBody.messages).toEqual([{ role: 'user', content: 'hello' }]);
+  });
+
+  it('complete() separates system messages into body.system field', async () => {
+    const fakeBody = {
+      content: [{ type: 'text', text: 'answer' }],
+      usage: { input_tokens: 5, output_tokens: 3 },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse(fakeBody));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    await client.complete([
+      { role: 'system', content: 'You are a helper.' },
+      { role: 'user', content: 'hello' },
+    ]);
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(sentBody.system).toBe('You are a helper.');
+    expect(sentBody.messages).toEqual([{ role: 'user', content: 'hello' }]);
+    // system message must NOT appear in messages array
+    expect(sentBody.messages.some((m: { role: string }) => m.role === 'system')).toBe(false);
+  });
+
+  it('complete() concatenates multiple system messages with newline', async () => {
+    const fakeBody = {
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 3, output_tokens: 1 },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse(fakeBody));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    await client.complete([
+      { role: 'system', content: 'Rule 1.' },
+      { role: 'system', content: 'Rule 2.' },
+      { role: 'user', content: 'hello' },
+    ]);
+
+    const sentBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+    expect(sentBody.system).toBe('Rule 1.\nRule 2.');
+  });
+
+  it('complete() returns empty string when no text block in content array', async () => {
+    const fakeBody = {
+      content: [{ type: 'image' }],
+      usage: { input_tokens: 1, output_tokens: 0 },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.text).toBe('');
+  });
+
+  it('complete() returns tokensUsed=undefined when usage field is absent', async () => {
+    const fakeBody = {
+      content: [{ type: 'text', text: 'ok' }],
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.tokensUsed).toBeUndefined();
+  });
+
+  it('complete() handles empty content array gracefully', async () => {
+    const fakeBody = { content: [], usage: { input_tokens: 1, output_tokens: 0 } };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+    expect(result.text).toBe('');
+  });
+
+  // -------------------------------------------------------------------------
+  // complete() — error paths
+  // -------------------------------------------------------------------------
+
+  it('complete() throws on HTTP 401 with status code in message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(401, 'Unauthorized')));
+
+    const client = new AnthropicLlmClient('sk-ant-bad-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('Anthropic API error 401');
+  });
+
+  it('complete() throws on HTTP 500 with status code in message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(500, 'Internal Server Error')));
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('Anthropic API error 500');
+  });
+
+  it('complete() includes error body text in the thrown error message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(403, 'Forbidden: quota exceeded')));
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('Forbidden: quota exceeded');
+  });
+
+  it('complete() falls back to status code string when response.text() throws', async () => {
+    const badResponse: Response = {
+      ok: false,
+      status: 503,
+      text: async () => { throw new Error('read error'); },
+      json: async () => { throw new Error('not json'); },
+    } as unknown as Response;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(badResponse));
+
+    const client = new AnthropicLlmClient('sk-ant-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('Anthropic API error 503');
+  });
+});

--- a/tests/analyzer/llm/LlmClientFactory.test.ts
+++ b/tests/analyzer/llm/LlmClientFactory.test.ts
@@ -1,0 +1,99 @@
+/// <reference types="node" />
+
+/**
+ * Unit tests for LlmClientFactory.resolveLlmClient.
+ *
+ * Tests env-based resolution without network calls.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetFallbackWarned, resolveLlmClient } from '../../../src/analyzer/llm/LlmClientFactory';
+import type { LlmClient, LlmCompletionOptions, LlmCompletionResult, LlmMessage } from '../../../src/analyzer/llm/LlmClient';
+
+// ---------------------------------------------------------------------------
+// Mock LlmClient for override test
+// ---------------------------------------------------------------------------
+
+class MockOverrideLlmClient implements LlmClient {
+  readonly providerName = 'vscode-lm' as const;
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  async complete(
+    _messages: LlmMessage[],
+    _options?: LlmCompletionOptions,
+  ): Promise<LlmCompletionResult> {
+    return { text: 'mock' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('resolveLlmClient', () => {
+  // Save original env values
+  let originalAnthropicKey: string | undefined;
+  let originalOpenAiKey: string | undefined;
+
+  beforeEach(() => {
+    originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+    originalOpenAiKey = process.env.OPENAI_API_KEY;
+    // Clear keys before each test
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    // Reset the module-level flag so warnings can fire again
+    _resetFallbackWarned();
+  });
+
+  afterEach(() => {
+    // Restore original env
+    if (originalAnthropicKey !== undefined) {
+      process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    } else {
+      delete process.env.ANTHROPIC_API_KEY;
+    }
+    if (originalOpenAiKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalOpenAiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+  });
+
+  it('returns AnthropicLlmClient when ANTHROPIC_API_KEY is set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+    const client = await resolveLlmClient();
+    expect(client).not.toBeNull();
+    expect(client?.providerName).toBe('anthropic');
+  });
+
+  it('returns OpenAiCompatibleLlmClient when OPENAI_API_KEY is set', async () => {
+    // No ANTHROPIC_API_KEY, only OPENAI
+    process.env.OPENAI_API_KEY = 'sk-openai-test-key';
+    const client = await resolveLlmClient();
+    expect(client).not.toBeNull();
+    expect(client?.providerName).toBe('openai-compatible');
+  });
+
+  it('returns null when no keys are set', async () => {
+    const client = await resolveLlmClient();
+    expect(client).toBeNull();
+  });
+
+  it('returns override when provided, ignoring env', async () => {
+    // Even with no env keys, override should be returned
+    const override = new MockOverrideLlmClient();
+    const client = await resolveLlmClient({ override });
+    expect(client).toBe(override);
+    expect(client?.providerName).toBe('vscode-lm');
+  });
+
+  it('prefers ANTHROPIC_API_KEY over OPENAI_API_KEY', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key';
+    process.env.OPENAI_API_KEY = 'sk-openai-test-key';
+    const client = await resolveLlmClient();
+    expect(client?.providerName).toBe('anthropic');
+  });
+});

--- a/tests/analyzer/llm/OpenAiCompatibleLlmClient.test.ts
+++ b/tests/analyzer/llm/OpenAiCompatibleLlmClient.test.ts
@@ -1,0 +1,278 @@
+/// <reference types="node" />
+
+/**
+ * Unit tests for OpenAiCompatibleLlmClient.
+ *
+ * All network calls are mocked via vi.stubGlobal('fetch', ...) — no real HTTP.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OpenAiCompatibleLlmClient } from '../../../src/analyzer/llm/OpenAiCompatibleLlmClient';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOkResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function makeErrorResponse(status: number, text: string): Response {
+  return {
+    ok: false,
+    status,
+    json: async () => { throw new Error('not json'); },
+    text: async () => text,
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OpenAiCompatibleLlmClient', () => {
+  let originalApiKey: string | undefined;
+  let originalBaseUrl: string | undefined;
+  let originalModel: string | undefined;
+
+  beforeEach(() => {
+    originalApiKey = process.env.OPENAI_API_KEY;
+    originalBaseUrl = process.env.OPENAI_BASE_URL;
+    originalModel = process.env.OPENAI_MODEL;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    // Restore env vars
+    if (originalApiKey !== undefined) {
+      process.env.OPENAI_API_KEY = originalApiKey;
+    } else {
+      delete process.env.OPENAI_API_KEY;
+    }
+    if (originalBaseUrl !== undefined) {
+      process.env.OPENAI_BASE_URL = originalBaseUrl;
+    } else {
+      delete process.env.OPENAI_BASE_URL;
+    }
+    if (originalModel !== undefined) {
+      process.env.OPENAI_MODEL = originalModel;
+    } else {
+      delete process.env.OPENAI_MODEL;
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // providerName
+  // -------------------------------------------------------------------------
+
+  it('has providerName "openai-compatible"', () => {
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    expect(client.providerName).toBe('openai-compatible');
+  });
+
+  // -------------------------------------------------------------------------
+  // isAvailable
+  // -------------------------------------------------------------------------
+
+  it('isAvailable() returns true when apiKey passed in constructor', async () => {
+    const client = new OpenAiCompatibleLlmClient('sk-openai-key');
+    expect(await client.isAvailable()).toBe(true);
+  });
+
+  it('isAvailable() returns true when OPENAI_API_KEY env is set', async () => {
+    process.env.OPENAI_API_KEY = 'sk-env-key';
+    const client = new OpenAiCompatibleLlmClient();
+    expect(await client.isAvailable()).toBe(true);
+  });
+
+  it('isAvailable() returns false when no key provided', async () => {
+    delete process.env.OPENAI_API_KEY;
+    const client = new OpenAiCompatibleLlmClient('');
+    expect(await client.isAvailable()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // complete() — nominal path
+  // -------------------------------------------------------------------------
+
+  it('complete() returns parsed text and tokensUsed from OpenAI response', async () => {
+    const fakeBody = {
+      choices: [{ message: { content: 'Hello from OpenAI' }, finish_reason: 'stop' }],
+      usage: { total_tokens: 20 },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.text).toBe('Hello from OpenAI');
+    expect(result.tokensUsed).toBe(20);
+  });
+
+  it('complete() sends correct URL, headers and body structure', async () => {
+    const fakeBody = {
+      choices: [{ message: { content: 'ok' } }],
+      usage: { total_tokens: 5 },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse(fakeBody));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new OpenAiCompatibleLlmClient('sk-key', 'https://api.openai.com/v1', 'gpt-4o');
+    await client.complete(
+      [{ role: 'user', content: 'hello' }],
+      { maxTokens: 64, temperature: 0.7 },
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/chat/completions');
+
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer sk-key');
+    expect(headers['Content-Type']).toBe('application/json');
+
+    const sentBody = JSON.parse(init.body as string);
+    expect(sentBody.model).toBe('gpt-4o');
+    expect(sentBody.max_tokens).toBe(64);
+    expect(sentBody.temperature).toBe(0.7);
+    expect(sentBody.messages).toEqual([{ role: 'user', content: 'hello' }]);
+  });
+
+  it('complete() strips trailing slash from baseUrl before appending path', async () => {
+    const fakeBody = {
+      choices: [{ message: { content: 'ok' } }],
+      usage: { total_tokens: 3 },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse(fakeBody));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new OpenAiCompatibleLlmClient('sk-key', 'https://custom.local/v1/');
+    await client.complete([{ role: 'user', content: 'hi' }]);
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    // Should not have double slash
+    expect(url).toBe('https://custom.local/v1/chat/completions');
+  });
+
+  it('complete() uses OPENAI_BASE_URL env when no baseUrl in constructor', async () => {
+    process.env.OPENAI_BASE_URL = 'https://env-custom.local/v1';
+    const fakeBody = {
+      choices: [{ message: { content: 'ok' } }],
+      usage: { total_tokens: 2 },
+    };
+    const mockFetch = vi.fn().mockResolvedValue(makeOkResponse(fakeBody));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    await client.complete([{ role: 'user', content: 'hi' }]);
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe('https://env-custom.local/v1/chat/completions');
+  });
+
+  it('complete() returns tokensUsed=undefined when usage field is absent', async () => {
+    const fakeBody = {
+      choices: [{ message: { content: 'ok' } }],
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.tokensUsed).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // complete() — choices[] edge cases
+  // -------------------------------------------------------------------------
+
+  it('complete() returns empty string when choices[] is empty', async () => {
+    const fakeBody = {
+      choices: [],
+      usage: { total_tokens: 0 },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.text).toBe('');
+  });
+
+  it('complete() returns empty string when choices[0].message.content is absent', async () => {
+    const fakeBody = {
+      choices: [{ message: {}, finish_reason: 'stop' }],
+      usage: { total_tokens: 1 },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.text).toBe('');
+  });
+
+  it('complete() returns empty string when choices[0].message is absent', async () => {
+    const fakeBody = {
+      choices: [{ finish_reason: 'stop' }],
+      usage: { total_tokens: 1 },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeOkResponse(fakeBody)));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    const result = await client.complete([{ role: 'user', content: 'hi' }]);
+
+    expect(result.text).toBe('');
+  });
+
+  // -------------------------------------------------------------------------
+  // complete() — error paths
+  // -------------------------------------------------------------------------
+
+  it('complete() throws on HTTP 401 with status code in message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(401, 'Unauthorized')));
+
+    const client = new OpenAiCompatibleLlmClient('sk-bad-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('OpenAI API error 401');
+  });
+
+  it('complete() throws on HTTP 500 with status code in message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(500, 'Internal Server Error')));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('OpenAI API error 500');
+  });
+
+  it('complete() includes error body text in the thrown error message', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeErrorResponse(429, 'Rate limit exceeded')));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('Rate limit exceeded');
+  });
+
+  it('complete() falls back to status code string when response.text() throws', async () => {
+    const badResponse: Response = {
+      ok: false,
+      status: 503,
+      text: async () => { throw new Error('network error'); },
+      json: async () => { throw new Error('not json'); },
+    } as unknown as Response;
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(badResponse));
+
+    const client = new OpenAiCompatibleLlmClient('sk-key');
+    await expect(
+      client.complete([{ role: 'user', content: 'hi' }]),
+    ).rejects.toThrow('OpenAI API error 503');
+  });
+});

--- a/tests/cli/query.test.ts
+++ b/tests/cli/query.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the `graph-it query` CLI command.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CliError } from '../../src/cli/errors.js';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be hoisted before any imports that would pull in the modules
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  executeQueryNaturalLanguage: vi.fn(),
+  resolveLlmClient: vi.fn(),
+}));
+
+vi.mock('../../src/mcp/tools', () => ({
+  executeQueryNaturalLanguage: mocks.executeQueryNaturalLanguage,
+}));
+
+vi.mock('../../src/analyzer/llm/LlmClientFactory.js', () => ({
+  resolveLlmClient: mocks.resolveLlmClient,
+}));
+
+import { run } from '../../src/cli/commands/query.js';
+
+// ---------------------------------------------------------------------------
+// Shared test helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ROOT = '/workspace';
+
+function makeRuntime(root = WORKSPACE_ROOT) {
+  return {
+    workspaceRoot: root,
+    ensureIndexed: vi.fn().mockResolvedValue(undefined),
+  } as never;
+}
+
+function makeToonResult(overrides: Record<string, unknown> = {}) {
+  return {
+    question: 'how does the indexer work',
+    extractedKeywords: ['indexer', 'work'],
+    nodeCount: 3,
+    edgeCount: 2,
+    toon: 'nodes:[A,B,C] edges:[A->B,B->C]',
+    meta: {
+      llmProvider: 'heuristic',
+      keywordExtractionMs: 5,
+      bfsMs: 10,
+      totalMs: 15,
+      tokenEstimate: 120,
+      truncated: false,
+    },
+    ...overrides,
+  };
+}
+
+function makeJsonResult(overrides: Record<string, unknown> = {}) {
+  return {
+    question: 'how does the indexer work',
+    extractedKeywords: ['indexer', 'work'],
+    nodeCount: 2,
+    edgeCount: 1,
+    nodes: [
+      { id: 'n1', name: 'CallGraphIndexer', type: 'class', path: '/workspace/src/analyzer/CallGraphIndexer.ts', relevanceScore: 0.9 },
+      { id: 'n2', name: 'QueryEngine', type: 'class', path: '/workspace/src/analyzer/QueryEngine.ts', relevanceScore: 0.7 },
+    ],
+    edges: [
+      { source: 'n1', target: 'n2' },
+    ],
+    meta: {
+      llmProvider: 'heuristic',
+      keywordExtractionMs: 5,
+      bfsMs: 10,
+      totalMs: 15,
+      tokenEstimate: 200,
+      truncated: false,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('query command', () => {
+  beforeEach(() => {
+    mocks.executeQueryNaturalLanguage.mockReset();
+    mocks.resolveLlmClient.mockReset();
+    // Default: LLM available
+    mocks.resolveLlmClient.mockResolvedValue({ /* fake client */ });
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Missing question → CliError
+  // -------------------------------------------------------------------------
+  it('throws CliError when no question is provided', async () => {
+    await expect(run([], makeRuntime(), 'text')).rejects.toThrow(CliError);
+    await expect(run(['--format', 'toon'], makeRuntime(), 'text')).rejects.toThrow(CliError);
+  });
+
+  it('CliError for missing question has GENERAL_ERROR exit code', async () => {
+    try {
+      await run([], makeRuntime(), 'text');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError);
+      expect((err as CliError).exitCode).toBe(1);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. --format toon → result.toon is returned
+  // -------------------------------------------------------------------------
+  it('returns toon string when --format toon', async () => {
+    const toonResult = makeToonResult();
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(toonResult);
+
+    const output = await run(
+      ['how does the indexer work', '--format', 'toon'],
+      makeRuntime(),
+      'text',
+    );
+
+    expect(output).toBe(toonResult.toon);
+  });
+
+  it('uses toon as default format when no --format flag', async () => {
+    const toonResult = makeToonResult();
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(toonResult);
+
+    const output = await run(['how does the indexer work'], makeRuntime(), 'text');
+
+    expect(output).toBe(toonResult.toon);
+    expect(mocks.executeQueryNaturalLanguage).toHaveBeenCalledWith(
+      expect.objectContaining({ outputFormat: 'toon' }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. --format json → JSON parseable output
+  // -------------------------------------------------------------------------
+  it('returns JSON parseable output when --format json', async () => {
+    const jsonResult = makeJsonResult();
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(jsonResult);
+
+    const output = await run(
+      ['how does the indexer work', '--format', 'json'],
+      makeRuntime(),
+      'text',
+    );
+
+    expect(() => JSON.parse(output)).not.toThrow();
+    const parsed = JSON.parse(output) as typeof jsonResult;
+    expect(parsed.question).toBe(jsonResult.question);
+    expect(parsed.nodeCount).toBe(jsonResult.nodeCount);
+    expect(parsed.extractedKeywords).toEqual(jsonResult.extractedKeywords);
+  });
+
+  it('passes outputFormat json to executeQueryNaturalLanguage when --format json', async () => {
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(makeJsonResult());
+
+    await run(
+      ['how does the indexer work', '--format', 'json'],
+      makeRuntime(),
+      'text',
+    );
+
+    expect(mocks.executeQueryNaturalLanguage).toHaveBeenCalledWith(
+      expect.objectContaining({ outputFormat: 'json' }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. --depth 3 → depth=3 passed to executeQueryNaturalLanguage
+  // -------------------------------------------------------------------------
+  it('passes depth=3 when --depth 3', async () => {
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(makeToonResult());
+
+    await run(
+      ['how does the indexer work', '--depth', '3'],
+      makeRuntime(),
+      'text',
+    );
+
+    expect(mocks.executeQueryNaturalLanguage).toHaveBeenCalledWith(
+      expect.objectContaining({ depth: 3 }),
+    );
+  });
+
+  it('uses default depth=2 when --depth is not provided', async () => {
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(makeToonResult());
+
+    await run(['how does the indexer work'], makeRuntime(), 'text');
+
+    expect(mocks.executeQueryNaturalLanguage).toHaveBeenCalledWith(
+      expect.objectContaining({ depth: 2 }),
+    );
+  });
+
+  it('passes --token-budget to executeQueryNaturalLanguage', async () => {
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(makeToonResult());
+
+    await run(
+      ['how does the indexer work', '--token-budget', '8000'],
+      makeRuntime(),
+      'text',
+    );
+
+    expect(mocks.executeQueryNaturalLanguage).toHaveBeenCalledWith(
+      expect.objectContaining({ tokenBudget: 8000 }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. No LLM → hint message written to stderr
+  // -------------------------------------------------------------------------
+  it('writes hint to stderr when no LLM is configured', async () => {
+    mocks.resolveLlmClient.mockResolvedValueOnce(null);
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(makeToonResult());
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await run(['how does the indexer work'], makeRuntime(), 'text');
+
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No LLM configured'),
+    );
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ANTHROPIC_API_KEY'),
+    );
+
+    stderrSpy.mockRestore();
+  });
+
+  it('does NOT write LLM hint to stderr when LLM is available', async () => {
+    mocks.resolveLlmClient.mockResolvedValueOnce({ /* fake client */ });
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(makeToonResult());
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await run(['how does the indexer work'], makeRuntime(), 'text');
+
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('No LLM configured'),
+    );
+
+    stderrSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // text format — human readable list of nodes
+  // -------------------------------------------------------------------------
+  it('formats text output with keywords and node names', async () => {
+    const jsonResult = makeJsonResult();
+    mocks.executeQueryNaturalLanguage.mockResolvedValueOnce(jsonResult);
+
+    const output = await run(
+      ['how does the indexer work', '--format', 'text'],
+      makeRuntime(),
+      'text',
+    );
+
+    expect(output).toContain('Keywords: indexer, work');
+    expect(output).toContain('CallGraphIndexer');
+    expect(output).toContain('QueryEngine');
+  });
+});

--- a/tests/mcp/tools/query.test.ts
+++ b/tests/mcp/tools/query.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Unit tests for the MCP natural language query tool (executeQueryNaturalLanguage).
+ *
+ * Uses a mock CallGraphIndexer (no sql.js WASM dependency) and mocks
+ * QueryEngine.query to isolate the tool logic.
+ *
+ * Test cases:
+ *  1. Valid params → QueryResult returned
+ *  2. Question too long (>1024 chars) → Zod validation error
+ *  3. depth out of bounds → Zod validation error
+ *  4. outputFormat 'toon' → returns TOON string
+ *  5. outputFormat 'json' → returns nodes/edges arrays (JSON-serializable)
+ *  6. tokenBudget out of bounds → Zod validation error
+ *  7. Throws when indexer not initialized
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CallGraphIndexer } from "../../../src/analyzer/callgraph/CallGraphIndexer";
+import { QueryEngine } from "../../../src/analyzer/QueryEngine";
+import { workerState } from "../../../src/mcp/shared/state";
+import {
+  executeQueryNaturalLanguage,
+  QueryNaturalLanguageSchema,
+} from "../../../src/mcp/tools/query";
+import { validateToolParams } from "../../../src/mcp/types";
+import type { QueryResult } from "../../../src/shared/query-types";
+
+// ---------------------------------------------------------------------------
+// Minimal mock database (sql.js-compatible shape)
+// ---------------------------------------------------------------------------
+
+type MockDb = { exec: ReturnType<typeof vi.fn> };
+
+function makeMockDb(): MockDb {
+  return { exec: vi.fn().mockReturnValue([]) };
+}
+
+// ---------------------------------------------------------------------------
+// Mock QueryResult
+// ---------------------------------------------------------------------------
+
+const WORKSPACE = "/workspace";
+const FILE_A = `${WORKSPACE}/src/a.ts`;
+
+function makeMockQueryResult(overrides: Partial<QueryResult> = {}): QueryResult {
+  return {
+    question: "How does the indexer work?",
+    extractedKeywords: ["indexer", "work"],
+    seedNodeIds: [`${FILE_A}::main`],
+    nodes: [
+      {
+        id: `${FILE_A}::main`,
+        name: "main",
+        type: "Function",
+        path: FILE_A,
+        startLine: 1,
+        relevanceScore: 0.9,
+      },
+    ],
+    edges: [],
+    nodeCount: 1,
+    edgeCount: 0,
+    toon: '{"nodes":[{"id":"main","name":"main"}],"edges":[],"nodeCount":1,"edgeCount":0}',
+    meta: {
+      llmProvider: "none",
+      keywordExtractionMs: 1,
+      bfsMs: 2,
+      totalMs: 3,
+      tokenEstimate: 50,
+      truncated: false,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers to set up workerState with a mock indexer
+// ---------------------------------------------------------------------------
+
+function setupWorkerState(db = makeMockDb()): void {
+  const mockIndexer = {
+    getDb: vi.fn().mockReturnValue(db),
+    dispose: vi.fn(),
+  } as unknown as CallGraphIndexer;
+
+  workerState.callGraphIndexer = mockIndexer;
+  workerState.callGraphIndexedRoot = WORKSPACE;
+  workerState.config = {
+    rootDir: WORKSPACE,
+    excludeNodeModules: true,
+    maxDepth: 10,
+  };
+  workerState.isReady = true;
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe("executeQueryNaturalLanguage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    workerState.reset();
+  });
+
+  // -----------------------------------------------------------------------
+  // 1. Valid params → QueryResult returned
+  // -----------------------------------------------------------------------
+
+  it("returns QueryResult for valid params", async () => {
+    setupWorkerState();
+    const mockResult = makeMockQueryResult();
+    vi.spyOn(QueryEngine.prototype, "query").mockResolvedValue(mockResult);
+
+    const result = await executeQueryNaturalLanguage({
+      question: "How does the indexer work?",
+    });
+
+    expect(result.question).toBe("How does the indexer work?");
+    expect(result.extractedKeywords).toEqual(["indexer", "work"]);
+    expect(result.nodeCount).toBe(1);
+    expect(result.edgeCount).toBe(0);
+  });
+
+  // -----------------------------------------------------------------------
+  // 2. Question too long (>1024 chars) → Zod validation error
+  // -----------------------------------------------------------------------
+
+  it("validates question length via toolSchemas", () => {
+    const longQuestion = "a".repeat(1025);
+    const validation = validateToolParams("query_natural_language", {
+      question: longQuestion,
+    });
+
+    expect(validation.success).toBe(false);
+    if (!validation.success) {
+      expect(validation.error).toMatch(/1024/);
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // 3. depth out of bounds → Zod validation error
+  // -----------------------------------------------------------------------
+
+  it("validates depth bounds via toolSchemas", () => {
+    const resultBelow = validateToolParams("query_natural_language", {
+      question: "valid question",
+      depth: 0,
+    });
+    expect(resultBelow.success).toBe(false);
+
+    const resultAbove = validateToolParams("query_natural_language", {
+      question: "valid question",
+      depth: 6,
+    });
+    expect(resultAbove.success).toBe(false);
+  });
+
+  // -----------------------------------------------------------------------
+  // 4. outputFormat 'toon' → returns TOON string
+  // -----------------------------------------------------------------------
+
+  it("returns toon string when outputFormat is toon", async () => {
+    setupWorkerState();
+    const toonString = '{"nodes":[],"edges":[],"nodeCount":0,"edgeCount":0}';
+    const mockResult = makeMockQueryResult({
+      toon: toonString,
+      nodeCount: 0,
+      edgeCount: 0,
+      nodes: [],
+    });
+    vi.spyOn(QueryEngine.prototype, "query").mockResolvedValue(mockResult);
+
+    const result = await executeQueryNaturalLanguage({
+      question: "test",
+      outputFormat: "toon",
+    });
+
+    expect(result.toon).toBe(toonString);
+    expect(result.nodes).toBeUndefined();
+    expect(result.edges).toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // 5. outputFormat 'json' → returns nodes/edges arrays (JSON-serializable)
+  // -----------------------------------------------------------------------
+
+  it("returns nodes and edges arrays when outputFormat is json", async () => {
+    setupWorkerState();
+    const mockResult = makeMockQueryResult();
+    vi.spyOn(QueryEngine.prototype, "query").mockResolvedValue(mockResult);
+
+    const result = await executeQueryNaturalLanguage({
+      question: "test",
+      outputFormat: "json",
+    });
+
+    expect(Array.isArray(result.nodes)).toBe(true);
+    expect(Array.isArray(result.edges)).toBe(true);
+    expect(result.toon).toBeUndefined();
+
+    // Ensure JSON-serializable
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  // -----------------------------------------------------------------------
+  // 6. tokenBudget out of bounds → Zod validation error
+  // -----------------------------------------------------------------------
+
+  it("validates tokenBudget bounds via schema", () => {
+    const tooLow = QueryNaturalLanguageSchema.safeParse({
+      question: "valid question",
+      tokenBudget: 499,
+    });
+    expect(tooLow.success).toBe(false);
+
+    const tooHigh = QueryNaturalLanguageSchema.safeParse({
+      question: "valid question",
+      tokenBudget: 16001,
+    });
+    expect(tooHigh.success).toBe(false);
+
+    const valid = QueryNaturalLanguageSchema.safeParse({
+      question: "valid question",
+      tokenBudget: 4000,
+    });
+    expect(valid.success).toBe(true);
+  });
+
+  // -----------------------------------------------------------------------
+  // 7. Throws when indexer is not initialized
+  // -----------------------------------------------------------------------
+
+  it("throws when callGraphIndexer is not available", async () => {
+    // Set config so getConfig() works, but leave indexer null
+    workerState.config = {
+      rootDir: WORKSPACE,
+      excludeNodeModules: true,
+      maxDepth: 10,
+    };
+    workerState.callGraphIndexer = null;
+    workerState.callGraphIndexedRoot = null;
+    workerState.isReady = true;
+
+    await expect(
+      executeQueryNaturalLanguage({ question: "test" }),
+    ).rejects.toThrow(/Call graph indexer not initialized/);
+  });
+});


### PR DESCRIPTION
## Summary

- **QueryEngine** (`analyzer/`): BFS multi-seeds, FTS5 SQLite full-text search (SCHEMA_VERSION 3), TOON output, heuristic fallback when no LLM key configured
- **MCP tool** `query_natural_language`: Zod-validated, returns TOON subgraph for Copilot/Claude/Cursor
- **CLI command** `graph-it query "<question>"`: `--depth`, `--token-budget`, `--format` flags; text/json/toon output
- **REPL** `/query` slash command — multi-word questions work without quotes

LLM support: Anthropic (`ANTHROPIC_API_KEY`), OpenAI-compatible (`OPENAI_API_KEY` + `OPENAI_BASE_URL` + `OPENAI_MODEL`), silent heuristic fallback.

S-4 (VS Code inline query) out of scope, tracked separately.

## Test plan

- [ ] `npm test` — all unit tests pass (LLM clients 100%, QueryEngine 86%, MCP query 100%, CLI query 92%)
- [ ] `npm run package:verify` — zero `.map` files in `.vsix` (15.66 MB)
- [ ] `graph-it query "how does Spider crawl files"` — returns TOON subgraph
- [ ] `graph-it query "..." --format text` — text summary output
- [ ] REPL: `graph-it` (no args) → `/query comment fonctionne le graphprovider` — full sentence used as question
- [ ] MCP: `query_natural_language` tool available and returns valid TOON
- [ ] No regression on existing commands (`architecture`, `trace`, `check`, etc.)