### PR TITLE
feat(wiki): generate navigable Markdown wiki from call graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,4 +227,4 @@ graphify-out/.graphify_root # local only
 graphify-out/cost.json # local only
 # graphify-out/cache/         # optional: commit for speed, skip to keep repo small
 # Generated wiki (graph-it wiki output)
-wiki/
+/wiki/

--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,5 @@ graphify-out/.graphify_python # local only
 graphify-out/.graphify_root # local only
 graphify-out/cost.json # local only
 # graphify-out/cache/         # optional: commit for speed, skip to keep repo small
+# Generated wiki (graph-it wiki output)
+wiki/

--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ graph-it check                  # Scan whole workspace for dead code (unused exp
 graph-it check <dir>            # Scan a subdirectory for dead code
 graph-it check <file>           # Detect unused exported symbols in a single file
 graph-it query "<question>"     # Natural language query over the call graph (LLM or heuristic fallback)
+graph-it wiki                   # Generate a navigable markdown wiki from the call graph
 graph-it serve                  # Launch MCP stdio server (for AI clients)
 graph-it tool --list            # List all 22 CLI analysis tools
 graph-it tool <mcp-tool> [args] # Run any MCP tool directly from the terminal
@@ -441,7 +442,7 @@ This output can be pasted directly into any Markdown renderer (GitHub, Notion, V
 
 **Use as MCP server (no VS Code):** Run `graph-it serve` and point your AI client at it — see [Manual MCP Server Configuration](#manual-mcp-server-configuration).
 
-**Interactive REPL:** Run `graph-it` with no arguments to enter interactive mode. Type `/query how does X work` to ask natural language questions about your codebase (no quotes needed). Other slash commands: `/trace`, `/summary`, `/architecture`, `/check`, `/cycles`, `/format`, `/help`.
+**Interactive REPL:** Run `graph-it` with no arguments to enter interactive mode. Type `/query how does X work` to ask natural language questions about your codebase (no quotes needed). Use `/wiki` to generate a navigable markdown wiki from the call graph. Other slash commands: `/trace`, `/summary`, `/architecture`, `/check`, `/cycles`, `/format`, `/help`.
 
 **Full CLI reference:** See **[docs/CLI.md](docs/CLI.md)** for complete documentation on every command, all options, output format examples, advanced workflows, and the full MCP tools reference.
 
@@ -512,6 +513,7 @@ The MCP server exposes **23 tools** for AI/LLM consumption. The 22 analysis tool
 | `graphitlive_query_call_graph` | Query cross-file callers/callees via BFS on the call graph SQLite database |
 | `graphitlive_scan_dead_code` | Scan the entire workspace (or a directory) for unused exported symbols in one call |
 | `query_natural_language` | Answer a natural language question about the codebase using the call graph (LLM or heuristic fallback) |
+| `graphitlive_generate_wiki` | Generate a navigable markdown wiki from the call graph (one article per file, hub scores, cross-links) |
 
 ### TOON Format (Token-Optimized Output)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,18 @@
 # Changelog
-je confirme par contre je vzais 
+
+## [Unreleased] — graph-it wiki
+
+### Added
+
+- **`graph-it wiki` CLI command**: Generates a navigable Markdown wiki from the call graph. Flags: `--scope <dir>`, `--exclude <pattern>` (repeatable), `--output <dir>` (default `wiki/`), `--top <N>`, `--format markdown|json|toon`.
+- **`/wiki` REPL slash command**: Interactive wiki generation inside `graph-it repl`.
+- **MCP tool `graphitlive_generate_wiki`**: Zod-validated tool for LLM clients (Copilot, Claude, Cursor). Returns relative paths and scopeNote.
+- **WikiGenerator** (`analyzer/wiki/`): Reads call graph SQLite index, applies scope/exclude filters, builds per-file articles with hub scores and Mermaid diagrams.
+- **DiagramBuilder**: Four diagram types — *External calls* (up to 50 nodes, deduplicated), *Called by* (all files), *Architecture overview* (index, top hubs), *Control flow* per function. All self-loop-free.
+- **ControlFlowAnalyzer**: TypeScript AST analysis via `ts.createSourceFile` — `flowchart TD` for every exported function with complexity ≥ 2. Covers if/else, switch/case, try/catch, loops.
+- **Scope filtering**: Auto-excludes `tests/`, `dist/`, `*.test.ts` etc. by default. Scope note rendered inline in index as `> ℹ️` blockquote.
+- **Restriction transparency**: Truncation limits documented as `> ⚠️` blockquotes directly in generated articles.
+
 ## [Unreleased] — graph-it query
 
 ### Added

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -169,6 +169,7 @@ graph-it [options]
 | Command | Description |
 |--------|-------------|
 | `/query` | Query the codebase with natural language (no quotes needed for multi-word questions) |
+| `/wiki` | Generate a navigable markdown wiki from the call graph |
 | `/trace` | Run trace flow for a selected file and optional symbol |
 | `/path` | Set session workspace scope (directory) |
 | `/file` | Set active file context for context-aware commands |
@@ -659,6 +660,55 @@ graph-it query "what is the entry point for the CLI" --format json
 
 ---
 
+### wiki
+
+Generate a navigable markdown wiki from the call graph. Creates one article per source file with hub scores, symbol lists, caller/callee cross-links, and a grouped index — all with relative links only (portable, can be committed to the repo).
+
+```
+graph-it wiki [options]
+```
+
+**Options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--output <dir>` | `wiki` | Output directory (relative to workspace root, or absolute) |
+| `--top <N>` | `10` | Number of top hub files to list in the index (1–50) |
+| `--format <fmt>` | `markdown` | Output summary format: `markdown`, `json`, `toon` |
+| `--workspace, -w` | auto-detected | Project root |
+
+**Examples:**
+
+```bash
+graph-it wiki                                  # write to ./wiki/
+graph-it wiki --output docs/wiki               # write to ./docs/wiki/
+graph-it wiki --top 20 --format json           # JSON summary, top 20 hubs
+graph-it wiki --output /tmp/preview            # absolute output path
+```
+
+**Output structure:**
+
+```
+wiki/
+  index.md          # Grouped file index with hub scores
+  articles/
+    src_foo.ts.md   # One article per source file
+    src_bar.ts.md
+    ...
+```
+
+Each article contains:
+- Hub score (0–100, higher = more depended-upon)
+- Symbols (functions, classes, interfaces, types)
+- Called by (callers from other files)
+- Calls (callees in other files)
+- All internal links are **relative** — safe to commit and view on any OS
+
+> **REPL equivalent:** Use `/wiki` inside `graph-it` interactive mode.
+> **MCP equivalent:** `graphitlive_generate_wiki` tool.
+
+---
+
 ### tool
 
 Invoke any of the 22 MCP analysis tools directly from the terminal — full MCP parity without a running server.
@@ -717,6 +767,7 @@ Available MCP tools:
   query_call_graph               BFS callers/callees via the SQLite call graph index
   scan_dead_code                 Workspace-wide scan for unused exported symbols
   query_natural_language         Answer a natural language question about the codebase (LLM or heuristic)
+  generate_wiki                  Generate a navigable markdown wiki from the call graph
 ```
 
 **Calling a tool with parameters:**
@@ -1180,6 +1231,25 @@ graph-it tool query_natural_language --question="explain the MCP server" --token
 - No key set → heuristic fallback (warning printed to stderr)
 
 > **Note:** The LLM calling this tool performs the synthesis — the tool returns a structured subgraph that the model interprets.
+
+---
+
+#### `generate_wiki`
+
+Generate a navigable markdown wiki from the call graph. One article per source file, hub scores, symbol lists, caller/callee cross-links, and a grouped index — all with relative links only.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `workspaceRoot` | string | configured workspace | Absolute path to workspace root |
+| `outputDir` | string | `wiki` | Output directory for wiki files |
+| `topHubsLimit` | number | `10` | Number of top hub files to list (1–50) |
+| `response_format` | string | `json` | Output summary format: `json`, `markdown`, or `toon` |
+
+```bash
+graph-it tool generate_wiki
+graph-it tool generate_wiki --outputDir=docs/wiki
+graph-it tool generate_wiki --topHubsLimit=20 --response_format=toon
+```
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,10 +47,10 @@
         "eslint": "^10.5.0",
         "fast-check": "^4.8.0",
         "glob": "^13.0.6",
-        "globals": "^17.6.0",
+        "globals": "^17.7.0",
         "mocha": "^11.7.6",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.61.1",
+        "typescript-eslint": "^8.62.0",
         "vitest": "^4.1.9"
       },
       "engines": {
@@ -2697,17 +2697,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
-      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/type-utils": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2720,7 +2720,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.61.1",
+        "@typescript-eslint/parser": "^8.62.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2736,16 +2736,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
-      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2761,14 +2761,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
-      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.61.1",
-        "@typescript-eslint/types": "^8.61.1",
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2783,14 +2783,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
-      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1"
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2801,9 +2801,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
-      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2818,15 +2818,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
-      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2843,9 +2843,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
-      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2857,16 +2857,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
-      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.61.1",
-        "@typescript-eslint/tsconfig-utils": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/visitor-keys": "8.61.1",
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2885,16 +2885,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
-      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.61.1",
-        "@typescript-eslint/types": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1"
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2909,13 +2909,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
-      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/types": "8.62.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5627,9 +5627,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.7.0.tgz",
+      "integrity": "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9671,16 +9671,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.61.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
-      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.61.1",
-        "@typescript-eslint/parser": "8.61.1",
-        "@typescript-eslint/typescript-estree": "8.61.1",
-        "@typescript-eslint/utils": "8.61.1"
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -1155,10 +1155,10 @@
     "eslint": "^10.5.0",
     "fast-check": "^4.8.0",
     "glob": "^13.0.6",
-    "globals": "^17.6.0",
+    "globals": "^17.7.0",
     "mocha": "^11.7.6",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.61.1",
+    "typescript-eslint": "^8.62.0",
     "vitest": "^4.1.9"
   },
   "overrides": {

--- a/src/analyzer/wiki/ControlFlowAnalyzer.ts
+++ b/src/analyzer/wiki/ControlFlowAnalyzer.ts
@@ -48,54 +48,62 @@ function collectExportedFunctions(sf: ts.SourceFile): FunctionInfo[] {
   const result: FunctionInfo[] = [];
 
   function visit(node: ts.Node) {
-    // export function foo() {}
-    if (ts.isFunctionDeclaration(node) && node.body && hasExportModifier(node)) {
-      const name = node.name?.text ?? "(anonymous)";
-      result.push({ name, body: node.body, complexity: countComplexity(node.body) });
-    }
-
-    // export class Foo { method() {} }
-    if (ts.isClassDeclaration(node) && hasExportModifier(node)) {
-      const className = node.name?.text ?? "Class";
-      for (const member of node.members) {
-        if (ts.isMethodDeclaration(member) && member.body) {
-          const methodName = `${className}.${member.name.getText(sf)}`;
-          result.push({
-            name: methodName,
-            body: member.body,
-            complexity: countComplexity(member.body),
-          });
-        }
-      }
-    }
-
-    // export const foo = () => {} or export const foo = function() {}
-    if (ts.isVariableStatement(node) && hasExportModifier(node)) {
-      for (const decl of node.declarationList.declarations) {
-        const name = ts.isIdentifier(decl.name) ? decl.name.text : "(var)";
-        if (decl.initializer) {
-          if (ts.isArrowFunction(decl.initializer) && ts.isBlock(decl.initializer.body)) {
-            result.push({
-              name,
-              body: decl.initializer.body,
-              complexity: countComplexity(decl.initializer.body),
-            });
-          } else if (ts.isFunctionExpression(decl.initializer) && decl.initializer.body) {
-            result.push({
-              name,
-              body: decl.initializer.body,
-              complexity: countComplexity(decl.initializer.body),
-            });
-          }
-        }
-      }
-    }
+    collectExportedFunctionDeclaration(node, result);
+    collectExportedClassMethods(sf, node, result);
+    collectExportedVariableFunctions(node, result);
 
     ts.forEachChild(node, visit);
   }
 
   visit(sf);
   return result;
+}
+
+function collectExportedFunctionDeclaration(node: ts.Node, result: FunctionInfo[]): void {
+  if (!ts.isFunctionDeclaration(node) || !node.body || !hasExportModifier(node)) return;
+
+  const name = node.name?.text ?? "(anonymous)";
+  result.push({ name, body: node.body, complexity: countComplexity(node.body) });
+}
+
+function collectExportedClassMethods(
+  sf: ts.SourceFile,
+  node: ts.Node,
+  result: FunctionInfo[],
+): void {
+  if (!ts.isClassDeclaration(node) || !hasExportModifier(node)) return;
+
+  const className = node.name?.text ?? "Class";
+  for (const member of node.members) {
+    if (!ts.isMethodDeclaration(member) || !member.body) continue;
+
+    const name = `${className}.${member.name.getText(sf)}`;
+    result.push({ name, body: member.body, complexity: countComplexity(member.body) });
+  }
+}
+
+function collectExportedVariableFunctions(node: ts.Node, result: FunctionInfo[]): void {
+  if (!ts.isVariableStatement(node) || !hasExportModifier(node)) return;
+
+  for (const decl of node.declarationList.declarations) {
+    collectVariableFunction(decl, result);
+  }
+}
+
+function collectVariableFunction(decl: ts.VariableDeclaration, result: FunctionInfo[]): void {
+  const body = getVariableFunctionBody(decl);
+  if (!body) return;
+
+  const name = ts.isIdentifier(decl.name) ? decl.name.text : "(var)";
+  result.push({ name, body, complexity: countComplexity(body) });
+}
+
+function getVariableFunctionBody(decl: ts.VariableDeclaration): ts.Block | undefined {
+  const initializer = decl.initializer;
+  if (!initializer) return undefined;
+  if (ts.isFunctionExpression(initializer)) return initializer.body;
+  if (ts.isArrowFunction(initializer) && ts.isBlock(initializer.body)) return initializer.body;
+  return undefined;
 }
 
 function hasExportModifier(node: ts.Node): boolean {
@@ -107,6 +115,16 @@ function hasExportModifier(node: ts.Node): boolean {
   );
 }
 
+function isLoopStatement(stmt: ts.Statement): boolean {
+  return (
+    ts.isForStatement(stmt) ||
+    ts.isWhileStatement(stmt) ||
+    ts.isForInStatement(stmt) ||
+    ts.isForOfStatement(stmt) ||
+    ts.isDoStatement(stmt)
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Mermaid generation
 // ---------------------------------------------------------------------------
@@ -114,9 +132,9 @@ function hasExportModifier(node: ts.Node): boolean {
 function sanitize(text: string): string {
   return text
     .replace(/['\n\r`"]/g, "")       // remove quotes, backticks, newlines
-    .replace(/\|/g, " or ")          // | breaks Mermaid diamond syntax
-    .replace(/&&/g, " and ")         // && before & to avoid double-replace
-    .replace(/&/g, " and ")          // remaining &
+    .replaceAll('|', " or ")          // | breaks Mermaid diamond syntax
+    .replaceAll('&&', " and ")         // && before & to avoid double-replace
+    .replaceAll('&', " and ")          // remaining &
     .replace(/[{}[\]()<>]/g, "")     // remove all brackets
     .replace(/[#;@!%^*=\\]/g, "")    // remove other special chars
     .replace(/\s+/g, " ")            // normalize whitespace
@@ -142,164 +160,6 @@ function buildControlFlowMermaid(
     lines.push(label ? `  ${from} -- ${label} --> ${to}` : `  ${from} --> ${to}`);
   }
 
-  // Returns the "exit" node id to chain next statement onto
-  function processStatement(stmt: ts.Statement, prevId: string): string {
-    if (counter >= MAX_NODES_PER_DIAGRAM) {
-      truncated = true;
-      return prevId;
-    }
-
-    if (ts.isReturnStatement(stmt)) {
-      const retId = newId();
-      const label = stmt.expression
-        ? sanitize(stmt.expression.getText(sf)).substring(0, 20)
-        : "void";
-      lines.push(`  ${retId}([return: ${label}])`);
-      connect(prevId, retId);
-      return retId;
-    }
-
-    if (ts.isThrowStatement(stmt)) {
-      const throwId = newId();
-      lines.push(`  ${throwId}[/throw/]`);
-      connect(prevId, throwId);
-      return throwId;
-    }
-
-    if (ts.isIfStatement(stmt)) {
-      const condId = newId();
-      const condText = sanitize(stmt.expression.getText(sf));
-      lines.push(`  ${condId}{${condText}?}`);
-      connect(prevId, condId);
-
-      // YES branch
-      const thenId = newId();
-      lines.push(`  ${thenId}[then]`);
-      connect(condId, thenId, "yes");
-      const thenExit = ts.isBlock(stmt.thenStatement)
-        ? processBlock(stmt.thenStatement, thenId)
-        : thenId;
-
-      // NO branch
-      let noExit = condId;
-      if (stmt.elseStatement && !truncated) {
-        const elseId = newId();
-        lines.push(`  ${elseId}[else]`);
-        connect(condId, elseId, "no");
-        noExit = ts.isBlock(stmt.elseStatement)
-          ? processBlock(stmt.elseStatement, elseId)
-          : elseId;
-      }
-
-      // Merge node
-      if (!truncated) {
-        const mergeId = newId();
-        lines.push(`  ${mergeId}[ ]`);
-        connect(thenExit, mergeId);
-        if (noExit !== condId) connect(noExit, mergeId);
-        else connect(condId, mergeId, "no");
-        return mergeId;
-      }
-      return thenExit;
-    }
-
-    if (ts.isSwitchStatement(stmt)) {
-      const switchId = newId();
-      const switchText = sanitize(stmt.expression.getText(sf));
-      lines.push(`  ${switchId}{switch: ${switchText}}`);
-      connect(prevId, switchId);
-
-      const exits: string[] = [];
-      const maxCases = Math.min(stmt.caseBlock.clauses.length, 4);
-      for (let i = 0; i < maxCases && !truncated; i++) {
-        const clause = stmt.caseBlock.clauses[i];
-        const caseId = newId();
-        const caseLabel =
-          ts.isCaseClause(clause)
-            ? sanitize(clause.expression.getText(sf))
-            : "default";
-        lines.push(`  ${caseId}[${caseLabel}]`);
-        connect(switchId, caseId, caseLabel);
-        exits.push(caseId);
-      }
-
-      if (stmt.caseBlock.clauses.length > maxCases && !truncated) {
-        const moreId = newId();
-        lines.push(`  ${moreId}[...${stmt.caseBlock.clauses.length - maxCases} more]`);
-        connect(switchId, moreId);
-        exits.push(moreId);
-      }
-
-      if (!truncated && exits.length > 0) {
-        const mergeId = newId();
-        lines.push(`  ${mergeId}[ ]`);
-        for (const e of exits) connect(e, mergeId);
-        return mergeId;
-      }
-      return switchId;
-    }
-
-    if (
-      ts.isForStatement(stmt) ||
-      ts.isWhileStatement(stmt) ||
-      ts.isForInStatement(stmt) ||
-      ts.isForOfStatement(stmt) ||
-      ts.isDoStatement(stmt)
-    ) {
-      const loopId = newId();
-      let loopLabel = "loop";
-      if (ts.isForOfStatement(stmt)) {
-        loopLabel = `forEach ${sanitize(stmt.expression.getText(sf))}`;
-      } else if (ts.isForInStatement(stmt)) {
-        loopLabel = `for...in ${sanitize(stmt.expression.getText(sf))}`;
-      } else if (ts.isWhileStatement(stmt)) {
-        loopLabel = `while ${sanitize(stmt.expression.getText(sf))}`;
-      } else if (ts.isDoStatement(stmt)) {
-        loopLabel = `do...while`;
-      }
-      lines.push(`  ${loopId}["${loopLabel}"]`);
-      connect(prevId, loopId);
-      return loopId;
-    }
-
-    if (ts.isTryStatement(stmt)) {
-      const tryId = newId();
-      lines.push(`  ${tryId}[try block]`);
-      connect(prevId, tryId);
-
-      if (stmt.catchClause && !truncated) {
-        const catchId = newId();
-        const catchLabel = stmt.catchClause.variableDeclaration
-          ? `catch ${sanitize(stmt.catchClause.variableDeclaration.name.getText(sf))}`
-          : "catch";
-        lines.push(`  ${catchId}[${catchLabel}]`);
-        connect(tryId, catchId, "error");
-      }
-
-      if (stmt.finallyBlock && !truncated) {
-        const finallyId = newId();
-        lines.push(`  ${finallyId}[finally]`);
-        connect(tryId, finallyId);
-        return finallyId;
-      }
-      return tryId;
-    }
-
-    // Generic expression statement — show if it's an await call (usually important)
-    if (ts.isExpressionStatement(stmt)) {
-      const expr = stmt.expression;
-      if (ts.isAwaitExpression(expr) || ts.isCallExpression(expr)) {
-        const exprId = newId();
-        const text = sanitize(stmt.expression.getText(sf));
-        lines.push(`  ${exprId}[${text}]`);
-        connect(prevId, exprId);
-        return exprId;
-      }
-    }
-
-    return prevId;
-  }
-
   function processBlock(block: ts.Block, prevId: string): string {
     let cur = prevId;
     for (const stmt of block.statements) {
@@ -309,12 +169,168 @@ function buildControlFlowMermaid(
     return cur;
   }
 
+  function processReturn(stmt: ts.ReturnStatement, prevId: string): string {
+    const retId = newId();
+    const label = stmt.expression
+      ? sanitize(stmt.expression.getText(sf)).substring(0, 20)
+      : "void";
+    lines.push(`  ${retId}([return: ${label}])`);
+    connect(prevId, retId);
+    return retId;
+  }
+
+  function processThrow(prevId: string): string {
+    const throwId = newId();
+    lines.push(`  ${throwId}[/throw/]`);
+    connect(prevId, throwId);
+    return throwId;
+  }
+
+  function processIf(stmt: ts.IfStatement, prevId: string): string {
+    const condId = newId();
+    const condText = sanitize(stmt.expression.getText(sf));
+    lines.push(`  ${condId}{${condText}?}`);
+    connect(prevId, condId);
+
+    const thenId = newId();
+    lines.push(`  ${thenId}[then]`);
+    connect(condId, thenId, "yes");
+    const thenExit = ts.isBlock(stmt.thenStatement)
+      ? processBlock(stmt.thenStatement, thenId)
+      : thenId;
+
+    let noExit = condId;
+    if (stmt.elseStatement && !truncated) {
+      const elseId = newId();
+      lines.push(`  ${elseId}[else]`);
+      connect(condId, elseId, "no");
+      noExit = ts.isBlock(stmt.elseStatement)
+        ? processBlock(stmt.elseStatement, elseId)
+        : elseId;
+    }
+
+    return connectIfMerge(condId, thenExit, noExit);
+  }
+
+  function connectIfMerge(condId: string, thenExit: string, noExit: string): string {
+    if (truncated) return thenExit;
+
+    const mergeId = newId();
+    lines.push(`  ${mergeId}[ ]`);
+    connect(thenExit, mergeId);
+    if (noExit === condId) {connect(condId, mergeId, "no");}
+    else {connect(noExit, mergeId);}
+    return mergeId;
+  }
+
+  function processSwitch(stmt: ts.SwitchStatement, prevId: string): string {
+    const switchId = newId();
+    const switchText = sanitize(stmt.expression.getText(sf));
+    lines.push(`  ${switchId}{switch: ${switchText}}`);
+    connect(prevId, switchId);
+
+    const exits = addSwitchCases(stmt, switchId);
+    if (truncated || exits.length === 0) return switchId;
+
+    const mergeId = newId();
+    lines.push(`  ${mergeId}[ ]`);
+    for (const exitId of exits) connect(exitId, mergeId);
+    return mergeId;
+  }
+
+  function addSwitchCases(stmt: ts.SwitchStatement, switchId: string): string[] {
+    const exits: string[] = [];
+    const maxCases = Math.min(stmt.caseBlock.clauses.length, 4);
+    for (let i = 0; i < maxCases && !truncated; i++) {
+      const clause = stmt.caseBlock.clauses[i];
+      const caseId = newId();
+      const caseLabel = ts.isCaseClause(clause)
+        ? sanitize(clause.expression.getText(sf))
+        : "default";
+      lines.push(`  ${caseId}[${caseLabel}]`);
+      connect(switchId, caseId, caseLabel);
+      exits.push(caseId);
+    }
+
+    if (stmt.caseBlock.clauses.length > maxCases && !truncated) {
+      const moreId = newId();
+      lines.push(`  ${moreId}[...${stmt.caseBlock.clauses.length - maxCases} more]`);
+      connect(switchId, moreId);
+      exits.push(moreId);
+    }
+    return exits;
+  }
+
+  function processLoop(stmt: ts.Statement, prevId: string): string {
+    const loopId = newId();
+    lines.push(`  ${loopId}["${getLoopLabel(stmt)}"]`);
+    connect(prevId, loopId);
+    return loopId;
+  }
+
+  function getLoopLabel(stmt: ts.Statement): string {
+    if (ts.isForOfStatement(stmt)) return `forEach ${sanitize(stmt.expression.getText(sf))}`;
+    if (ts.isForInStatement(stmt)) return `for...in ${sanitize(stmt.expression.getText(sf))}`;
+    if (ts.isWhileStatement(stmt)) return `while ${sanitize(stmt.expression.getText(sf))}`;
+    if (ts.isDoStatement(stmt)) return "do...while";
+    return "loop";
+  }
+
+  function processTry(stmt: ts.TryStatement, prevId: string): string {
+    const tryId = newId();
+    lines.push(`  ${tryId}[try block]`);
+    connect(prevId, tryId);
+
+    if (stmt.catchClause && !truncated) {
+      const catchId = newId();
+      const catchLabel = stmt.catchClause.variableDeclaration
+        ? `catch ${sanitize(stmt.catchClause.variableDeclaration.name.getText(sf))}`
+        : "catch";
+      lines.push(`  ${catchId}[${catchLabel}]`);
+      connect(tryId, catchId, "error");
+    }
+
+    if (!stmt.finallyBlock || truncated) return tryId;
+
+    const finallyId = newId();
+    lines.push(`  ${finallyId}[finally]`);
+    connect(tryId, finallyId);
+    return finallyId;
+  }
+
+  function processExpression(stmt: ts.ExpressionStatement, prevId: string): string {
+    const expr = stmt.expression;
+    if (!ts.isAwaitExpression(expr) && !ts.isCallExpression(expr)) return prevId;
+
+    const exprId = newId();
+    const text = sanitize(stmt.expression.getText(sf));
+    lines.push(`  ${exprId}[${text}]`);
+    connect(prevId, exprId);
+    return exprId;
+  }
+
+  // Returns the "exit" node id to chain next statement onto
+  function processStatement(stmt: ts.Statement, prevId: string): string {
+    if (counter >= MAX_NODES_PER_DIAGRAM) {
+      truncated = true;
+      return prevId;
+    }
+
+    if (ts.isReturnStatement(stmt)) return processReturn(stmt, prevId);
+    if (ts.isThrowStatement(stmt)) return processThrow(prevId);
+    if (ts.isIfStatement(stmt)) return processIf(stmt, prevId);
+    if (ts.isSwitchStatement(stmt)) return processSwitch(stmt, prevId);
+    if (isLoopStatement(stmt)) return processLoop(stmt, prevId);
+    if (ts.isTryStatement(stmt)) return processTry(stmt, prevId);
+    if (ts.isExpressionStatement(stmt)) return processExpression(stmt, prevId);
+    return prevId;
+  }
+
   prev = processBlock(fn.body, prev);
 
   // End node (only if we didn't end on a return/throw)
   const endId = newId();
-  lines.push(`  ${endId}([end])`);
-  lines.push(`  ${prev} --> ${endId}`);
+  lines.push(`  ${endId}([end])`, `  ${prev} --> ${endId}`);
 
   return {
     mermaid: lines.join("\n"),
@@ -346,7 +362,7 @@ export function analyzeControlFlow(filePath: string): MermaidDiagram[] {
   const totalComplex = candidates.length;
 
   return top.map((fn, idx) => {
-    const { mermaid, nodeCount, truncated } = buildControlFlowMermaid(sf, fn);
+    const { mermaid, truncated } = buildControlFlowMermaid(sf, fn);
 
     const notes: string[] = [];
     if (truncated) notes.push(`Diagram truncated at ${MAX_NODES_PER_DIAGRAM} nodes — function too complex to render fully.`);

--- a/src/analyzer/wiki/ControlFlowAnalyzer.ts
+++ b/src/analyzer/wiki/ControlFlowAnalyzer.ts
@@ -1,0 +1,364 @@
+/**
+ * Extracts control-flow Mermaid diagrams from TypeScript source files.
+ * Uses the TypeScript compiler API directly — no ts-morph project, no WASM.
+ */
+
+import * as fs from "node:fs";
+import ts from "typescript";
+import type { MermaidDiagram } from "../../shared/wiki-types.js";
+
+const MAX_NODES_PER_DIAGRAM = 50;
+const MAX_FUNCTIONS_PER_FILE = 999;
+const MIN_COMPLEXITY = 2;
+
+interface FunctionInfo {
+  name: string;
+  complexity: number;
+  body: ts.Block;
+}
+
+// ---------------------------------------------------------------------------
+// Complexity counting (cyclomatic-ish: branches only)
+// ---------------------------------------------------------------------------
+
+function countComplexity(node: ts.Node): number {
+  let n = 0;
+  if (ts.isIfStatement(node)) n += node.elseStatement ? 2 : 1;
+  else if (ts.isSwitchStatement(node)) n += node.caseBlock.clauses.length;
+  else if (
+    ts.isForStatement(node) ||
+    ts.isWhileStatement(node) ||
+    ts.isForInStatement(node) ||
+    ts.isForOfStatement(node) ||
+    ts.isDoStatement(node)
+  ) n += 1;
+  else if (ts.isTryStatement(node))
+    n += (node.catchClause ? 1 : 0) + (node.finallyBlock ? 1 : 0);
+  else if (ts.isConditionalExpression(node)) n += 1;
+
+  ts.forEachChild(node, (child) => { n += countComplexity(child); });
+  return n;
+}
+
+// ---------------------------------------------------------------------------
+// Exported function discovery
+// ---------------------------------------------------------------------------
+
+function collectExportedFunctions(sf: ts.SourceFile): FunctionInfo[] {
+  const result: FunctionInfo[] = [];
+
+  function visit(node: ts.Node) {
+    // export function foo() {}
+    if (ts.isFunctionDeclaration(node) && node.body && hasExportModifier(node)) {
+      const name = node.name?.text ?? "(anonymous)";
+      result.push({ name, body: node.body, complexity: countComplexity(node.body) });
+    }
+
+    // export class Foo { method() {} }
+    if (ts.isClassDeclaration(node) && hasExportModifier(node)) {
+      const className = node.name?.text ?? "Class";
+      for (const member of node.members) {
+        if (ts.isMethodDeclaration(member) && member.body) {
+          const methodName = `${className}.${member.name.getText(sf)}`;
+          result.push({
+            name: methodName,
+            body: member.body,
+            complexity: countComplexity(member.body),
+          });
+        }
+      }
+    }
+
+    // export const foo = () => {} or export const foo = function() {}
+    if (ts.isVariableStatement(node) && hasExportModifier(node)) {
+      for (const decl of node.declarationList.declarations) {
+        const name = ts.isIdentifier(decl.name) ? decl.name.text : "(var)";
+        if (decl.initializer) {
+          if (ts.isArrowFunction(decl.initializer) && ts.isBlock(decl.initializer.body)) {
+            result.push({
+              name,
+              body: decl.initializer.body,
+              complexity: countComplexity(decl.initializer.body),
+            });
+          } else if (ts.isFunctionExpression(decl.initializer) && decl.initializer.body) {
+            result.push({
+              name,
+              body: decl.initializer.body,
+              complexity: countComplexity(decl.initializer.body),
+            });
+          }
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sf);
+  return result;
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    (ts.getModifiers(node) ?? []).some(
+      (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+    )
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mermaid generation
+// ---------------------------------------------------------------------------
+
+function sanitize(text: string): string {
+  return text
+    .replace(/['\n\r`"]/g, "")       // remove quotes, backticks, newlines
+    .replace(/\|/g, " or ")          // | breaks Mermaid diamond syntax
+    .replace(/&&/g, " and ")         // && before & to avoid double-replace
+    .replace(/&/g, " and ")          // remaining &
+    .replace(/[{}[\]()<>]/g, "")     // remove all brackets
+    .replace(/[#;@!%^*=\\]/g, "")    // remove other special chars
+    .replace(/\s+/g, " ")            // normalize whitespace
+    .trim()
+    .substring(0, 80);
+}
+
+function buildControlFlowMermaid(
+  sf: ts.SourceFile,
+  fn: FunctionInfo,
+): { mermaid: string; nodeCount: number; truncated: boolean } {
+  const lines: string[] = ["flowchart TD"];
+  let counter = 0;
+  let truncated = false;
+
+  const newId = () => `n${counter++}`;
+
+  const startId = newId();
+  lines.push(`  ${startId}([${sanitize(fn.name)}])`);
+  let prev = startId;
+
+  function connect(from: string, to: string, label?: string) {
+    lines.push(label ? `  ${from} -- ${label} --> ${to}` : `  ${from} --> ${to}`);
+  }
+
+  // Returns the "exit" node id to chain next statement onto
+  function processStatement(stmt: ts.Statement, prevId: string): string {
+    if (counter >= MAX_NODES_PER_DIAGRAM) {
+      truncated = true;
+      return prevId;
+    }
+
+    if (ts.isReturnStatement(stmt)) {
+      const retId = newId();
+      const label = stmt.expression
+        ? sanitize(stmt.expression.getText(sf)).substring(0, 20)
+        : "void";
+      lines.push(`  ${retId}([return: ${label}])`);
+      connect(prevId, retId);
+      return retId;
+    }
+
+    if (ts.isThrowStatement(stmt)) {
+      const throwId = newId();
+      lines.push(`  ${throwId}[/throw/]`);
+      connect(prevId, throwId);
+      return throwId;
+    }
+
+    if (ts.isIfStatement(stmt)) {
+      const condId = newId();
+      const condText = sanitize(stmt.expression.getText(sf));
+      lines.push(`  ${condId}{${condText}?}`);
+      connect(prevId, condId);
+
+      // YES branch
+      const thenId = newId();
+      lines.push(`  ${thenId}[then]`);
+      connect(condId, thenId, "yes");
+      const thenExit = ts.isBlock(stmt.thenStatement)
+        ? processBlock(stmt.thenStatement, thenId)
+        : thenId;
+
+      // NO branch
+      let noExit = condId;
+      if (stmt.elseStatement && !truncated) {
+        const elseId = newId();
+        lines.push(`  ${elseId}[else]`);
+        connect(condId, elseId, "no");
+        noExit = ts.isBlock(stmt.elseStatement)
+          ? processBlock(stmt.elseStatement, elseId)
+          : elseId;
+      }
+
+      // Merge node
+      if (!truncated) {
+        const mergeId = newId();
+        lines.push(`  ${mergeId}[ ]`);
+        connect(thenExit, mergeId);
+        if (noExit !== condId) connect(noExit, mergeId);
+        else connect(condId, mergeId, "no");
+        return mergeId;
+      }
+      return thenExit;
+    }
+
+    if (ts.isSwitchStatement(stmt)) {
+      const switchId = newId();
+      const switchText = sanitize(stmt.expression.getText(sf));
+      lines.push(`  ${switchId}{switch: ${switchText}}`);
+      connect(prevId, switchId);
+
+      const exits: string[] = [];
+      const maxCases = Math.min(stmt.caseBlock.clauses.length, 4);
+      for (let i = 0; i < maxCases && !truncated; i++) {
+        const clause = stmt.caseBlock.clauses[i];
+        const caseId = newId();
+        const caseLabel =
+          ts.isCaseClause(clause)
+            ? sanitize(clause.expression.getText(sf))
+            : "default";
+        lines.push(`  ${caseId}[${caseLabel}]`);
+        connect(switchId, caseId, caseLabel);
+        exits.push(caseId);
+      }
+
+      if (stmt.caseBlock.clauses.length > maxCases && !truncated) {
+        const moreId = newId();
+        lines.push(`  ${moreId}[...${stmt.caseBlock.clauses.length - maxCases} more]`);
+        connect(switchId, moreId);
+        exits.push(moreId);
+      }
+
+      if (!truncated && exits.length > 0) {
+        const mergeId = newId();
+        lines.push(`  ${mergeId}[ ]`);
+        for (const e of exits) connect(e, mergeId);
+        return mergeId;
+      }
+      return switchId;
+    }
+
+    if (
+      ts.isForStatement(stmt) ||
+      ts.isWhileStatement(stmt) ||
+      ts.isForInStatement(stmt) ||
+      ts.isForOfStatement(stmt) ||
+      ts.isDoStatement(stmt)
+    ) {
+      const loopId = newId();
+      let loopLabel = "loop";
+      if (ts.isForOfStatement(stmt)) {
+        loopLabel = `forEach ${sanitize(stmt.expression.getText(sf))}`;
+      } else if (ts.isForInStatement(stmt)) {
+        loopLabel = `for...in ${sanitize(stmt.expression.getText(sf))}`;
+      } else if (ts.isWhileStatement(stmt)) {
+        loopLabel = `while ${sanitize(stmt.expression.getText(sf))}`;
+      } else if (ts.isDoStatement(stmt)) {
+        loopLabel = `do...while`;
+      }
+      lines.push(`  ${loopId}["${loopLabel}"]`);
+      connect(prevId, loopId);
+      return loopId;
+    }
+
+    if (ts.isTryStatement(stmt)) {
+      const tryId = newId();
+      lines.push(`  ${tryId}[try block]`);
+      connect(prevId, tryId);
+
+      if (stmt.catchClause && !truncated) {
+        const catchId = newId();
+        const catchLabel = stmt.catchClause.variableDeclaration
+          ? `catch ${sanitize(stmt.catchClause.variableDeclaration.name.getText(sf))}`
+          : "catch";
+        lines.push(`  ${catchId}[${catchLabel}]`);
+        connect(tryId, catchId, "error");
+      }
+
+      if (stmt.finallyBlock && !truncated) {
+        const finallyId = newId();
+        lines.push(`  ${finallyId}[finally]`);
+        connect(tryId, finallyId);
+        return finallyId;
+      }
+      return tryId;
+    }
+
+    // Generic expression statement — show if it's an await call (usually important)
+    if (ts.isExpressionStatement(stmt)) {
+      const expr = stmt.expression;
+      if (ts.isAwaitExpression(expr) || ts.isCallExpression(expr)) {
+        const exprId = newId();
+        const text = sanitize(stmt.expression.getText(sf));
+        lines.push(`  ${exprId}[${text}]`);
+        connect(prevId, exprId);
+        return exprId;
+      }
+    }
+
+    return prevId;
+  }
+
+  function processBlock(block: ts.Block, prevId: string): string {
+    let cur = prevId;
+    for (const stmt of block.statements) {
+      if (truncated) break;
+      cur = processStatement(stmt, cur);
+    }
+    return cur;
+  }
+
+  prev = processBlock(fn.body, prev);
+
+  // End node (only if we didn't end on a return/throw)
+  const endId = newId();
+  lines.push(`  ${endId}([end])`);
+  lines.push(`  ${prev} --> ${endId}`);
+
+  return {
+    mermaid: lines.join("\n"),
+    nodeCount: counter,
+    truncated,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function analyzeControlFlow(filePath: string): MermaidDiagram[] {
+  let source: string;
+  try {
+    source = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const sf = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
+  const functions = collectExportedFunctions(sf);
+
+  const candidates = functions
+    .filter((f) => f.complexity >= MIN_COMPLEXITY)
+    .sort((a, b) => b.complexity - a.complexity);
+
+  const top = candidates.slice(0, MAX_FUNCTIONS_PER_FILE);
+  const totalComplex = candidates.length;
+
+  return top.map((fn, idx) => {
+    const { mermaid, nodeCount, truncated } = buildControlFlowMermaid(sf, fn);
+
+    const notes: string[] = [];
+    if (truncated) notes.push(`Diagram truncated at ${MAX_NODES_PER_DIAGRAM} nodes — function too complex to render fully.`);
+    if (idx === 0 && totalComplex > MAX_FUNCTIONS_PER_FILE)
+      notes.push(`Showing ${top.length} of ${totalComplex} complex functions`);
+
+    return {
+      title: `Control flow: \`${fn.name}()\``,
+      type: "control-flow" as const,
+      mermaid,
+      truncated: truncated || (idx === 0 && totalComplex > MAX_FUNCTIONS_PER_FILE),
+      truncationNote: notes.length > 0 ? notes.join("; ") : undefined,
+    };
+  });
+}

--- a/src/analyzer/wiki/DiagramBuilder.ts
+++ b/src/analyzer/wiki/DiagramBuilder.ts
@@ -1,0 +1,221 @@
+/**
+ * Builds Mermaid dependency, caller, and architecture diagrams from WikiArticle data.
+ * All labels use display paths (relative, no absolute workspace root).
+ */
+
+import { normalizePath } from "../../shared/path.js";
+import type { MermaidDiagram, WikiArticle } from "../../shared/wiki-types.js";
+
+/** Practical Mermaid.js rendering limit before diagrams become unreadable. */
+const MAX_NODES = 50;
+const MAX_ARCH_EDGES = 40;
+
+/** Escape label text for Mermaid "..." quoted node labels. */
+function mermaidLabel(text: string): string {
+  return text
+    .replace(/[\n\r]/g, " ")
+    .replace(/"/g, "'")
+    .replace(/[|<>]/g, "")
+    .substring(0, 60);
+}
+
+/**
+ * Stable, unique node ID derived from the display path (relative path).
+ * Uses last 2 segments to be readable but avoids collisions between
+ * e.g. src/mcp/types.ts and src/analyzer/types.ts.
+ */
+function nodeId(displayPath: string): string {
+  const parts = displayPath.replace(/\\/g, "/").split("/");
+  const key = parts.length >= 2
+    ? `${parts[parts.length - 2]}_${parts[parts.length - 1]}`
+    : parts[parts.length - 1];
+  return key
+    .replace(/[^a-zA-Z0-9]/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase()
+    .substring(0, 40);
+}
+
+/**
+ * Disambiguate collisions: if two different files produce the same nodeId,
+ * append a counter suffix.
+ */
+function buildNodeRegistry(
+  filePaths: string[],
+  display: (fp: string) => string,
+): Map<string, string> {
+  const registry = new Map<string, string>(); // absPath → mermaidId
+  const seen = new Map<string, number>();      // mermaidId → count
+
+  for (const fp of filePaths) {
+    const dp = display(fp);
+    const base = nodeId(dp);
+    const count = seen.get(base) ?? 0;
+    seen.set(base, count + 1);
+    const id = count > 0 ? `${base}_${count}` : base;
+    registry.set(normalizePath(fp), id);
+  }
+  return registry;
+}
+
+/**
+ * flowchart LR — file → its callees (dependency diagram).
+ * Always generated when the file has callees.
+ */
+export function buildDependencyDiagram(
+  article: WikiArticle,
+  display: (fp: string) => string,
+): MermaidDiagram | null {
+  if (article.callees.length === 0) return null;
+
+  const seenFiles = new Set<string>();
+  const external = article.callees
+    .filter((c) => normalizePath(c.filePath) !== normalizePath(article.filePath))
+    .filter((c) => {
+      const k = normalizePath(c.filePath);
+      if (seenFiles.has(k)) return false;
+      seenFiles.add(k);
+      return true;
+    });
+  const truncated = external.length > MAX_NODES;
+  const shown = external.slice(0, MAX_NODES);
+  if (shown.length === 0) return null;
+
+  const allPaths = [article.filePath, ...shown.map((c) => c.filePath)];
+  const registry = buildNodeRegistry(allPaths, display);
+
+  const lines: string[] = ["flowchart LR"];
+  const selfId = registry.get(normalizePath(article.filePath))!;
+  lines.push(`  ${selfId}["${mermaidLabel(display(article.filePath))}"]`);
+
+  const declared = new Set<string>([normalizePath(article.filePath)]);
+  for (const c of shown) {
+    const norm = normalizePath(c.filePath);
+    const id = registry.get(norm)!;
+    if (!declared.has(norm)) {
+      declared.add(norm);
+      lines.push(`  ${id}["${mermaidLabel(display(c.filePath))}"]`);
+    }
+    lines.push(`  ${selfId} --> ${id}`);
+  }
+
+  return {
+    title: "External calls",
+    type: "dependency",
+    mermaid: lines.join("\n"),
+    truncated,
+    truncationNote: truncated
+      ? `Showing ${shown.length} of ${external.length} dependencies`
+      : undefined,
+  };
+}
+
+/**
+ * flowchart LR — callers → file (caller diagram).
+ * Only generated for hub files (score ≥ threshold).
+ */
+export function buildCallerDiagram(
+  article: WikiArticle,
+  display: (fp: string) => string,
+): MermaidDiagram | null {
+  if (article.callers.length === 0) return null;
+
+  const seenCallers = new Set<string>();
+  const external = article.callers
+    .filter((c) => normalizePath(c.filePath) !== normalizePath(article.filePath))
+    .filter((c) => {
+      const k = normalizePath(c.filePath);
+      if (seenCallers.has(k)) return false;
+      seenCallers.add(k);
+      return true;
+    });
+  const truncated = external.length > MAX_NODES;
+  const shown = external.slice(0, MAX_NODES);
+  if (shown.length === 0) return null;
+
+  const allPaths = [article.filePath, ...shown.map((c) => c.filePath)];
+  const registry = buildNodeRegistry(allPaths, display);
+
+  const lines: string[] = ["flowchart LR"];
+  const selfId = registry.get(normalizePath(article.filePath))!;
+  lines.push(`  ${selfId}["${mermaidLabel(display(article.filePath))}"]`);
+
+  const declared = new Set<string>([normalizePath(article.filePath)]);
+  for (const c of shown) {
+    const norm = normalizePath(c.filePath);
+    const id = registry.get(norm)!;
+    if (!declared.has(norm)) {
+      declared.add(norm);
+      lines.push(`  ${id}["${mermaidLabel(display(c.filePath))}"]`);
+    }
+    lines.push(`  ${id} --> ${selfId}`);
+  }
+
+  return {
+    title: `Called by`,
+    type: "caller",
+    mermaid: lines.join("\n"),
+    truncated,
+    truncationNote: truncated
+      ? `Showing ${shown.length} of ${external.length} callers`
+      : undefined,
+  };
+}
+
+/**
+ * flowchart TD — top hub files and edges between them (architecture overview).
+ * Included in the wiki index.
+ */
+export function buildArchitectureDiagram(
+  articles: WikiArticle[],
+  display: (fp: string) => string,
+  limit = MAX_NODES,
+): MermaidDiagram | null {
+  const hubs = [...articles]
+    .sort((a, b) => b.hubScore - a.hubScore)
+    .slice(0, limit);
+
+  if (hubs.length < 2) return null;
+
+  const hubNorm = new Set(hubs.map((h) => normalizePath(h.filePath)));
+  const registry = buildNodeRegistry(hubs.map((h) => h.filePath), display);
+
+  const lines: string[] = ["flowchart TD"];
+
+  for (const hub of hubs) {
+    const id = registry.get(normalizePath(hub.filePath))!;
+    const label = mermaidLabel(`${display(hub.filePath)} (${hub.hubScore})`);
+    lines.push(`  ${id}["${label}"]`);
+  }
+
+  const seenEdges = new Set<string>();
+  let edgeCount = 0;
+  for (const hub of hubs) {
+    const srcId = registry.get(normalizePath(hub.filePath))!;
+    for (const callee of hub.callees) {
+      const norm = normalizePath(callee.filePath);
+      if (hubNorm.has(norm) && edgeCount < MAX_ARCH_EDGES) {
+        const tgtId = registry.get(norm);
+        if (tgtId && tgtId !== srcId) {
+          const edgeKey = `${srcId}-->${tgtId}`;
+          if (!seenEdges.has(edgeKey)) {
+            seenEdges.add(edgeKey);
+            lines.push(`  ${srcId} --> ${tgtId}`);
+            edgeCount++;
+          }
+        }
+      }
+    }
+  }
+
+  const truncated = hubs.length < articles.length;
+  return {
+    title: "Architecture overview",
+    type: "architecture",
+    mermaid: lines.join("\n"),
+    truncated,
+    truncationNote: truncated
+      ? `Showing top ${hubs.length} of ${articles.length} files by hub score`
+      : undefined,
+  };
+}

--- a/src/analyzer/wiki/WikiGenerator.ts
+++ b/src/analyzer/wiki/WikiGenerator.ts
@@ -24,11 +24,11 @@ import {
 function relLink(fromArticlePath: string, toArticlePath: string): string {
   return path
     .relative(path.dirname(fromArticlePath), toArticlePath)
-    .replace(/\\/g, "/");
+    .replaceAll('\\', "/");
 }
 
 function displayPath(filePath: string, workspaceRoot: string): string {
-  return path.relative(workspaceRoot, filePath).replace(/\\/g, "/");
+  return path.relative(workspaceRoot, filePath).replaceAll('\\', "/");
 }
 
 // ---------------------------------------------------------------------------
@@ -66,7 +66,7 @@ const DEFAULT_EXCLUDE_SUFFIXES = [
 
 function matchesSimplePattern(relPath: string, pattern: string): boolean {
   // "tests/**" or "tests/" → starts with
-  const p = pattern.replace(/\/\*\*$/, "/").replace(/\*\*\//g, "").replace(/\*/g, "");
+  const p = pattern.replace(/\/\*\*$/, "/").replaceAll('**/', "").replaceAll('*', "");
   if (pattern.endsWith("/**") || pattern.endsWith("/")) {
     return relPath.startsWith(p);
   }
@@ -88,11 +88,11 @@ function buildScopePredicate(
   const useDefaults = exclude === undefined;
 
   return (absPath: string): boolean => {
-    const rel = path.relative(workspaceRoot, absPath).replace(/\\/g, "/");
+    const rel = path.relative(workspaceRoot, absPath).replaceAll('\\', "/");
 
     // Scope restriction
     if (scope) {
-      const normalizedScope = scope.replace(/\\/g, "/").replace(/\/$/, "") + "/";
+      const normalizedScope = scope.replaceAll('\\', "/").replace(/\/$/, "") + "/";
       if (!rel.startsWith(normalizedScope) && rel !== scope.replace(/\/$/, "")) {
         return false;
       }
@@ -139,7 +139,7 @@ export class WikiGenerator {
 
   constructor(opts: WikiGeneratorOptions) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.db = opts.db as any;
+    this.db = opts.db;
     this.outputDir = opts.outputDir;
     this.workspaceRoot = opts.workspaceRoot;
     this.topHubsLimit = opts.topHubsLimit ?? 10;
@@ -230,7 +230,7 @@ export class WikiGenerator {
     const articlePath = path.join(
       this.outputDir,
       "articles",
-      displayPath(filePath, this.workspaceRoot).replace(/\//g, "_") + ".md",
+      displayPath(filePath, this.workspaceRoot).replaceAll('/', "_") + ".md",
     );
 
     const symbols = this.querySymbols(filePath);
@@ -335,7 +335,7 @@ export class WikiGenerator {
 
     // Scope note
     if (scopeNote) {
-      lines.push(...[`> ℹ️ ${scopeNote}`, ""]);
+      lines.push(`> ℹ️ ${scopeNote}`, "");
     }
 
     // Architecture diagram
@@ -353,11 +353,11 @@ export class WikiGenerator {
         path.join(this.outputDir, "index.md"),
         godNode.articlePath,
       );
-      lines.push(...[
+      lines.push(
         "## God Node",
         `[${godNode.title}](${godLink}) — Hub Score: ${godNode.hubScore}/100 — ${godNode.symbols.length} symbols — ${godNode.callers.length} callers`,
-        "",
-      ]);
+        ""
+      );
     }
 
     // Group by folder
@@ -366,7 +366,7 @@ export class WikiGenerator {
       const folder =
         path
           .relative(this.workspaceRoot, path.dirname(article.filePath))
-          .replace(/\\/g, "/") || ".";
+          .replaceAll('\\', "/") || ".";
       const key = normalizePath(folder);
       if (!folders.has(key)) folders.set(key, []);
       folders.get(key)!.push(article);
@@ -397,7 +397,7 @@ export class WikiGenerator {
     return path.join(
       this.outputDir,
       "articles",
-      displayPath(normalized, this.workspaceRoot).replace(/\//g, "_") + ".md",
+      displayPath(normalized, this.workspaceRoot).replaceAll('/', "_") + ".md",
     );
   }
 

--- a/src/analyzer/wiki/WikiGenerator.ts
+++ b/src/analyzer/wiki/WikiGenerator.ts
@@ -260,58 +260,63 @@ export class WikiGenerator {
   renderArticle(article: WikiArticle): string {
     const lines: string[] = [];
     const relSrc = displayPath(article.filePath, this.workspaceRoot);
-    const safe = (s: string) => s.replace(/\|/g, "\\|");
+    const escapedBackslash = String.raw`\\`;
+    const escapedPipe = String.raw`\|`;
+    const safe = (s: string) => s.replaceAll("\\", escapedBackslash).replaceAll("|", escapedPipe);
 
-    lines.push(`# ${article.title}`);
-    lines.push(`> ${relSrc} | Hub Score: ${article.hubScore}/100`);
-    lines.push("");
+    const headerLines = [`# ${article.title}`, `> ${relSrc} | Hub Score: ${article.hubScore}/100`, ""];
+    lines.push(...headerLines);
 
     if (article.symbols.length > 0) {
-      lines.push("## Symbols");
-      lines.push("| Name | Type | Line |");
-      lines.push("|------|------|------|");
-      for (const s of article.symbols) {
-        lines.push(`| ${safe(s.name)} | ${s.type} | ${s.declarationLine} |`);
-      }
-      lines.push("");
+      const symbolLines = [
+        "## Symbols",
+        "| Name | Type | Line |",
+        "|------|------|------|",
+        ...article.symbols.map((s) => `| ${safe(s.name)} | ${s.type} | ${s.declarationLine} |`),
+        "",
+      ];
+      lines.push(...symbolLines);
     }
 
     if (article.callers.length > 0) {
-      lines.push("## Called by");
-      lines.push("| Symbol | File | Line |");
-      lines.push("|--------|------|------|");
-      for (const c of article.callers) {
-        const link = relLink(article.articlePath, this.articlePathFor(c.filePath));
-        const fileDisplay = displayPath(c.filePath, this.workspaceRoot);
-        lines.push(`| ${safe(c.name)} | [${safe(fileDisplay)}](${link}) | ${c.callSiteLine} |`);
-      }
-      lines.push("");
+      const callerLines = [
+        "## Called by",
+        "| Symbol | File | Line |",
+        "|--------|------|------|",
+        ...article.callers.map((c) => {
+          const link = relLink(article.articlePath, this.articlePathFor(c.filePath));
+          const fileDisplay = displayPath(c.filePath, this.workspaceRoot);
+          return `| ${safe(c.name)} | [${safe(fileDisplay)}](${link}) | ${c.callSiteLine} |`;
+        }),
+        "",
+      ];
+      lines.push(...callerLines);
     }
 
     if (article.callees.length > 0) {
-      lines.push("## External calls");
-      lines.push("| Symbol | File | Line |");
-      lines.push("|--------|------|------|");
-      for (const c of article.callees) {
-        const link = relLink(article.articlePath, this.articlePathFor(c.filePath));
-        const fileDisplay = displayPath(c.filePath, this.workspaceRoot);
-        lines.push(`| ${safe(c.name)} | [${safe(fileDisplay)}](${link}) | ${c.callSiteLine} |`);
-      }
-      lines.push("");
+      const calleeLines = [
+        "## External calls",
+        "| Symbol | File | Line |",
+        "|--------|------|------|",
+        ...article.callees.map((c) => {
+          const link = relLink(article.articlePath, this.articlePathFor(c.filePath));
+          const fileDisplay = displayPath(c.filePath, this.workspaceRoot);
+          return `| ${safe(c.name)} | [${safe(fileDisplay)}](${link}) | ${c.callSiteLine} |`;
+        }),
+        "",
+      ];
+      lines.push(...calleeLines);
     }
 
-    // Diagrams
-    for (const diagram of article.diagrams) {
-      lines.push(`## ${diagram.title}`);
+    const diagramLines = article.diagrams.flatMap((diagram) => {
+      const block = [`## ${diagram.title}`];
       if (diagram.truncationNote) {
-        lines.push(`> ⚠️ ${diagram.truncationNote}`);
-        lines.push("");
+        block.push(`> ⚠️ ${diagram.truncationNote}`, "");
       }
-      lines.push("```mermaid");
-      lines.push(diagram.mermaid);
-      lines.push("```");
-      lines.push("");
-    }
+      block.push("```mermaid", diagram.mermaid, "```", "");
+      return block;
+    });
+    lines.push(...diagramLines);
 
     return lines.join("\n");
   }
@@ -325,26 +330,22 @@ export class WikiGenerator {
     const godNode = sorted[0];
     const lines: string[] = [];
 
-    lines.push(`# Wiki — ${path.basename(this.workspaceRoot)}`);
-    lines.push("");
+    const headerLines = [`# Wiki — ${path.basename(this.workspaceRoot)}`, ""];
+    lines.push(...headerLines);
 
     // Scope note
     if (scopeNote) {
-      lines.push(`> ℹ️ ${scopeNote}`);
-      lines.push("");
+      lines.push(...[`> ℹ️ ${scopeNote}`, ""]);
     }
 
     // Architecture diagram
     if (archDiagram) {
-      lines.push("## Architecture overview");
+      const archLines = ["## Architecture overview"];
       if (archDiagram.truncationNote) {
-        lines.push(`> ⚠️ ${archDiagram.truncationNote}`);
-        lines.push("");
+        archLines.push(`> ⚠️ ${archDiagram.truncationNote}`, "");
       }
-      lines.push("```mermaid");
-      lines.push(archDiagram.mermaid);
-      lines.push("```");
-      lines.push("");
+      archLines.push("```mermaid", archDiagram.mermaid, "```", "");
+      lines.push(...archLines);
     }
 
     if (godNode) {
@@ -352,11 +353,11 @@ export class WikiGenerator {
         path.join(this.outputDir, "index.md"),
         godNode.articlePath,
       );
-      lines.push("## God Node");
-      lines.push(
+      lines.push(...[
+        "## God Node",
         `[${godNode.title}](${godLink}) — Hub Score: ${godNode.hubScore}/100 — ${godNode.symbols.length} symbols — ${godNode.callers.length} callers`,
-      );
-      lines.push("");
+        "",
+      ]);
     }
 
     // Group by folder
@@ -372,19 +373,20 @@ export class WikiGenerator {
     }
 
     for (const [folder, folderArticles] of folders) {
-      lines.push(`## ${folder}/`);
-      lines.push("| File | Hub Score | Symbols | Callers | Diagrams |");
-      lines.push("|------|-----------|---------|---------|----------|");
-      for (const a of folderArticles) {
-        const link = relLink(
-          path.join(this.outputDir, "index.md"),
-          a.articlePath,
-        );
-        lines.push(
-          `| [${a.title}](${link}) | ${a.hubScore} | ${a.symbols.length} | ${a.callers.length} | ${a.diagrams.length} |`,
-        );
-      }
-      lines.push("");
+      const folderLines = [
+        `## ${folder}/`,
+        "| File | Hub Score | Symbols | Callers | Diagrams |",
+        "|------|-----------|---------|---------|----------|",
+        ...folderArticles.map((a) => {
+          const link = relLink(
+            path.join(this.outputDir, "index.md"),
+            a.articlePath,
+          );
+          return `| [${a.title}](${link}) | ${a.hubScore} | ${a.symbols.length} | ${a.callers.length} | ${a.diagrams.length} |`;
+        }),
+        "",
+      ];
+      lines.push(...folderLines);
     }
 
     return lines.join("\n");

--- a/src/analyzer/wiki/WikiGenerator.ts
+++ b/src/analyzer/wiki/WikiGenerator.ts
@@ -1,0 +1,555 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { normalizePath } from "../../shared/path.js";
+import type {
+  MermaidDiagram,
+  WikiArticle,
+  WikiGenerateResult,
+  WikiGeneratorOptions,
+  WikiLink,
+  WikiSymbol,
+} from "../../shared/wiki-types.js";
+import { analyzeControlFlow } from "./ControlFlowAnalyzer.js";
+import {
+  buildArchitectureDiagram,
+  buildCallerDiagram,
+  buildDependencyDiagram,
+} from "./DiagramBuilder.js";
+
+// Constraint #0: NEVER emit absolute paths in generated markdown.
+// - Internal storage: normalizePath(filePath) — for Sets/Maps
+// - Markdown links: path.relative(from, to).replace(/\\/g, '/')
+// - Markdown display: path.relative(workspaceRoot, filePath).replace(/\\/g, '/')
+
+function relLink(fromArticlePath: string, toArticlePath: string): string {
+  return path
+    .relative(path.dirname(fromArticlePath), toArticlePath)
+    .replace(/\\/g, "/");
+}
+
+function displayPath(filePath: string, workspaceRoot: string): string {
+  return path.relative(workspaceRoot, filePath).replace(/\\/g, "/");
+}
+
+// ---------------------------------------------------------------------------
+// Scope filtering helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Default exclusion patterns applied when no explicit --exclude is passed.
+ * Each entry is checked against the relative path from workspaceRoot.
+ */
+const DEFAULT_EXCLUDES = [
+  "tests/",
+  "test/",
+  "__tests__/",
+  "dist/",
+  "out/",
+  "build/",
+  "node_modules/",
+  ".git/",
+  ".claude/",
+  ".github/",
+  "graphify-out/",
+];
+
+const DEFAULT_EXCLUDE_SUFFIXES = [
+  ".test.ts",
+  ".spec.ts",
+  ".test.js",
+  ".spec.js",
+  ".test.tsx",
+  ".spec.tsx",
+  ".d.ts",
+  ".min.js",
+];
+
+function matchesSimplePattern(relPath: string, pattern: string): boolean {
+  // "tests/**" or "tests/" → starts with
+  const p = pattern.replace(/\/\*\*$/, "/").replace(/\*\*\//g, "").replace(/\*/g, "");
+  if (pattern.endsWith("/**") || pattern.endsWith("/")) {
+    return relPath.startsWith(p);
+  }
+  // "**/*.test.ts" → suffix check
+  if (pattern.startsWith("**/")) {
+    const suffix = pattern.slice(3);
+    return relPath.endsWith(suffix) || relPath.includes(`/${suffix}`);
+  }
+  // Exact match or contains
+  return relPath === p || relPath.includes(p);
+}
+
+function buildScopePredicate(
+  workspaceRoot: string,
+  scope?: string,
+  exclude?: string[],
+): (absPath: string) => boolean {
+  const effectiveExclude = exclude ?? [];
+  const useDefaults = exclude === undefined;
+
+  return (absPath: string): boolean => {
+    const rel = path.relative(workspaceRoot, absPath).replace(/\\/g, "/");
+
+    // Scope restriction
+    if (scope) {
+      const normalizedScope = scope.replace(/\\/g, "/").replace(/\/$/, "") + "/";
+      if (!rel.startsWith(normalizedScope) && rel !== scope.replace(/\/$/, "")) {
+        return false;
+      }
+    }
+
+    // Explicit exclude patterns
+    for (const pattern of effectiveExclude) {
+      if (matchesSimplePattern(rel, pattern)) return false;
+    }
+
+    // Default excludes (applied when no explicit --exclude given)
+    if (useDefaults) {
+      for (const prefix of DEFAULT_EXCLUDES) {
+        if (rel.startsWith(prefix)) return false;
+      }
+      for (const suffix of DEFAULT_EXCLUDE_SUFFIXES) {
+        if (rel.endsWith(suffix)) return false;
+      }
+    }
+
+    return true;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// WikiGenerator
+// ---------------------------------------------------------------------------
+
+export class WikiGenerator {
+  private readonly db: {
+    exec: (sql: string) => Array<{ columns: string[]; values: unknown[][] }>;
+    prepare: (sql: string) => {
+      bind: (params: unknown[]) => void;
+      step: () => boolean;
+      getAsObject: () => Record<string, unknown>;
+      free: () => void;
+    };
+  };
+  private readonly outputDir: string;
+  private readonly workspaceRoot: string;
+  private readonly topHubsLimit: number;
+  private readonly scope: string | undefined;
+  private readonly exclude: string[] | undefined;
+
+  constructor(opts: WikiGeneratorOptions) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.db = opts.db as any;
+    this.outputDir = opts.outputDir;
+    this.workspaceRoot = opts.workspaceRoot;
+    this.topHubsLimit = opts.topHubsLimit ?? 10;
+    this.scope = opts.scope;
+    this.exclude = opts.exclude;
+  }
+
+  async generate(): Promise<WikiGenerateResult> {
+    const scopePredicate = buildScopePredicate(
+      this.workspaceRoot,
+      this.scope,
+      this.exclude,
+    );
+
+    // Build hub score map
+    const hubMap = this.buildHubMap();
+
+    // Enumerate files — with scope/exclude applied
+    const allFiles = this.queryFiles();
+    const files = allFiles.filter(scopePredicate);
+
+    // Build all articles (pure, no I/O)
+    const articles: WikiArticle[] = files.map((filePath) => {
+      const normalized = normalizePath(filePath);
+      const score = hubMap.get(normalized) ?? 0;
+      return this.buildArticle(normalized, score);
+    });
+
+    // Write output files
+    await fs.mkdir(this.outputDir, { recursive: true });
+    const articlesDir = path.join(this.outputDir, "articles");
+    await fs.mkdir(articlesDir, { recursive: true });
+
+    for (const article of articles) {
+      const markdown = this.renderArticle(article);
+      await fs.writeFile(article.articlePath, markdown, "utf-8");
+    }
+
+    // Build architecture diagram from article data
+    const archDiagram = buildArchitectureDiagram(
+      articles,
+      (fp) => displayPath(fp, this.workspaceRoot),
+    );
+
+    // Build scope note
+    const excludedCount = allFiles.length - files.length;
+    const scopeNote = this.buildScopeNote(files.length, excludedCount);
+
+    const indexMarkdown = this.renderIndex(articles, archDiagram, scopeNote);
+    const indexPath = path.join(this.outputDir, "index.md");
+    await fs.writeFile(indexPath, indexMarkdown, "utf-8");
+
+    // Build topHubs
+    const sorted = [...articles].sort((a, b) => b.hubScore - a.hubScore);
+    const topHubs = sorted.slice(0, this.topHubsLimit).map((a) => ({
+      name: a.title,
+      score: a.hubScore,
+    }));
+
+    return {
+      articlesCount: articles.length,
+      indexPath,
+      articlesDir,
+      topHubs,
+      scopeNote,
+    };
+  }
+
+  private buildScopeNote(includedCount: number, excludedCount: number): string | undefined {
+    const parts: string[] = [];
+    if (this.scope) {
+      const displayScope = path.isAbsolute(this.scope)
+        ? path.relative(this.workspaceRoot, this.scope)
+        : this.scope;
+      parts.push(`scope: \`${displayScope}\``);
+    }
+    if (this.exclude?.length) parts.push(`excluding: ${this.exclude.map((e) => `\`${e}\``).join(", ")}`);
+    if (!this.exclude) parts.push("auto-excludes: tests/, dist/, *.test.ts applied");
+    if (excludedCount > 0) parts.push(`${excludedCount} file${excludedCount > 1 ? "s" : ""} excluded`);
+
+    if (parts.length === 0) return undefined;
+    return `${includedCount} files included — ${parts.join(" · ")}`;
+  }
+
+  buildArticle(filePath: string, hubScore: number): WikiArticle {
+    const ext = path.extname(filePath);
+    const title = path.basename(filePath, ext);
+    const articlePath = path.join(
+      this.outputDir,
+      "articles",
+      displayPath(filePath, this.workspaceRoot).replace(/\//g, "_") + ".md",
+    );
+
+    const symbols = this.querySymbols(filePath);
+    const callers = this.queryCallers(filePath);
+    const callees = this.queryCallees(filePath);
+    const display = (fp: string) => displayPath(fp, this.workspaceRoot);
+
+    // Build diagrams
+    const diagrams: MermaidDiagram[] = [];
+
+    const depDiagram = buildDependencyDiagram({ title, filePath, articlePath, hubScore, symbols, callers, callees, diagrams: [] }, display);
+    if (depDiagram) diagrams.push(depDiagram);
+
+    const callerDiagram = buildCallerDiagram({ title, filePath, articlePath, hubScore, symbols, callers, callees, diagrams: [] }, display);
+    if (callerDiagram) diagrams.push(callerDiagram);
+
+    // Control flow diagrams (only for TS/JS files)
+    const ext2 = path.extname(filePath).toLowerCase();
+    if ([".ts", ".tsx", ".js", ".jsx"].includes(ext2)) {
+      const cfDiagrams = analyzeControlFlow(filePath);
+      diagrams.push(...cfDiagrams);
+    }
+
+    return { title, filePath, articlePath, hubScore, symbols, callers, callees, diagrams };
+  }
+
+  renderArticle(article: WikiArticle): string {
+    const lines: string[] = [];
+    const relSrc = displayPath(article.filePath, this.workspaceRoot);
+    const safe = (s: string) => s.replace(/\|/g, "\\|");
+
+    lines.push(`# ${article.title}`);
+    lines.push(`> ${relSrc} | Hub Score: ${article.hubScore}/100`);
+    lines.push("");
+
+    if (article.symbols.length > 0) {
+      lines.push("## Symbols");
+      lines.push("| Name | Type | Line |");
+      lines.push("|------|------|------|");
+      for (const s of article.symbols) {
+        lines.push(`| ${safe(s.name)} | ${s.type} | ${s.declarationLine} |`);
+      }
+      lines.push("");
+    }
+
+    if (article.callers.length > 0) {
+      lines.push("## Called by");
+      lines.push("| Symbol | File | Line |");
+      lines.push("|--------|------|------|");
+      for (const c of article.callers) {
+        const link = relLink(article.articlePath, this.articlePathFor(c.filePath));
+        const fileDisplay = displayPath(c.filePath, this.workspaceRoot);
+        lines.push(`| ${safe(c.name)} | [${safe(fileDisplay)}](${link}) | ${c.callSiteLine} |`);
+      }
+      lines.push("");
+    }
+
+    if (article.callees.length > 0) {
+      lines.push("## External calls");
+      lines.push("| Symbol | File | Line |");
+      lines.push("|--------|------|------|");
+      for (const c of article.callees) {
+        const link = relLink(article.articlePath, this.articlePathFor(c.filePath));
+        const fileDisplay = displayPath(c.filePath, this.workspaceRoot);
+        lines.push(`| ${safe(c.name)} | [${safe(fileDisplay)}](${link}) | ${c.callSiteLine} |`);
+      }
+      lines.push("");
+    }
+
+    // Diagrams
+    for (const diagram of article.diagrams) {
+      lines.push(`## ${diagram.title}`);
+      if (diagram.truncationNote) {
+        lines.push(`> ⚠️ ${diagram.truncationNote}`);
+        lines.push("");
+      }
+      lines.push("```mermaid");
+      lines.push(diagram.mermaid);
+      lines.push("```");
+      lines.push("");
+    }
+
+    return lines.join("\n");
+  }
+
+  renderIndex(
+    articles: WikiArticle[],
+    archDiagram: MermaidDiagram | null,
+    scopeNote: string | undefined,
+  ): string {
+    const sorted = [...articles].sort((a, b) => b.hubScore - a.hubScore);
+    const godNode = sorted[0];
+    const lines: string[] = [];
+
+    lines.push(`# Wiki — ${path.basename(this.workspaceRoot)}`);
+    lines.push("");
+
+    // Scope note
+    if (scopeNote) {
+      lines.push(`> ℹ️ ${scopeNote}`);
+      lines.push("");
+    }
+
+    // Architecture diagram
+    if (archDiagram) {
+      lines.push("## Architecture overview");
+      if (archDiagram.truncationNote) {
+        lines.push(`> ⚠️ ${archDiagram.truncationNote}`);
+        lines.push("");
+      }
+      lines.push("```mermaid");
+      lines.push(archDiagram.mermaid);
+      lines.push("```");
+      lines.push("");
+    }
+
+    if (godNode) {
+      const godLink = relLink(
+        path.join(this.outputDir, "index.md"),
+        godNode.articlePath,
+      );
+      lines.push("## God Node");
+      lines.push(
+        `[${godNode.title}](${godLink}) — Hub Score: ${godNode.hubScore}/100 — ${godNode.symbols.length} symbols — ${godNode.callers.length} callers`,
+      );
+      lines.push("");
+    }
+
+    // Group by folder
+    const folders = new Map<string, WikiArticle[]>();
+    for (const article of sorted) {
+      const folder =
+        path
+          .relative(this.workspaceRoot, path.dirname(article.filePath))
+          .replace(/\\/g, "/") || ".";
+      const key = normalizePath(folder);
+      if (!folders.has(key)) folders.set(key, []);
+      folders.get(key)!.push(article);
+    }
+
+    for (const [folder, folderArticles] of folders) {
+      lines.push(`## ${folder}/`);
+      lines.push("| File | Hub Score | Symbols | Callers | Diagrams |");
+      lines.push("|------|-----------|---------|---------|----------|");
+      for (const a of folderArticles) {
+        const link = relLink(
+          path.join(this.outputDir, "index.md"),
+          a.articlePath,
+        );
+        lines.push(
+          `| [${a.title}](${link}) | ${a.hubScore} | ${a.symbols.length} | ${a.callers.length} | ${a.diagrams.length} |`,
+        );
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n");
+  }
+
+  private articlePathFor(filePath: string): string {
+    const normalized = normalizePath(filePath);
+    return path.join(
+      this.outputDir,
+      "articles",
+      displayPath(normalized, this.workspaceRoot).replace(/\//g, "_") + ".md",
+    );
+  }
+
+  private buildHubMap(): Map<string, number> {
+    const map = new Map<string, number>();
+    let maxHub = 0;
+
+    try {
+      const result = this.db.exec(`
+        SELECT n.path, COUNT(DISTINCT e.source_id) AS hub
+        FROM edges e JOIN nodes n ON e.target_id = n.id
+        GROUP BY n.path
+        ORDER BY hub DESC
+      `);
+
+      if (result.length > 0) {
+        const rows = result[0];
+        const pathIdx = rows.columns.indexOf("path");
+        const hubIdx = rows.columns.indexOf("hub");
+        for (const row of rows.values) {
+          const hub = Number(row[hubIdx]) || 0;
+          if (hub > maxHub) maxHub = hub;
+          map.set(normalizePath(String(row[pathIdx])), hub);
+        }
+      }
+    } catch {
+      // No edges yet — all hub scores = 0
+    }
+
+    if (maxHub > 0) {
+      for (const [k, v] of map) {
+        map.set(k, Math.round((v / maxHub) * 100));
+      }
+    }
+
+    return map;
+  }
+
+  private queryFiles(): string[] {
+    const files: string[] = [];
+    try {
+      const result = this.db.exec("SELECT path FROM file_index ORDER BY path ASC");
+      if (result.length > 0) {
+        const pathIdx = result[0].columns.indexOf("path");
+        for (const row of result[0].values) {
+          files.push(String(row[pathIdx]));
+        }
+      }
+    } catch {
+      // Fall back to distinct paths in nodes
+      try {
+        const result = this.db.exec(
+          "SELECT DISTINCT path FROM nodes ORDER BY path ASC",
+        );
+        if (result.length > 0) {
+          const pathIdx = result[0].columns.indexOf("path");
+          for (const row of result[0].values) {
+            files.push(String(row[pathIdx]));
+          }
+        }
+      } catch {
+        // empty
+      }
+    }
+    return files;
+  }
+
+  private querySymbols(filePath: string): WikiSymbol[] {
+    const symbols: WikiSymbol[] = [];
+    try {
+      const stmt = this.db.prepare(
+        "SELECT name, type, start_line FROM nodes WHERE path = ? ORDER BY start_line ASC",
+      );
+      stmt.bind([filePath]);
+      while (stmt.step()) {
+        const row = stmt.getAsObject() as {
+          name: string;
+          type: string;
+          start_line: number;
+        };
+        symbols.push({
+          name: row.name,
+          type: row.type as WikiSymbol["type"],
+          declarationLine: row.start_line,
+        });
+      }
+      stmt.free();
+    } catch {
+      // empty
+    }
+    return symbols;
+  }
+
+  private queryCallers(filePath: string): WikiLink[] {
+    const callers: WikiLink[] = [];
+    try {
+      const stmt = this.db.prepare(`
+        SELECT DISTINCT n_src.path AS caller_path, n_src.name AS caller_name, e.source_line
+        FROM edges e
+        JOIN nodes n_tgt ON e.target_id = n_tgt.id
+        JOIN nodes n_src ON e.source_id = n_src.id
+        WHERE n_tgt.path = ?
+        ORDER BY e.source_line ASC
+        LIMIT 20
+      `);
+      stmt.bind([filePath]);
+      while (stmt.step()) {
+        const row = stmt.getAsObject() as {
+          caller_path: string;
+          caller_name: string;
+          source_line: number;
+        };
+        callers.push({
+          name: row.caller_name,
+          filePath: normalizePath(row.caller_path),
+          callSiteLine: row.source_line,
+        });
+      }
+      stmt.free();
+    } catch {
+      // empty
+    }
+    return callers;
+  }
+
+  private queryCallees(filePath: string): WikiLink[] {
+    const callees: WikiLink[] = [];
+    try {
+      const stmt = this.db.prepare(`
+        SELECT DISTINCT n_tgt.path AS callee_path, n_tgt.name AS callee_name, e.source_line
+        FROM edges e
+        JOIN nodes n_src ON e.source_id = n_src.id
+        JOIN nodes n_tgt ON e.target_id = n_tgt.id
+        WHERE n_src.path = ?
+        ORDER BY e.source_line ASC
+        LIMIT 20
+      `);
+      stmt.bind([filePath]);
+      while (stmt.step()) {
+        const row = stmt.getAsObject() as {
+          callee_path: string;
+          callee_name: string;
+          source_line: number;
+        };
+        callees.push({
+          name: row.callee_name,
+          filePath: normalizePath(row.callee_path),
+          callSiteLine: row.source_line,
+        });
+      }
+      stmt.free();
+    } catch {
+      // empty
+    }
+    return callees;
+  }
+}

--- a/src/analyzer/wiki/WikiIndexBuilder.ts
+++ b/src/analyzer/wiki/WikiIndexBuilder.ts
@@ -1,0 +1,16 @@
+import type { WikiArticle, WikiGenerateResult } from "../../shared/wiki-types.js";
+
+export class WikiIndexBuilder {
+  buildIndex(articles: WikiArticle[]): WikiArticle[] {
+    return [...articles].sort((a, b) => b.hubScore - a.hubScore);
+  }
+
+  topHubs(
+    articles: WikiArticle[],
+    n = 10,
+  ): WikiGenerateResult["topHubs"] {
+    return this.buildIndex(articles)
+      .slice(0, n)
+      .map((a) => ({ name: a.title, score: a.hubScore }));
+  }
+}

--- a/src/cli/commands/query.ts
+++ b/src/cli/commands/query.ts
@@ -99,9 +99,7 @@ function formatTextOutput(
   workspaceRoot: string,
 ): string {
   const lines: string[] = [];
-  lines.push(`Question: ${result.question}`);
-  lines.push(`Keywords: ${result.extractedKeywords.join(", ") || "(none)"}`);
-  lines.push(`Nodes: ${result.nodeCount}  Edges: ${result.edgeCount}`);
+  lines.push(`Question: ${result.question}`, `Keywords: ${result.extractedKeywords.join(", ") || "(none)"}`, `Nodes: ${result.nodeCount}  Edges: ${result.edgeCount}`);
   if (result.meta.truncated) {
     lines.push("(result truncated — increase --token-budget for more)");
   }
@@ -143,8 +141,8 @@ export async function run(
   const depth = parseDepth(args);
   const tokenBudget = parseTokenBudget(args);
   // --format in args overrides the top-level CLI format (e.g. REPL session default)
-  const queryFormat: 'toon' | 'json' | 'text' =
-    parseQueryFormatFromArgs(args) ?? (format === 'json' ? 'json' : format === 'toon' ? 'toon' : 'toon');
+  const queryFormatFromArgs = parseQueryFormatFromArgs(args);
+  const queryFormat: 'toon' | 'json' | 'text' = queryFormatFromArgs ?? (format === 'json' ? 'json' : 'toon');
 
   await runtime.ensureIndexed();
 

--- a/src/cli/commands/repl.ts
+++ b/src/cli/commands/repl.ts
@@ -22,6 +22,7 @@ import {
   confirmScan,
   inputCommandLine,
   inputQueryQuestion,
+  inputWikiOutputDir,
   inputSavePath,
   searchDirectory,
   searchFile,
@@ -92,6 +93,7 @@ const REPL_TYPED_RUNNER_LOADERS = {
   explain: () => import('./explain.js'),
   scan: () => import('./scan.js'),
   query: () => import('./query.js'),
+  wiki: () => import('./wiki.js'),
 } satisfies Record<string, () => Promise<{ run: ReplRunner }>>;
 
 function resolveTypedRunnerKey(command: string): keyof typeof REPL_TYPED_RUNNER_LOADERS | undefined {
@@ -106,6 +108,9 @@ function resolveTypedRunnerKey(command: string): keyof typeof REPL_TYPED_RUNNER_
   }
   if (command === 'q' || command === 'search') {
     return 'query';
+  }
+  if (command === 'docs' || command === 'documentation') {
+    return 'wiki';
   }
   if (command in REPL_TYPED_RUNNER_LOADERS) {
     return command as keyof typeof REPL_TYPED_RUNNER_LOADERS;
@@ -136,6 +141,7 @@ function buildReplHelpText(state: ReturnType<typeof createSessionState>): string
     '  /architecture   Build the workspace graph',
     '  /check          Find unused exports',
     '  /query          Query the codebase with natural language',
+    '  /wiki           Generate a markdown wiki from the call graph',
     '  /format         Change the default display format',
     '  /command        Run a raw CLI command line',
     '  /help           Show this help',
@@ -1215,6 +1221,11 @@ async function runAction(
       };
     }
     return executeCommandForRepl('query', [question], runtime, preferredFormat, (await import('./query.js')).run);
+  }
+
+  if (action === 'wiki') {
+    const outputDir = await inputWikiOutputDir();
+    return executeCommandForRepl('wiki', outputDir ? ['--output', outputDir] : [], runtime, preferredFormat, (await import('./wiki.js')).run);
   }
 
   if (action === 'architecture' || action === 'summary' || action === 'check') {

--- a/src/cli/commands/tool.ts
+++ b/src/cli/commands/tool.ts
@@ -30,7 +30,28 @@ import {
   executeTraceFunctionExecution,
   executeVerifyDependencyUsage,
 } from "../../mcp/tools";
-import type { McpToolName } from "../../mcp/types";
+import type {
+  AnalyzeBreakingChangesParams,
+  AnalyzeDependenciesParams,
+  AnalyzeFileLogicParams,
+  CrawlDependencyGraphParams,
+  ExpandNodeParams,
+  FindReferencingFilesParams,
+  FindUnusedSymbolsParams,
+  GenerateCodemapParams,
+  GetImpactAnalysisParams,
+  GetSymbolCallersParams,
+  GetSymbolDependentsParams,
+  GetSymbolGraphParams,
+  InvalidateFilesParams,
+  McpToolName,
+  ParseImportsParams,
+  QueryCallGraphParams,
+  ResolveModulePathParams,
+  ScanDeadCodeParams,
+  TraceFunctionExecutionParams,
+  VerifyDependencyUsageParams,
+} from "../../mcp/types";
 import { validateFilePath, validateToolParams } from "../../mcp/types";
 import { CliError, ExitCode } from "../errors";
 import type { CliOutputFormat } from "../formatter";
@@ -156,78 +177,112 @@ function parseToolArgs(args: string[]): Record<string, unknown> {
   return result;
 }
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-async function invokeTool(tool: McpToolName, params: any): Promise<unknown> {
-  const config = workerState.getConfig();
-  const rootDir = config.rootDir;
+type CliToolHandler = (params: unknown, rootDir: string) => Promise<unknown> | unknown;
 
-  // Helper for path validation on common fields
-  const vfp = (p: string) => validateFilePath(p, rootDir);
-
-  switch (tool) {
-    case "analyze_dependencies":
-      vfp(params.filePath);
-      return executeAnalyzeDependencies(params);
-    case "crawl_dependency_graph":
-      vfp(params.entryFile);
-      return executeCrawlDependencyGraph(params);
-    case "find_referencing_files":
-      vfp(params.targetPath);
-      return executeFindReferencingFiles(params);
-    case "expand_node":
-      vfp(params.filePath);
-      return executeExpandNode(params);
-    case "parse_imports":
-      vfp(params.filePath);
-      return executeParseImports(params);
-    case "verify_dependency_usage":
-      vfp(params.sourceFile);
-      vfp(params.targetFile);
-      return executeVerifyDependencyUsage(params);
-    case "resolve_module_path":
-      vfp(params.fromFile);
-      return executeResolveModulePath(params);
-    case "get_index_status":
-      return executeGetIndexStatus();
-    case "invalidate_files":
-      for (const fp of params.filePaths) vfp(fp);
-      return executeInvalidateFiles(params);
-    case "rebuild_index":
-      return executeRebuildIndex(() => {/* no-op progress for CLI */});
-    case "get_symbol_graph":
-      vfp(params.filePath);
-      return executeGetSymbolGraph(params);
-    case "find_unused_symbols":
-      vfp(params.filePath);
-      return executeFindUnusedSymbols(params);
-    case "get_symbol_dependents":
-      vfp(params.filePath);
-      return executeGetSymbolDependents(params);
-    case "trace_function_execution":
-      vfp(params.filePath);
-      return executeTraceFunctionExecution(params);
-    case "get_symbol_callers":
-      vfp(params.filePath);
-      return executeGetSymbolCallers(params);
-    case "analyze_breaking_changes":
-      vfp(params.filePath);
-      return executeAnalyzeBreakingChanges(params);
-    case "get_impact_analysis":
-      vfp(params.filePath);
-      return executeGetImpactAnalysis(params);
-    case "analyze_file_logic":
-      vfp(params.filePath);
-      return executeAnalyzeFileLogic(params);
-    case "generate_codemap":
-      vfp(params.filePath);
-      return executeGenerateCodemap(params);
-    case "query_call_graph":
-      vfp(params.filePath);
-      return executeQueryCallGraph(params);
-    case "scan_dead_code":
-      return executeScanDeadCode(params);
-    default:
-      throw new CliError(`Unknown tool: ${tool}`, ExitCode.GENERAL_ERROR);
-  }
+function validateCliPath(filePath: string, rootDir: string): void {
+  validateFilePath(filePath, rootDir);
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const cliToolHandlers: Partial<Record<McpToolName, CliToolHandler>> = {
+  analyze_dependencies: (params, rootDir) => {
+    const p = params as AnalyzeDependenciesParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeAnalyzeDependencies(p);
+  },
+  crawl_dependency_graph: (params, rootDir) => {
+    const p = params as CrawlDependencyGraphParams;
+    validateCliPath(p.entryFile, rootDir);
+    return executeCrawlDependencyGraph(p);
+  },
+  find_referencing_files: (params, rootDir) => {
+    const p = params as FindReferencingFilesParams;
+    validateCliPath(p.targetPath, rootDir);
+    return executeFindReferencingFiles(p);
+  },
+  expand_node: (params, rootDir) => {
+    const p = params as ExpandNodeParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeExpandNode(p);
+  },
+  parse_imports: (params, rootDir) => {
+    const p = params as ParseImportsParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeParseImports(p);
+  },
+  verify_dependency_usage: (params, rootDir) => {
+    const p = params as VerifyDependencyUsageParams;
+    validateCliPath(p.sourceFile, rootDir);
+    validateCliPath(p.targetFile, rootDir);
+    return executeVerifyDependencyUsage(p);
+  },
+  resolve_module_path: (params, rootDir) => {
+    const p = params as ResolveModulePathParams;
+    validateCliPath(p.fromFile, rootDir);
+    return executeResolveModulePath(p);
+  },
+  get_index_status: () => executeGetIndexStatus(),
+  invalidate_files: (params, rootDir) => {
+    const p = params as InvalidateFilesParams;
+    for (const filePath of p.filePaths) validateCliPath(filePath, rootDir);
+    return executeInvalidateFiles(p);
+  },
+  rebuild_index: () => executeRebuildIndex(() => {/* no-op progress for CLI */}),
+  get_symbol_graph: (params, rootDir) => {
+    const p = params as GetSymbolGraphParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeGetSymbolGraph(p);
+  },
+  find_unused_symbols: (params, rootDir) => {
+    const p = params as FindUnusedSymbolsParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeFindUnusedSymbols(p);
+  },
+  get_symbol_dependents: (params, rootDir) => {
+    const p = params as GetSymbolDependentsParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeGetSymbolDependents(p);
+  },
+  trace_function_execution: (params, rootDir) => {
+    const p = params as TraceFunctionExecutionParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeTraceFunctionExecution(p);
+  },
+  get_symbol_callers: (params, rootDir) => {
+    const p = params as GetSymbolCallersParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeGetSymbolCallers(p);
+  },
+  analyze_breaking_changes: (params, rootDir) => {
+    const p = params as AnalyzeBreakingChangesParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeAnalyzeBreakingChanges(p);
+  },
+  get_impact_analysis: (params, rootDir) => {
+    const p = params as GetImpactAnalysisParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeGetImpactAnalysis(p);
+  },
+  analyze_file_logic: (params, rootDir) => {
+    const p = params as AnalyzeFileLogicParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeAnalyzeFileLogic(p);
+  },
+  generate_codemap: (params, rootDir) => {
+    const p = params as GenerateCodemapParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeGenerateCodemap(p);
+  },
+  query_call_graph: (params, rootDir) => {
+    const p = params as QueryCallGraphParams;
+    validateCliPath(p.filePath, rootDir);
+    return executeQueryCallGraph(p);
+  },
+  scan_dead_code: (params) => executeScanDeadCode(params as ScanDeadCodeParams),
+};
+
+async function invokeTool(tool: McpToolName, params: unknown): Promise<unknown> {
+  const config = workerState.getConfig();
+  const handler = cliToolHandlers[tool];
+  if (!handler) throw new CliError(`Unknown tool: ${tool}`, ExitCode.GENERAL_ERROR);
+  return handler(params, config.rootDir);
+}

--- a/src/cli/commands/wiki.ts
+++ b/src/cli/commands/wiki.ts
@@ -78,12 +78,13 @@ export async function run(
 
   const workspaceRoot = normalizePath(runtime.workspaceRoot);
   const absoluteOutputDir = path.isAbsolute(outputDir)
-    ? outputDir
+    ? path.resolve(outputDir)
     : path.resolve(workspaceRoot, outputDir);
+  const normalizedOutputDir = normalizePath(absoluteOutputDir);
 
   const result = await executeGenerateWiki({
     workspaceRoot,
-    outputDir: absoluteOutputDir,
+    outputDir: normalizedOutputDir,
     topHubsLimit,
     scope,
     exclude: exclude.length > 0 ? exclude : undefined,
@@ -93,11 +94,12 @@ export async function run(
     case "json":
       return JSON.stringify(result, null, 2);
     case "toon": {
+      const topHubsSummary = result.topHubs.map((h) => `${h.name}(${h.score})`).join(", ");
       const lines = [
         `wiki articles=${result.articlesCount}`,
         `index=${result.indexPath}`,
         `dir=${result.articlesDir}`,
-        `topHubs: ${result.topHubs.map((h) => `${h.name}(${h.score})`).join(", ")}`,
+        `topHubs: ${topHubsSummary}`,
       ];
       if (result.scopeNote) lines.push(`scope: ${result.scopeNote}`);
       return lines.join("\n");
@@ -114,8 +116,8 @@ export async function run(
       if (result.scopeNote) {
         lines.push(`- **Scope**: ${result.scopeNote}`);
       }
-      lines.push(``, `## Top hub files`);
-      lines.push(...result.topHubs.map((h) => `- ${h.name} (score: ${h.score})`));
+      const topHubLines = result.topHubs.map((h) => `- ${h.name} (score: ${h.score})`);
+      lines.push(``, `## Top hub files`, ...topHubLines);
       return lines.join("\n");
     }
   }

--- a/src/cli/commands/wiki.ts
+++ b/src/cli/commands/wiki.ts
@@ -1,0 +1,122 @@
+/**
+ * graph-it wiki — Generate a navigable markdown wiki from the call graph.
+ *
+ * Usage:
+ *   graph-it wiki [--output <dir>] [--scope <rel-path>] [--exclude <pattern>]...
+ *                 [--top N] [--format markdown|json|toon]
+ *
+ * By default, tests/, dist/, *.test.ts etc. are excluded automatically.
+ * Limitations (scope, truncation) are documented in the generated wiki itself.
+ */
+
+import path from "node:path";
+import { normalizePath } from "../../shared/path.js";
+import type { CliOutputFormat } from "../formatter.js";
+import type { CliRuntime } from "../runtime.js";
+import { executeGenerateWiki } from "../../mcp/tools/wiki.js";
+
+// ---------------------------------------------------------------------------
+// Flag helpers
+// ---------------------------------------------------------------------------
+
+function parseFlag(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx >= 0 && args[idx + 1] && !args[idx + 1].startsWith("-")) {
+    return args[idx + 1];
+  }
+  return undefined;
+}
+
+function parseFlagMulti(args: string[], flag: string): string[] {
+  const results: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === flag && args[i + 1] && !args[i + 1].startsWith("-")) {
+      results.push(args[i + 1]);
+    }
+  }
+  return results;
+}
+
+function parseOutputDir(args: string[]): string {
+  return parseFlag(args, "--output") ?? "wiki";
+}
+
+function parseTop(args: string[]): number {
+  const raw = parseFlag(args, "--top");
+  if (!raw) return 10;
+  const parsed = Number.parseInt(raw, 10);
+  return !Number.isNaN(parsed) && parsed >= 1 && parsed <= 50 ? parsed : 10;
+}
+
+function parseWikiFormat(
+  args: string[],
+  topLevelFormat: CliOutputFormat,
+): "markdown" | "json" | "toon" {
+  const raw = parseFlag(args, "--format");
+  if (raw === "markdown" || raw === "json" || raw === "toon") return raw;
+  if (topLevelFormat === "json") return "json";
+  if (topLevelFormat === "toon") return "toon";
+  return "markdown";
+}
+
+// ---------------------------------------------------------------------------
+// Command entry point
+// ---------------------------------------------------------------------------
+
+export async function run(
+  args: string[],
+  runtime: CliRuntime,
+  format: CliOutputFormat,
+): Promise<string> {
+  const outputDir = parseOutputDir(args);
+  const topHubsLimit = parseTop(args);
+  const wikiFormat = parseWikiFormat(args, format);
+  const scope = parseFlag(args, "--scope");
+  const exclude = parseFlagMulti(args, "--exclude");
+
+  await runtime.ensureIndexed();
+
+  const workspaceRoot = normalizePath(runtime.workspaceRoot);
+  const absoluteOutputDir = path.isAbsolute(outputDir)
+    ? outputDir
+    : path.resolve(workspaceRoot, outputDir);
+
+  const result = await executeGenerateWiki({
+    workspaceRoot,
+    outputDir: absoluteOutputDir,
+    topHubsLimit,
+    scope,
+    exclude: exclude.length > 0 ? exclude : undefined,
+  });
+
+  switch (wikiFormat) {
+    case "json":
+      return JSON.stringify(result, null, 2);
+    case "toon": {
+      const lines = [
+        `wiki articles=${result.articlesCount}`,
+        `index=${result.indexPath}`,
+        `dir=${result.articlesDir}`,
+        `topHubs: ${result.topHubs.map((h) => `${h.name}(${h.score})`).join(", ")}`,
+      ];
+      if (result.scopeNote) lines.push(`scope: ${result.scopeNote}`);
+      return lines.join("\n");
+    }
+    case "markdown":
+    default: {
+      const lines = [
+        `# Wiki generated`,
+        ``,
+        `- **Articles**: ${result.articlesCount}`,
+        `- **Index**: \`${result.indexPath}\``,
+        `- **Articles dir**: \`${result.articlesDir}\``,
+      ];
+      if (result.scopeNote) {
+        lines.push(`- **Scope**: ${result.scopeNote}`);
+      }
+      lines.push(``, `## Top hub files`);
+      lines.push(...result.topHubs.map((h) => `- ${h.name} (score: ${h.score})`));
+      return lines.join("\n");
+    }
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -349,6 +349,10 @@ async function dispatch(
       const { run } = await import("./commands/query.js");
       return run(args, runtime, format);
     }
+    case "wiki": {
+      const { run } = await import("./commands/wiki.js");
+      return run(args, runtime, format);
+    }
     default:
       throw new CliError(
         `Unknown command "${command}". Run graph-it --help for usage.`,

--- a/src/cli/repl/ink/ReplInkApp.ts
+++ b/src/cli/repl/ink/ReplInkApp.ts
@@ -85,6 +85,7 @@ const SLASH_COMMANDS: SlashCommandEntry[] = [
   { command: '/check', description: 'Find dead code' },
   { command: '/scan', description: 'Force indexing scan' },
   { command: '/query', description: 'Query the codebase with natural language', argsHint: '/query "<question>" [--depth N] [--token-budget N]' },
+  { command: '/wiki', description: 'Generate a markdown wiki from the call graph', argsHint: '/wiki [--output <dir>] [--top N] [--format markdown|json|toon]' },
   { command: '/command', description: 'Run raw command line', argsHint: '/command <graph-it command...>' },
   { command: '/format', description: 'Set default output format', argsHint: '/format <text|json|toon|markdown|mermaid>' },
   { command: '/help', description: 'Show REPL help' },

--- a/src/cli/repl/prompts.ts
+++ b/src/cli/repl/prompts.ts
@@ -29,6 +29,7 @@ export type MainAction =
   | 'summary'
   | 'architecture'
   | 'query'
+  | 'wiki'
   | 'format'
   | 'help'
   | 'quit';
@@ -157,6 +158,15 @@ const MAIN_ACTION_ENTRIES: PaletteEntry<MainAction>[] = [
     aliases: ['query', 'q', 'search'],
     keywords: ['query', 'search', 'ask', 'natural language', 'question'],
     value: 'query',
+    group: '🔍 Code Analysis',
+  },
+  {
+    slash: '/wiki',
+    title: 'Generate markdown wiki',
+    description: 'Generate a navigable markdown wiki from the call graph.',
+    aliases: ['wiki', 'docs', 'documentation'],
+    keywords: ['wiki', 'docs', 'generate', 'markdown', 'documentation'],
+    value: 'wiki',
     group: '🔍 Code Analysis',
   },
   {
@@ -1041,6 +1051,14 @@ export async function selectPreferredFormat(
 export async function inputQueryQuestion(defaultValue = ''): Promise<string> {
   return input({
     message: 'Ask a question about the codebase (e.g. "how does Spider crawl files")',
+    default: defaultValue,
+  });
+}
+
+/** Prompt for a wiki output directory. */
+export async function inputWikiOutputDir(defaultValue = 'wiki'): Promise<string> {
+  return input({
+    message: 'Output directory for wiki (relative to workspace root)',
     default: defaultValue,
   });
 }

--- a/src/mcp/mcpServer.ts
+++ b/src/mcp/mcpServer.ts
@@ -151,6 +151,7 @@ import {
   validateFilePath,
   VerifyDependencyUsageParamsSchema,
 } from "./types";
+import { GenerateWikiSchema } from "./tools/wiki.js";
 
 // ============================================================================
 // Environment Configuration
@@ -1889,6 +1890,53 @@ RETURNS:
     const response = await invokeToolWithResponse(
       "query_natural_language",
       { question, depth, tokenBudget, fileFilter, outputFormat },
+    );
+
+    return formatToolResponse(response, responseFormat);
+  },
+);
+
+// Tool: graphitlive_generate_wiki
+server.registerTool(
+  "graphitlive_generate_wiki",
+  {
+    title: "Generate Markdown Wiki from Call Graph",
+    description: `Generate a navigable markdown wiki from the call graph index. Creates one article per source file with hub scores, symbol lists, caller/callee cross-links, and a grouped index.
+
+WHEN TO USE:
+- User wants to produce documentation from the codebase
+- User wants a navigable overview of the project files and their relationships
+- Useful after indexing to create a persistent, browsable artifact
+
+RETURNS:
+- articlesCount: Number of markdown files written
+- indexPath: Relative path to the generated index.md (relative to workspaceRoot)
+- articlesDir: Relative path to the articles directory (relative to workspaceRoot)
+- topHubs: Top files by hub score (most depended-upon)
+
+First invocation indexes the entire workspace (3-8s). Subsequent calls are fast.`,
+    inputSchema: GenerateWikiSchema.extend({
+      response_format: ResponseFormatSchema.describe(
+        "Output format: 'json', 'markdown', or 'toon' (default: json). scope and exclude filtering is applied before generation — limitations are documented in the generated wiki itself.",
+      ),
+    }),
+    outputSchema: McpToolResponseSchema,
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async ({ workspaceRoot, outputDir, topHubsLimit, scope, exclude, response_format }) => {
+    const workerCheck = await ensureWorkerReady();
+    const responseFormat = response_format ?? "json";
+    if (workerCheck.error)
+      return formatToolResponse(workerCheck.response, responseFormat);
+
+    const response = await invokeToolWithResponse(
+      "generate_wiki",
+      { workspaceRoot, outputDir, topHubsLimit, scope, exclude },
     );
 
     return formatToolResponse(response, responseFormat);

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -45,3 +45,7 @@ export {
     executeQueryNaturalLanguage,
     QueryNaturalLanguageSchema
 } from "./query";
+export {
+    executeGenerateWiki,
+    GenerateWikiSchema
+} from "./wiki";

--- a/src/mcp/tools/wiki.ts
+++ b/src/mcp/tools/wiki.ts
@@ -1,0 +1,127 @@
+import * as path from "node:path";
+import { z } from "zod/v4";
+import { workerState } from "../shared/state.js";
+import type { WikiGenerateResult } from "../../shared/wiki-types.js";
+import { normalizePath } from "../../shared/path.js";
+
+// NO vscode imports — VS Code agnostic
+
+export const GenerateWikiSchema = z.object({
+  workspaceRoot: z
+    .string()
+    .optional()
+    .describe(
+      "Absolute path to workspace root. Defaults to the configured workspace.",
+    ),
+  outputDir: z
+    .string()
+    .optional()
+    .describe(
+      "Absolute path to wiki output directory. Defaults to <workspaceRoot>/wiki.",
+    ),
+  topHubsLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe("Number of top hub files to include (default: 10, max: 50)."),
+  scope: z
+    .string()
+    .optional()
+    .describe(
+      "Relative path within workspace to restrict wiki to (e.g. 'src/'). Defaults to entire workspace.",
+    ),
+  exclude: z
+    .array(z.string())
+    .optional()
+    .describe(
+      "Relative glob-like patterns to exclude (e.g. ['tests/**', '**/*.test.ts']). When omitted, default exclusions apply: tests/, dist/, *.test.ts, etc.",
+    ),
+});
+
+export type GenerateWikiParams = z.infer<typeof GenerateWikiSchema>;
+
+export interface GenerateWikiMcpResult {
+  articlesCount: number;
+  /** Relative to workspaceRoot — e.g. "wiki/index.md" */
+  indexPath: string;
+  /** Relative to workspaceRoot — e.g. "wiki/articles" */
+  articlesDir: string;
+  topHubs: Array<{ name: string; score: number }>;
+  /** Human-readable description of applied scope/exclusion rules. */
+  scopeNote?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Lazy call graph initialization (same pattern as query.ts)
+// ---------------------------------------------------------------------------
+
+async function ensureCallGraphReady(workspaceRoot: string): Promise<void> {
+  if (
+    workerState.callGraphIndexer &&
+    workerState.callGraphIndexedRoot === workspaceRoot
+  ) {
+    return;
+  }
+
+  const { executeQueryCallGraph } = await import("./callgraph.js");
+  try {
+    await executeQueryCallGraph({
+      filePath: workspaceRoot,
+      symbolName: "__init_only__",
+      direction: "both",
+      depth: 1,
+    });
+  } catch {
+    // Ignore — we only need the side-effect of initializing the indexer
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tool execution
+// ---------------------------------------------------------------------------
+
+export async function executeGenerateWiki(
+  params: GenerateWikiParams,
+): Promise<GenerateWikiMcpResult> {
+  const config = workerState.getConfig();
+  const workspaceRoot = normalizePath(params.workspaceRoot ?? config.rootDir);
+
+  await ensureCallGraphReady(workspaceRoot);
+
+  const indexer = workerState.callGraphIndexer;
+  if (!indexer) {
+    throw new Error(
+      "Call graph indexer not initialized. The workspace may not have supported source files.",
+    );
+  }
+
+  const resolvedOutputDir = normalizePath(
+    params.outputDir ?? path.join(workspaceRoot, "wiki"),
+  );
+
+  const { WikiGenerator } = await import(
+    "../../analyzer/wiki/WikiGenerator.js"
+  );
+
+  const generator = new WikiGenerator({
+    db: indexer.getDb(),
+    outputDir: resolvedOutputDir,
+    workspaceRoot,
+    topHubsLimit: params.topHubsLimit ?? 10,
+    scope: params.scope,
+    exclude: params.exclude,
+  });
+
+  const result: WikiGenerateResult = await generator.generate();
+
+  // Constraint #0: return relative paths to workspaceRoot
+  return {
+    articlesCount: result.articlesCount,
+    indexPath: path.relative(workspaceRoot, result.indexPath).replace(/\\/g, "/"),
+    articlesDir: path.relative(workspaceRoot, result.articlesDir).replace(/\\/g, "/"),
+    topHubs: result.topHubs,
+    scopeNote: result.scopeNote,
+  };
+}

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -108,7 +108,8 @@ export type McpToolName =
   | "generate_codemap" // NEW: Full codemap generation for a single file
   | "query_call_graph" // NEW: Cross-file call graph query (callers/callees via SQLite)
   | "scan_dead_code" // NEW: Workspace-wide dead code scan
-  | "query_natural_language"; // NEW: Natural language query over the call graph
+  | "query_natural_language" // Natural language query over the call graph
+  | "generate_wiki"; // Generate markdown wiki from call graph
 
 // ============================================================================
 // Zod Schemas for Tool Parameters
@@ -541,6 +542,22 @@ export const QueryNaturalLanguageParamsSchema = z.object({
 });
 export type QueryNaturalLanguageParams = z.infer<typeof QueryNaturalLanguageParamsSchema>;
 
+// Schema for generate_wiki
+export const GenerateWikiParamsSchema = z.object({
+  workspaceRoot: z.string().optional().describe("Absolute path to workspace root. Defaults to configured workspace."),
+  outputDir: z.string().optional().describe("Output directory for wiki files (default: wiki)"),
+  topHubsLimit: z
+    .number()
+    .int()
+    .min(1)
+    .max(50)
+    .optional()
+    .describe("Number of top hub files to list (max: 50, default: 10)"),
+  scope: z.string().optional().describe("Relative path within workspace to restrict wiki to (e.g. 'src/')"),
+  exclude: z.array(z.string()).optional().describe("Relative glob-like patterns to exclude"),
+});
+export type GenerateWikiParams = z.infer<typeof GenerateWikiParamsSchema>;
+
 // NEW: Schema for scan_dead_code (workspace-wide dead code scan)
 export const ScanDeadCodeParamsSchema = z.object({
   scopePath: FilePathSchema.optional().describe(
@@ -591,6 +608,7 @@ export const toolSchemas: Record<McpToolName, z.ZodType<unknown>> = {
   query_call_graph: QueryCallGraphParamsSchema,
   scan_dead_code: ScanDeadCodeParamsSchema,
   query_natural_language: QueryNaturalLanguageParamsSchema,
+  generate_wiki: GenerateWikiParamsSchema,
 };
 
 /**

--- a/src/mcp/worker/invokeTool.ts
+++ b/src/mcp/worker/invokeTool.ts
@@ -39,6 +39,7 @@ import type {
   GetSymbolGraphParams,
   InvalidateFilesParams,
   McpToolName,
+  McpWorkerConfig,
   McpWorkerResponse,
   ParseImportsParams,
   QueryCallGraphParams,
@@ -53,6 +54,126 @@ import {
   validateFilePath,
   validateToolParams,
 } from "../types";
+
+type ToolHandler = (
+  params: unknown,
+  config: McpWorkerConfig,
+  postMessage: (msg: McpWorkerResponse) => void,
+) => Promise<unknown> | unknown;
+
+function validateRootPath(filePath: string, config: McpWorkerConfig): void {
+  validateFilePath(filePath, config.rootDir);
+}
+
+const toolHandlers: Partial<Record<McpToolName, ToolHandler>> = {
+  analyze_dependencies: async (params, config) => {
+    const p = params as AnalyzeDependenciesParams;
+    validateRootPath(p.filePath, config);
+    return executeAnalyzeDependencies(p);
+  },
+  crawl_dependency_graph: async (params, config) => {
+    const p = params as CrawlDependencyGraphParams;
+    validateRootPath(p.entryFile, config);
+    return executeCrawlDependencyGraph(p);
+  },
+  find_referencing_files: async (params, config) => {
+    const p = params as FindReferencingFilesParams;
+    validateRootPath(p.targetPath, config);
+    return executeFindReferencingFiles(p);
+  },
+  expand_node: async (params, config) => {
+    const p = params as ExpandNodeParams;
+    validateRootPath(p.filePath, config);
+    return executeExpandNode(p);
+  },
+  parse_imports: async (params, config) => {
+    const p = params as ParseImportsParams;
+    validateRootPath(p.filePath, config);
+    return executeParseImports(p);
+  },
+  verify_dependency_usage: async (params, config) => {
+    const p = params as VerifyDependencyUsageParams;
+    validateRootPath(p.sourceFile, config);
+    validateRootPath(p.targetFile, config);
+    return executeVerifyDependencyUsage(p);
+  },
+  resolve_module_path: async (params, config) => {
+    const p = params as ResolveModulePathParams;
+    validateRootPath(p.fromFile, config);
+    return executeResolveModulePath(p);
+  },
+  get_index_status: () => executeGetIndexStatus(),
+  invalidate_files: (params, config) => {
+    const p = params as InvalidateFilesParams;
+    for (const filePath of p.filePaths) validateRootPath(filePath, config);
+    return executeInvalidateFiles(p);
+  },
+  rebuild_index: (_params, _config, postMessage) => executeRebuildIndex(postMessage),
+  get_symbol_graph: async (params, config) => {
+    const p = params as GetSymbolGraphParams;
+    validateRootPath(p.filePath, config);
+    return executeGetSymbolGraph(p);
+  },
+  find_unused_symbols: async (params, config) => {
+    const p = params as FindUnusedSymbolsParams;
+    validateRootPath(p.filePath, config);
+    return executeFindUnusedSymbols(p);
+  },
+  get_symbol_dependents: async (params, config) => {
+    const p = params as GetSymbolDependentsParams;
+    validateRootPath(p.filePath, config);
+    return executeGetSymbolDependents(p);
+  },
+  trace_function_execution: async (params, config) => {
+    const p = params as TraceFunctionExecutionParams;
+    validateRootPath(p.filePath, config);
+    return executeTraceFunctionExecution(p);
+  },
+  get_symbol_callers: async (params, config) => {
+    const p = params as GetSymbolCallersParams;
+    validateRootPath(p.filePath, config);
+    return executeGetSymbolCallers(p);
+  },
+  analyze_breaking_changes: async (params, config) => {
+    const p = params as AnalyzeBreakingChangesParams;
+    validateRootPath(p.filePath, config);
+    return executeAnalyzeBreakingChanges(p);
+  },
+  get_impact_analysis: async (params, config) => {
+    const p = params as GetImpactAnalysisParams;
+    validateRootPath(p.filePath, config);
+    return executeGetImpactAnalysis(p);
+  },
+  analyze_file_logic: async (params, config) => {
+    const p = params as AnalyzeFileLogicParams;
+    validateRootPath(p.filePath, config);
+    return executeAnalyzeFileLogic(p);
+  },
+  generate_codemap: async (params, config) => {
+    const p = params as GenerateCodemapParams;
+    validateRootPath(p.filePath, config);
+    return executeGenerateCodemap(p);
+  },
+  query_call_graph: async (params, config) => {
+    const p = params as QueryCallGraphParams;
+    validateRootPath(p.filePath, config);
+    return executeQueryCallGraph(p);
+  },
+  scan_dead_code: (params) => executeScanDeadCode(params as ScanDeadCodeParams),
+  query_natural_language: (params) => executeQueryNaturalLanguage(params as QueryNaturalLanguageParams),
+  generate_wiki: (params) => executeGenerateWiki(params as GenerateWikiParams),
+};
+
+async function executeValidatedTool(
+  tool: McpToolName,
+  params: unknown,
+  config: McpWorkerConfig,
+  postMessage: (msg: McpWorkerResponse) => void,
+): Promise<unknown> {
+  const handler = toolHandlers[tool];
+  if (!handler) throw new Error(`Unknown tool: ${tool}`);
+  return handler(params, config, postMessage);
+}
 
 export async function invokeTool(
   requestId: string,
@@ -93,144 +214,7 @@ export async function invokeTool(
 
     const validatedParams = validation.data;
     const config = workerState.getConfig();
-    let result: unknown;
-
-    switch (tool) {
-      case "analyze_dependencies": {
-        const p = validatedParams as AnalyzeDependenciesParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeAnalyzeDependencies(p);
-        break;
-      }
-      case "crawl_dependency_graph": {
-        const p = validatedParams as CrawlDependencyGraphParams;
-        validateFilePath(p.entryFile, config.rootDir);
-        result = await executeCrawlDependencyGraph(p);
-        break;
-      }
-      case "find_referencing_files": {
-        const p = validatedParams as FindReferencingFilesParams;
-        validateFilePath(p.targetPath, config.rootDir);
-        result = await executeFindReferencingFiles(p);
-        break;
-      }
-      case "expand_node": {
-        const p = validatedParams as ExpandNodeParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeExpandNode(p);
-        break;
-      }
-      case "parse_imports": {
-        const p = validatedParams as ParseImportsParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeParseImports(p);
-        break;
-      }
-      case "verify_dependency_usage": {
-        const p = validatedParams as VerifyDependencyUsageParams;
-        validateFilePath(p.sourceFile, config.rootDir);
-        validateFilePath(p.targetFile, config.rootDir);
-        result = await executeVerifyDependencyUsage(p);
-        break;
-      }
-      case "resolve_module_path": {
-        const p = validatedParams as ResolveModulePathParams;
-        validateFilePath(p.fromFile, config.rootDir);
-        result = await executeResolveModulePath(p);
-        break;
-      }
-      case "get_index_status":
-        result = await executeGetIndexStatus();
-        break;
-      case "invalidate_files": {
-        const p = validatedParams as InvalidateFilesParams;
-        for (const filePath of p.filePaths) {
-          validateFilePath(filePath, config.rootDir);
-        }
-        result = executeInvalidateFiles(p);
-        break;
-      }
-      case "rebuild_index":
-        result = await executeRebuildIndex(postMessage);
-        break;
-      case "get_symbol_graph": {
-        const p = validatedParams as GetSymbolGraphParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeGetSymbolGraph(p);
-        break;
-      }
-      case "find_unused_symbols": {
-        const p = validatedParams as FindUnusedSymbolsParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeFindUnusedSymbols(p);
-        break;
-      }
-      case "get_symbol_dependents": {
-        const p = validatedParams as GetSymbolDependentsParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeGetSymbolDependents(p);
-        break;
-      }
-      case "trace_function_execution": {
-        const p = validatedParams as TraceFunctionExecutionParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeTraceFunctionExecution(p);
-        break;
-      }
-      case "get_symbol_callers": {
-        const p = validatedParams as GetSymbolCallersParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeGetSymbolCallers(p);
-        break;
-      }
-      case "analyze_breaking_changes": {
-        const p = validatedParams as AnalyzeBreakingChangesParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeAnalyzeBreakingChanges(p);
-        break;
-      }
-      case "get_impact_analysis": {
-        const p = validatedParams as GetImpactAnalysisParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeGetImpactAnalysis(p);
-        break;
-      }
-      case "analyze_file_logic": {
-        const p = validatedParams as AnalyzeFileLogicParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeAnalyzeFileLogic(p);
-        break;
-      }
-      case "generate_codemap": {
-        const p = validatedParams as GenerateCodemapParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeGenerateCodemap(p);
-        break;
-      }
-      case "query_call_graph": {
-        const p = validatedParams as QueryCallGraphParams;
-        validateFilePath(p.filePath, config.rootDir);
-        result = await executeQueryCallGraph(p);
-        break;
-      }
-      case "scan_dead_code": {
-        const p = validatedParams as ScanDeadCodeParams;
-        result = await executeScanDeadCode(p);
-        break;
-      }
-      case "query_natural_language": {
-        const p = validatedParams as QueryNaturalLanguageParams;
-        result = await executeQueryNaturalLanguage(p);
-        break;
-      }
-      case "generate_wiki": {
-        const p = validatedParams as GenerateWikiParams;
-        result = await executeGenerateWiki(p);
-        break;
-      }
-      default:
-        throw new Error(`Unknown tool: ${tool}`);
-    }
+    const result = await executeValidatedTool(tool, validatedParams, config, postMessage);
 
     const executionTimeMs = Date.now() - startTime;
 

--- a/src/mcp/worker/invokeTool.ts
+++ b/src/mcp/worker/invokeTool.ts
@@ -22,6 +22,7 @@ import {
   executeTraceFunctionExecution,
   executeVerifyDependencyUsage,
   executeQueryNaturalLanguage,
+  executeGenerateWiki,
 } from "../tools";
 import type {
   AnalyzeBreakingChangesParams,
@@ -47,6 +48,7 @@ import type {
   VerifyDependencyUsageParams,
   QueryNaturalLanguageParams,
 } from "../types";
+import type { GenerateWikiParams } from "../types.js";
 import {
   validateFilePath,
   validateToolParams,
@@ -219,6 +221,11 @@ export async function invokeTool(
       case "query_natural_language": {
         const p = validatedParams as QueryNaturalLanguageParams;
         result = await executeQueryNaturalLanguage(p);
+        break;
+      }
+      case "generate_wiki": {
+        const p = validatedParams as GenerateWikiParams;
+        result = await executeGenerateWiki(p);
         break;
       }
       default:

--- a/src/shared/wiki-types.ts
+++ b/src/shared/wiki-types.ts
@@ -1,0 +1,63 @@
+export type SymbolNodeType =
+  | "function"
+  | "class"
+  | "method"
+  | "interface"
+  | "type"
+  | "variable";
+
+export interface WikiSymbol {
+  name: string;
+  type: SymbolNodeType;
+  declarationLine: number; // = start_line from nodes table
+}
+
+export interface WikiLink {
+  name: string;
+  filePath: string; // absolute normalized — internal use only, never emitted in markdown
+  callSiteLine: number; // = source_line from edges table
+}
+
+export interface MermaidDiagram {
+  title: string;
+  type: "dependency" | "caller" | "control-flow" | "architecture";
+  mermaid: string;
+  truncated: boolean;
+  /** Shown as a blockquote in the generated markdown when truncated. */
+  truncationNote?: string;
+}
+
+export interface WikiArticle {
+  title: string; // = path.basename(filePath, ext)
+  filePath: string; // absolute normalized — internal use only
+  articlePath: string; // absolute path of generated .md file — internal use only
+  hubScore: number; // 0–100 normalized
+  symbols: WikiSymbol[];
+  callers: WikiLink[]; // top 20
+  callees: WikiLink[]; // top 20
+  diagrams: MermaidDiagram[];
+}
+
+export interface WikiScopeOptions {
+  /** Relative path within workspace to restrict wiki to (e.g. "src/"). */
+  scope?: string;
+  /** Relative glob-like patterns to exclude (e.g. ["tests/**", "*.test.ts"]). */
+  exclude?: string[];
+}
+
+export interface WikiGeneratorOptions extends WikiScopeOptions {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  db: any; // sql.js Database — typed as any to avoid sql.js import in shared/
+  outputDir: string; // absolute
+  workspaceRoot: string; // absolute
+  topHubsLimit?: number; // default 10
+}
+
+export interface WikiGenerateResult {
+  articlesCount: number;
+  indexPath: string; // absolute — relativized by CLI/MCP before returning to caller
+  articlesDir: string; // absolute
+  topHubs: Array<{ name: string; score: number }>;
+  /** Human-readable scope / exclusion summary — included in generated index.md. */
+  scopeNote?: string;
+}

--- a/tests/analyzer/wiki/ControlFlowAnalyzer.test.ts
+++ b/tests/analyzer/wiki/ControlFlowAnalyzer.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { analyzeControlFlow } from "../../../src/analyzer/wiki/ControlFlowAnalyzer.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cfa-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeTmp(filename: string, content: string): string {
+  const filePath = path.join(tmpDir, filename);
+  fs.writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("analyzeControlFlow", () => {
+  it("returns empty array for a non-existent file", () => {
+    const result = analyzeControlFlow(path.join(tmpDir, "does-not-exist.ts"));
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for a file with no exported functions", () => {
+    const filePath = writeTmp("no-exports.ts", `
+function internal() {
+  if (true) { return 1; }
+}
+const x = 42;
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array for exported function with low complexity (< 2)", () => {
+    const filePath = writeTmp("simple.ts", `
+export function simple() {
+  return 42;
+}
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toEqual([]);
+  });
+
+  it("returns a control-flow diagram for exported function with if/else (complexity ≥ 2)", () => {
+    const filePath = writeTmp("with-if.ts", `
+export function doCheck(x: number): string {
+  if (x > 0) {
+    return "positive";
+  } else {
+    return "non-positive";
+  }
+}
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("control-flow");
+    expect(result[0].title).toContain("doCheck");
+    expect(result[0].mermaid).toContain("flowchart TD");
+    expect(result[0].mermaid).toContain("doCheck");
+  });
+
+  it("returns diagram containing switch node for function with switch statement", () => {
+    const filePath = writeTmp("with-switch.ts", `
+export function handleStatus(status: string): number {
+  switch (status) {
+    case "ok": return 200;
+    case "not-found": return 404;
+    case "error": return 500;
+    default: return 0;
+  }
+}
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toHaveLength(1);
+    expect(result[0].mermaid).toContain("switch");
+  });
+
+  it("shows ALL exported complex functions (no MAX_FUNCTIONS_PER_FILE limit)", () => {
+    // Write 5 exported functions all with complexity >= 2
+    const filePath = writeTmp("many-fns.ts", `
+export function fn1(x: number) { if (x) { return 1; } else { return 2; } }
+export function fn2(x: number) { if (x) { return 1; } else { return 2; } }
+export function fn3(x: number) { if (x) { return 1; } else { return 2; } }
+export function fn4(x: number) { if (x) { return 1; } else { return 2; } }
+export function fn5(x: number) { if (x) { return 1; } else { return 2; } }
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result.length).toBe(5);
+  });
+
+  it("does not set truncated for function count when all functions are shown", () => {
+    const filePath = writeTmp("many-complex.ts", `
+export function fn1(x: number) { if (x > 0) { return 1; } else { return 2; } }
+export function fn2(x: number) { if (x > 0) { return 1; } else { return 2; } }
+export function fn3(x: number) { if (x > 0) { return 1; } else { return 2; } }
+export function fn4(x: number) { if (x > 0) { return 1; } else { return 2; } }
+`);
+    const result = analyzeControlFlow(filePath);
+    // All 4 functions should be shown — no truncation note for function count
+    expect(result.length).toBe(4);
+    // None should have a "Showing X of Y" truncation note
+    for (const diagram of result) {
+      expect(diagram.truncationNote ?? "").not.toMatch(/Showing \d+ of \d+/);
+    }
+  });
+
+  it("handles exported arrow function with if/else", () => {
+    const filePath = writeTmp("arrow.ts", `
+export const compute = (n: number): string => {
+  if (n > 100) {
+    return "big";
+  } else {
+    return "small";
+  }
+};
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toContain("compute");
+  });
+
+  it("handles exported class method with if/else", () => {
+    const filePath = writeTmp("class.ts", `
+export class MyService {
+  process(value: number): string {
+    if (value > 0) {
+      return "positive";
+    } else {
+      return "negative";
+    }
+  }
+}
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toContain("MyService.process");
+  });
+
+  it("handles try/catch/finally in exported function", () => {
+    // try + catch + finally = complexity 2 (>= MIN_COMPLEXITY)
+    const filePath = writeTmp("try-catch.ts", `
+export function safeParse(json: string): unknown {
+  try {
+    return JSON.parse(json);
+  } catch (err) {
+    return null;
+  } finally {
+    console.log("done");
+  }
+}
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toHaveLength(1);
+    expect(result[0].mermaid).toContain("try");
+    expect(result[0].mermaid).toContain("catch");
+  });
+
+  it("diagram is not truncated for a function with moderate complexity", () => {
+    const filePath = writeTmp("moderate.ts", `
+export function moderate(x: number): number {
+  if (x > 0) {
+    return x * 2;
+  } else {
+    return x;
+  }
+}
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result).toHaveLength(1);
+    // truncated flag should be false for a small function
+    expect(result[0].truncated).toBe(false);
+  });
+
+  it("sorts functions by complexity descending — most complex first", () => {
+    // fn_low has if+else = complexity 2; fn_high has if+else+switch(4 cases) = complexity 6+
+    const filePath = writeTmp("sort-order.ts", `
+export function fn_low(x: number) {
+  if (x > 0) {
+    return 1;
+  } else {
+    return 0;
+  }
+}
+export function fn_high(x: number, y: string) {
+  if (x > 0) {
+    return 1;
+  } else {
+    switch (y) {
+      case "a": return 2;
+      case "b": return 3;
+      case "c": return 4;
+      default: return 0;
+    }
+  }
+}
+`);
+    const result = analyzeControlFlow(filePath);
+    expect(result.length).toBeGreaterThanOrEqual(2);
+    // The first result should be fn_high (higher complexity)
+    expect(result[0].title).toContain("fn_high");
+  });
+});

--- a/tests/analyzer/wiki/DiagramBuilder.test.ts
+++ b/tests/analyzer/wiki/DiagramBuilder.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDependencyDiagram,
+  buildCallerDiagram,
+  buildArchitectureDiagram,
+} from "../../../src/analyzer/wiki/DiagramBuilder.js";
+import type { WikiArticle, WikiLink } from "../../../src/shared/wiki-types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeLink(filePath: string, name = "fn"): WikiLink {
+  return { filePath, name, callSiteLine: 1 };
+}
+
+function makeArticle(overrides: Partial<WikiArticle> = {}): WikiArticle {
+  return {
+    title: "foo",
+    filePath: "/workspace/src/foo.ts",
+    articlePath: "/out/articles/foo.md",
+    hubScore: 10,
+    symbols: [],
+    callers: [],
+    callees: [],
+    diagrams: [],
+    ...overrides,
+  };
+}
+
+/** Simple display function: strips /workspace/ prefix */
+const display = (fp: string) => fp.replace("/workspace/", "");
+
+// ---------------------------------------------------------------------------
+// buildDependencyDiagram
+// ---------------------------------------------------------------------------
+
+describe("buildDependencyDiagram", () => {
+  it("returns null when callees is empty", () => {
+    const article = makeArticle({ callees: [] });
+    expect(buildDependencyDiagram(article, display)).toBeNull();
+  });
+
+  it("returns a diagram when callees are present", () => {
+    const article = makeArticle({
+      callees: [makeLink("/workspace/src/bar.ts")],
+    });
+    const result = buildDependencyDiagram(article, display);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("dependency");
+    expect(result!.title).toBe("External calls");
+    expect(result!.mermaid).toContain("flowchart LR");
+    expect(result!.mermaid).toContain("bar.ts");
+  });
+
+  it("filters out self-loops (callee.filePath === article.filePath)", () => {
+    const article = makeArticle({
+      callees: [makeLink("/workspace/src/foo.ts")], // same as article.filePath
+    });
+    // All callees are self — result should be null
+    expect(buildDependencyDiagram(article, display)).toBeNull();
+  });
+
+  it("deduplicates callees with same filePath — produces only one edge", () => {
+    const article = makeArticle({
+      callees: [
+        makeLink("/workspace/src/bar.ts", "fn1"),
+        makeLink("/workspace/src/bar.ts", "fn2"),
+      ],
+    });
+    const result = buildDependencyDiagram(article, display);
+    expect(result).not.toBeNull();
+    // Only one "-->" line for the deduplicated callee
+    const edges = result!.mermaid.split("\n").filter((l) => l.includes("-->"));
+    expect(edges).toHaveLength(1);
+  });
+
+  it("truncates when more than 50 callees", () => {
+    const callees: WikiLink[] = Array.from({ length: 55 }, (_, i) =>
+      makeLink(`/workspace/src/dep${i}.ts`),
+    );
+    const article = makeArticle({ callees });
+    const result = buildDependencyDiagram(article, display);
+    expect(result).not.toBeNull();
+    expect(result!.truncated).toBe(true);
+    expect(result!.truncationNote).toMatch(/50/);
+  });
+
+  it("is not truncated when exactly 50 callees", () => {
+    const callees: WikiLink[] = Array.from({ length: 50 }, (_, i) =>
+      makeLink(`/workspace/src/dep${i}.ts`),
+    );
+    const article = makeArticle({ callees });
+    const result = buildDependencyDiagram(article, display);
+    expect(result).not.toBeNull();
+    expect(result!.truncated).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCallerDiagram
+// ---------------------------------------------------------------------------
+
+describe("buildCallerDiagram", () => {
+  it("returns null when callers is empty", () => {
+    const article = makeArticle({ callers: [] });
+    expect(buildCallerDiagram(article, display)).toBeNull();
+  });
+
+  it("returns a diagram when callers are present", () => {
+    const article = makeArticle({
+      callers: [makeLink("/workspace/src/caller.ts")],
+    });
+    const result = buildCallerDiagram(article, display);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("caller");
+    expect(result!.title).toBe("Called by");
+    expect(result!.mermaid).toContain("flowchart LR");
+    expect(result!.mermaid).toContain("caller.ts");
+  });
+
+  it("filters out self-loop callers", () => {
+    const article = makeArticle({
+      callers: [makeLink("/workspace/src/foo.ts")], // self
+    });
+    expect(buildCallerDiagram(article, display)).toBeNull();
+  });
+
+  it("deduplicates callers with same filePath — produces only one edge", () => {
+    const article = makeArticle({
+      callers: [
+        makeLink("/workspace/src/caller.ts", "a"),
+        makeLink("/workspace/src/caller.ts", "b"),
+      ],
+    });
+    const result = buildCallerDiagram(article, display);
+    expect(result).not.toBeNull();
+    const edges = result!.mermaid.split("\n").filter((l) => l.includes("-->"));
+    expect(edges).toHaveLength(1);
+  });
+
+  it("edges point TO the article (callers --> self)", () => {
+    const article = makeArticle({
+      filePath: "/workspace/src/foo.ts",
+      callers: [makeLink("/workspace/src/caller.ts")],
+    });
+    const result = buildCallerDiagram(article, display);
+    expect(result).not.toBeNull();
+    // The edge must end with the article's node id, not start with it
+    const edgeLine = result!.mermaid.split("\n").find((l) => l.includes("-->"))!;
+    // caller node id comes first
+    const [left, right] = edgeLine.split("-->").map((s) => s.trim());
+    expect(left).toContain("caller");
+    expect(right).toContain("foo");
+  });
+
+  it("truncates when more than 50 callers", () => {
+    const callers: WikiLink[] = Array.from({ length: 60 }, (_, i) =>
+      makeLink(`/workspace/src/caller${i}.ts`),
+    );
+    const article = makeArticle({ callers });
+    const result = buildCallerDiagram(article, display);
+    expect(result).not.toBeNull();
+    expect(result!.truncated).toBe(true);
+    expect(result!.truncationNote).toMatch(/50/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildArchitectureDiagram
+// ---------------------------------------------------------------------------
+
+describe("buildArchitectureDiagram", () => {
+  it("returns null when articles array is empty", () => {
+    expect(buildArchitectureDiagram([], display)).toBeNull();
+  });
+
+  it("returns null when only one article (needs ≥2 hubs)", () => {
+    const articles = [makeArticle({ hubScore: 10 })];
+    expect(buildArchitectureDiagram(articles, display)).toBeNull();
+  });
+
+  it("returns a diagram when at least 2 hub articles exist", () => {
+    const articles = [
+      makeArticle({
+        filePath: "/workspace/src/hub1.ts",
+        hubScore: 20,
+        callees: [],
+      }),
+      makeArticle({
+        filePath: "/workspace/src/hub2.ts",
+        hubScore: 10,
+        callees: [],
+      }),
+    ];
+    const result = buildArchitectureDiagram(articles, display);
+    expect(result).not.toBeNull();
+    expect(result!.type).toBe("architecture");
+    expect(result!.mermaid).toContain("flowchart TD");
+    expect(result!.mermaid).toContain("hub1.ts");
+    expect(result!.mermaid).toContain("hub2.ts");
+  });
+
+  it("deduplicates edges between hub files", () => {
+    const hub2 = makeArticle({
+      filePath: "/workspace/src/hub2.ts",
+      hubScore: 10,
+      callees: [],
+    });
+    const hub1 = makeArticle({
+      filePath: "/workspace/src/hub1.ts",
+      hubScore: 20,
+      callees: [
+        makeLink("/workspace/src/hub2.ts"),
+        makeLink("/workspace/src/hub2.ts"), // duplicate
+      ],
+    });
+    const result = buildArchitectureDiagram([hub1, hub2], display);
+    expect(result).not.toBeNull();
+    const edges = result!.mermaid
+      .split("\n")
+      .filter((l) => /^\s+\w+ --> \w+$/.test(l));
+    // Only one edge hub1 → hub2, no duplicate
+    expect(edges).toHaveLength(1);
+  });
+
+  it("truncates when articles exceed limit", () => {
+    const articles: WikiArticle[] = Array.from({ length: 10 }, (_, i) =>
+      makeArticle({
+        filePath: `/workspace/src/file${i}.ts`,
+        hubScore: 10 - i,
+        callees: [],
+      }),
+    );
+    // limit to 3 → truncated because 10 > 3
+    const result = buildArchitectureDiagram(articles, display, 3);
+    expect(result).not.toBeNull();
+    expect(result!.truncated).toBe(true);
+    expect(result!.truncationNote).toMatch(/3/);
+  });
+
+  it("is not truncated when articles fit within limit", () => {
+    const articles = [
+      makeArticle({ filePath: "/workspace/src/a.ts", hubScore: 5, callees: [] }),
+      makeArticle({ filePath: "/workspace/src/b.ts", hubScore: 3, callees: [] }),
+    ];
+    const result = buildArchitectureDiagram(articles, display);
+    expect(result).not.toBeNull();
+    expect(result!.truncated).toBe(false);
+  });
+
+  it("respects MAX_ARCH_EDGES (40) limit on edges", () => {
+    // Create one big hub with 50 callees all pointing to other hubs
+    const targets: WikiArticle[] = Array.from({ length: 50 }, (_, i) =>
+      makeArticle({
+        filePath: `/workspace/src/dep${i}.ts`,
+        hubScore: 1,
+        callees: [],
+      }),
+    );
+    const hub = makeArticle({
+      filePath: "/workspace/src/hub.ts",
+      hubScore: 100,
+      callees: targets.map((t) => makeLink(t.filePath)),
+    });
+    const result = buildArchitectureDiagram([hub, ...targets], display);
+    expect(result).not.toBeNull();
+    const edges = result!.mermaid
+      .split("\n")
+      .filter((l) => /^\s+\w+ --> \w+$/.test(l));
+    expect(edges.length).toBeLessThanOrEqual(40);
+  });
+});

--- a/tests/analyzer/wiki/WikiGenerator.test.ts
+++ b/tests/analyzer/wiki/WikiGenerator.test.ts
@@ -142,6 +142,20 @@ describe("WikiGenerator", () => {
     expect(article.articlePath.startsWith(tmpDir)).toBe(true);
   });
 
+  it("escapes backslashes and pipes in rendered table cells", () => {
+    const workspaceRoot = "/workspace";
+    const db = makeDb({
+      fileIndex: ["/workspace/src/d.ts"],
+      nodes: [{ path: "/workspace/src/d.ts", name: String.raw`foo\bar|baz`, type: "function", start_line: 3 }],
+    });
+    const gen = new WikiGenerator({ db, outputDir: tmpDir, workspaceRoot });
+
+    const article = gen.buildArticle("/workspace/src/d.ts", 50);
+    const rendered = gen.renderArticle(article);
+
+    expect(rendered).toContain(String.raw`foo\\bar\|baz`);
+  });
+
   it("relLink produces relative paths only", async () => {
     const workspaceRoot = "/workspace";
     const db = makeDb({

--- a/tests/analyzer/wiki/WikiGenerator.test.ts
+++ b/tests/analyzer/wiki/WikiGenerator.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as os from "node:os";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { WikiGenerator } from "../../../src/analyzer/wiki/WikiGenerator.js";
+
+// ---------------------------------------------------------------------------
+// Minimal DB mock helpers
+// ---------------------------------------------------------------------------
+
+function makeDb(rows: {
+  fileIndex?: string[];
+  nodes?: Array<{ path: string; name: string; type: string; start_line: number }>;
+  edges?: Array<{ source_path: string; source_name: string; target_path: string; source_line: number }>;
+}) {
+  const fileIndex = rows.fileIndex ?? [];
+  const nodes = rows.nodes ?? [];
+  const edges = rows.edges ?? [];
+
+  return {
+    exec: vi.fn((sql: string) => {
+      if (sql.includes("FROM file_index")) {
+        return [{ columns: ["path"], values: fileIndex.map((p) => [p]) }];
+      }
+      if (sql.includes("COUNT(DISTINCT e.source_id)")) {
+        // hub score query
+        const hubMap = new Map<string, number>();
+        for (const e of edges) {
+          hubMap.set(e.target_path, (hubMap.get(e.target_path) ?? 0) + 1);
+        }
+        const result = [...hubMap.entries()].map(([p, h]) => [p, h]);
+        return [{ columns: ["path", "hub"], values: result }];
+      }
+      return [];
+    }),
+    prepare: vi.fn((sql: string) => {
+      let results: Array<Record<string, unknown>> = [];
+      if (sql.includes("FROM nodes WHERE path = ?")) {
+        results = nodes.map((n) => ({ name: n.name, type: n.type, start_line: n.start_line }));
+      } else if (sql.includes("n_tgt.path = ?")) {
+        // callers
+        results = edges.map((e) => ({
+          caller_path: e.source_path,
+          caller_name: e.source_name,
+          source_line: e.source_line,
+        }));
+      } else if (sql.includes("n_src.path = ?")) {
+        // callees
+        results = edges.map((e) => ({
+          callee_path: e.target_path,
+          callee_name: e.source_name,
+          source_line: e.source_line,
+        }));
+      }
+      let idx = 0;
+      return {
+        bind: vi.fn(),
+        step: vi.fn(() => idx < results.length),
+        getAsObject: vi.fn(() => results[idx++] ?? {}),
+        free: vi.fn(),
+      };
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WikiGenerator", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wiki-gen-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("generates index and article files", async () => {
+    const workspaceRoot = "/workspace";
+    const db = makeDb({
+      fileIndex: ["/workspace/src/foo.ts", "/workspace/src/bar.ts"],
+      nodes: [
+        { path: "/workspace/src/foo.ts", name: "fooFn", type: "function", start_line: 1 },
+      ],
+    });
+
+    const gen = new WikiGenerator({ db, outputDir: tmpDir, workspaceRoot });
+    const result = await gen.generate();
+
+    expect(result.articlesCount).toBe(2);
+
+    const indexContent = await fs.readFile(path.join(tmpDir, "index.md"), "utf-8");
+    expect(indexContent).toContain("# Wiki");
+    expect(indexContent).not.toMatch(/^.*\/workspace\/.*/m); // no absolute paths
+
+    const artDir = await fs.readdir(path.join(tmpDir, "articles"));
+    expect(artDir).toHaveLength(2);
+  });
+
+  it("renders article with no absolute paths", async () => {
+    const workspaceRoot = "/workspace";
+    const db = makeDb({
+      fileIndex: ["/workspace/src/a.ts", "/workspace/src/b.ts"],
+      nodes: [
+        { path: "/workspace/src/a.ts", name: "aFn", type: "function", start_line: 5 },
+      ],
+      edges: [
+        { source_path: "/workspace/src/b.ts", source_name: "bFn", target_path: "/workspace/src/a.ts", source_line: 10 },
+      ],
+    });
+
+    const gen = new WikiGenerator({ db, outputDir: tmpDir, workspaceRoot });
+    const result = await gen.generate();
+
+    // Read the article for a.ts
+    const articles = await fs.readdir(path.join(tmpDir, "articles"));
+    const aArticle = articles.find((f) => f.includes("src_a.ts") || f.includes("a.ts"));
+    expect(aArticle).toBeTruthy();
+
+    if (aArticle) {
+      const content = await fs.readFile(path.join(tmpDir, "articles", aArticle), "utf-8");
+      expect(content).not.toContain("/workspace");
+      expect(content).toContain("aFn");
+    }
+
+    expect(result.topHubs[0]?.score).toBeGreaterThan(0);
+  });
+
+  it("buildArticle produces correct structure", () => {
+    const workspaceRoot = "/workspace";
+    const db = makeDb({ fileIndex: ["/workspace/src/c.ts"] });
+    const gen = new WikiGenerator({ db, outputDir: tmpDir, workspaceRoot });
+
+    const article = gen.buildArticle("/workspace/src/c.ts", 75);
+    expect(article.hubScore).toBe(75);
+    expect(article.filePath).toBe("/workspace/src/c.ts");
+    expect(article.title).toBe("c");
+    expect(article.articlePath).not.toContain("/workspace");
+    expect(article.articlePath.startsWith(tmpDir)).toBe(true);
+  });
+
+  it("relLink produces relative paths only", async () => {
+    const workspaceRoot = "/workspace";
+    const db = makeDb({
+      fileIndex: ["/workspace/src/x.ts", "/workspace/lib/y.ts"],
+    });
+
+    const gen = new WikiGenerator({ db, outputDir: tmpDir, workspaceRoot });
+    const result = await gen.generate();
+
+    const indexContent = await fs.readFile(path.join(tmpDir, "index.md"), "utf-8");
+    const links = [...indexContent.matchAll(/\[.*?\]\((.*?)\)/g)].map((m) => m[1]);
+    for (const link of links) {
+      expect(link).not.toMatch(/^[A-Za-z]:\\|^\//); // not absolute
+    }
+
+    expect(result.articlesCount).toBe(2);
+  });
+
+  it("handles empty database gracefully", async () => {
+    const db = makeDb({});
+    const gen = new WikiGenerator({ db, outputDir: tmpDir, workspaceRoot: "/workspace" });
+    const result = await gen.generate();
+
+    expect(result.articlesCount).toBe(0);
+    expect(result.topHubs).toEqual([]);
+  });
+});

--- a/tests/analyzer/wiki/WikiIndexBuilder.test.ts
+++ b/tests/analyzer/wiki/WikiIndexBuilder.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { WikiIndexBuilder } from "../../../src/analyzer/wiki/WikiIndexBuilder.js";
+import type { WikiArticle } from "../../../src/shared/wiki-types.js";
+
+function makeArticle(title: string, hubScore: number, filePath = `/ws/${title}.ts`): WikiArticle {
+  return {
+    title,
+    filePath,
+    articlePath: `/out/articles/${title}.md`,
+    hubScore,
+    symbols: [],
+    callers: [],
+    callees: [],
+  };
+}
+
+describe("WikiIndexBuilder", () => {
+  it("buildIndex sorts by hubScore descending", () => {
+    const builder = new WikiIndexBuilder();
+    const articles = [
+      makeArticle("a", 10),
+      makeArticle("b", 90),
+      makeArticle("c", 50),
+    ];
+    const sorted = builder.buildIndex(articles);
+    expect(sorted.map((a) => a.hubScore)).toEqual([90, 50, 10]);
+  });
+
+  it("buildIndex does not mutate input", () => {
+    const builder = new WikiIndexBuilder();
+    const articles = [makeArticle("a", 10), makeArticle("b", 90)];
+    builder.buildIndex(articles);
+    expect(articles[0].title).toBe("a"); // original order preserved
+  });
+
+  it("topHubs returns top N by score", () => {
+    const builder = new WikiIndexBuilder();
+    const articles = [
+      makeArticle("a", 20),
+      makeArticle("b", 80),
+      makeArticle("c", 60),
+      makeArticle("d", 40),
+    ];
+    const top2 = builder.topHubs(articles, 2);
+    expect(top2).toHaveLength(2);
+    expect(top2[0].name).toBe("b");
+    expect(top2[0].score).toBe(80);
+    expect(top2[1].name).toBe("c");
+  });
+
+  it("topHubs defaults to 10", () => {
+    const builder = new WikiIndexBuilder();
+    const articles = Array.from({ length: 15 }, (_, i) => makeArticle(`f${i}`, i * 5));
+    const top = builder.topHubs(articles);
+    expect(top).toHaveLength(10);
+  });
+
+  it("topHubs handles empty list", () => {
+    const builder = new WikiIndexBuilder();
+    expect(builder.topHubs([])).toEqual([]);
+  });
+});

--- a/tests/cli/commands/wiki.test.ts
+++ b/tests/cli/commands/wiki.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Unit tests for the `graph-it wiki` CLI command.
+ * executeGenerateWiki is mocked — no DB or WikiGenerator runs.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoist mocks
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  executeGenerateWiki: vi.fn(),
+}));
+
+vi.mock("../../../src/mcp/tools/wiki.js", () => ({
+  executeGenerateWiki: mocks.executeGenerateWiki,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { run } from "../../../src/cli/commands/wiki.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE_ROOT = "/workspace";
+
+function makeRuntime(root = WORKSPACE_ROOT) {
+  return {
+    workspaceRoot: root,
+    ensureIndexed: vi.fn().mockResolvedValue(undefined),
+  } as never;
+}
+
+function makeWikiResult(overrides = {}) {
+  return {
+    articlesCount: 5,
+    indexPath: "wiki/index.md",
+    articlesDir: "wiki/articles",
+    topHubs: [
+      { name: "CallGraphIndexer.ts", score: 42 },
+      { name: "Spider.ts", score: 30 },
+    ],
+    scopeNote: undefined,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("wiki command", () => {
+  beforeEach(() => {
+    mocks.executeGenerateWiki.mockReset();
+    mocks.executeGenerateWiki.mockResolvedValue(makeWikiResult());
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. ensureIndexed is called
+  // -------------------------------------------------------------------------
+
+  it("calls runtime.ensureIndexed before generating wiki", async () => {
+    const runtime = makeRuntime();
+    await run([], runtime, "text");
+    expect(runtime.ensureIndexed).toHaveBeenCalledOnce();
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Default flag values
+  // -------------------------------------------------------------------------
+
+  it("uses default outputDir 'wiki' when --output is not provided", async () => {
+    await run([], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputDir: expect.stringContaining("wiki"),
+      }),
+    );
+  });
+
+  it("uses default topHubsLimit 10 when --top is not provided", async () => {
+    await run([], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ topHubsLimit: 10 }),
+    );
+  });
+
+  it("does not pass scope when --scope is not provided", async () => {
+    await run([], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: undefined }),
+    );
+  });
+
+  it("does not pass exclude when --exclude is not provided", async () => {
+    await run([], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ exclude: undefined }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Flag parsing
+  // -------------------------------------------------------------------------
+
+  it("parses --output flag", async () => {
+    await run(["--output", "out/wiki"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outputDir: expect.stringContaining("out/wiki"),
+      }),
+    );
+  });
+
+  it("parses --scope flag", async () => {
+    await run(["--scope", "src/analyzer"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "src/analyzer" }),
+    );
+  });
+
+  it("parses --exclude flag (single)", async () => {
+    await run(["--exclude", "tests/"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ exclude: ["tests/"] }),
+    );
+  });
+
+  it("parses multiple --exclude flags", async () => {
+    await run(["--exclude", "tests/", "--exclude", "dist/"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ exclude: ["tests/", "dist/"] }),
+    );
+  });
+
+  it("parses --top flag as integer", async () => {
+    await run(["--top", "5"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ topHubsLimit: 5 }),
+    );
+  });
+
+  it("clamps --top to default 10 when value is invalid", async () => {
+    await run(["--top", "abc"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ topHubsLimit: 10 }),
+    );
+  });
+
+  it("clamps --top to default 10 when value is 0", async () => {
+    await run(["--top", "0"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ topHubsLimit: 10 }),
+    );
+  });
+
+  it("clamps --top to default 10 when value exceeds 50", async () => {
+    await run(["--top", "99"], makeRuntime(), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({ topHubsLimit: 10 }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Output formats
+  // -------------------------------------------------------------------------
+
+  it("returns markdown output by default (text format)", async () => {
+    const output = await run([], makeRuntime(), "text");
+
+    expect(output).toContain("# Wiki generated");
+    expect(output).toContain("Articles");
+    expect(output).toContain("wiki/index.md");
+    expect(output).toContain("CallGraphIndexer.ts");
+  });
+
+  it("returns JSON output when --format json", async () => {
+    const output = await run(["--format", "json"], makeRuntime(), "text");
+
+    expect(() => JSON.parse(output)).not.toThrow();
+    const parsed = JSON.parse(output);
+    expect(parsed.articlesCount).toBe(5);
+    expect(parsed.indexPath).toBe("wiki/index.md");
+    expect(parsed.topHubs).toHaveLength(2);
+  });
+
+  it("returns JSON when top-level format is json (no --format flag)", async () => {
+    const output = await run([], makeRuntime(), "json");
+
+    expect(() => JSON.parse(output)).not.toThrow();
+    expect(JSON.parse(output).articlesCount).toBe(5);
+  });
+
+  it("returns toon output when --format toon", async () => {
+    const output = await run(["--format", "toon"], makeRuntime(), "text");
+
+    expect(output).toContain("wiki articles=5");
+    expect(output).toContain("index=wiki/index.md");
+    expect(output).toContain("dir=wiki/articles");
+    expect(output).toContain("CallGraphIndexer.ts(42)");
+  });
+
+  it("returns toon when top-level format is toon (no --format flag)", async () => {
+    const output = await run([], makeRuntime(), "toon");
+
+    expect(output).toContain("wiki articles=5");
+  });
+
+  it("--format flag overrides top-level format", async () => {
+    const output = await run(["--format", "markdown"], makeRuntime(), "json");
+
+    expect(output).toContain("# Wiki generated");
+    expect(() => JSON.parse(output)).toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. scopeNote in output
+  // -------------------------------------------------------------------------
+
+  it("includes scopeNote in markdown output when present", async () => {
+    mocks.executeGenerateWiki.mockResolvedValue(makeWikiResult({ scopeNote: "Scoped to src/" }));
+
+    const output = await run([], makeRuntime(), "text");
+
+    expect(output).toContain("Scoped to src/");
+  });
+
+  it("includes scopeNote in toon output when present", async () => {
+    mocks.executeGenerateWiki.mockResolvedValue(makeWikiResult({ scopeNote: "Scoped to src/" }));
+
+    const output = await run(["--format", "toon"], makeRuntime(), "text");
+
+    expect(output).toContain("scope: Scoped to src/");
+  });
+
+  it("does not include scopeNote line in markdown when absent", async () => {
+    const output = await run([], makeRuntime(), "text");
+
+    expect(output).not.toContain("Scope");
+  });
+
+  // -------------------------------------------------------------------------
+  // 6. workspaceRoot is passed correctly
+  // -------------------------------------------------------------------------
+
+  it("passes normalized workspaceRoot to executeGenerateWiki", async () => {
+    await run([], makeRuntime("/my/project"), "text");
+
+    expect(mocks.executeGenerateWiki).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceRoot: expect.stringContaining("my"),
+      }),
+    );
+  });
+});

--- a/tests/integration/BuildVerification.test.ts
+++ b/tests/integration/BuildVerification.test.ts
@@ -37,7 +37,7 @@ describe('Build Verification', () => {
       
       // Verify it's a valid WASM file (starts with WASM magic number)
       const buffer = fs.readFileSync(wasmPath);
-      const magicNumber = buffer.slice(0, 4);
+      const magicNumber = buffer.subarray(0, 4);
       expect(magicNumber.toString('hex')).toBe('0061736d'); // \0asm in hex
     });
 
@@ -47,7 +47,7 @@ describe('Build Verification', () => {
       
       // Verify it's a valid WASM file
       const buffer = fs.readFileSync(wasmPath);
-      const magicNumber = buffer.slice(0, 4);
+      const magicNumber = buffer.subarray(0, 4);
       expect(magicNumber.toString('hex')).toBe('0061736d');
     });
 
@@ -57,7 +57,7 @@ describe('Build Verification', () => {
       
       // Verify it's a valid WASM file
       const buffer = fs.readFileSync(wasmPath);
-      const magicNumber = buffer.slice(0, 4);
+      const magicNumber = buffer.subarray(0, 4);
       expect(magicNumber.toString('hex')).toBe('0061736d');
     });
 

--- a/tests/integration/BuildVerification.test.ts
+++ b/tests/integration/BuildVerification.test.ts
@@ -8,7 +8,7 @@
  * Requirements: 7.1, 7.2, 7.3
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
@@ -89,7 +89,7 @@ describe('Build Verification', () => {
     });
   });
 
-  describe('.vsix package WASM files', { timeout: 30_000 }, () => {
+  describe('.vsix package WASM files', { timeout: 60_000 }, () => {
     let vsixPath: string | null = null;
     let vsixContents: string[] = [];
 
@@ -119,16 +119,22 @@ describe('Build Verification', () => {
       // List contents of .vsix package using vsce
       // --no-dependencies skips @types/vscode vs engines.vscode version validation
       try {
-        const output = execSync('npx vsce ls --no-dependencies', {
-          cwd: workspaceRoot,
-          encoding: 'utf-8',
-        });
+        const output = execFileSync(
+          process.platform === 'win32' ? 'npx.cmd' : 'npx',
+          ['vsce', 'ls', '--no-dependencies'],
+          {
+            cwd: workspaceRoot,
+            encoding: 'utf-8',
+            timeout: 60_000,
+            stdio: ['ignore', 'pipe', 'pipe'],
+          }
+        );
         vsixContents = output.split('\n').map(line => line.trim()).filter(Boolean);
       } catch (error) {
         console.error('Failed to list .vsix contents:', error);
         throw error;
       }
-    });
+    }, 60_000);
 
     it('should include tree-sitter.wasm in package', () => {
       if (!vsixPath) {

--- a/tests/mcp/tools/wiki.test.ts
+++ b/tests/mcp/tools/wiki.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for the MCP wiki generation tool (executeGenerateWiki).
+ * Uses a mock CallGraphIndexer (no sql.js WASM) — WikiGenerator runs for real.
+ */
+
+import * as os from "node:os";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CallGraphIndexer } from "../../../src/analyzer/callgraph/CallGraphIndexer";
+import { workerState } from "../../../src/mcp/shared/state";
+import { executeGenerateWiki } from "../../../src/mcp/tools/wiki";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WORKSPACE = path.join(os.tmpdir(), "wiki-mcp-workspace");
+
+function makeMockDb() {
+  return {
+    exec: vi.fn().mockReturnValue([]),
+    prepare: vi.fn().mockReturnValue({
+      bind: vi.fn(),
+      step: vi.fn().mockReturnValue(false),
+      getAsObject: vi.fn().mockReturnValue({}),
+      free: vi.fn(),
+    }),
+  };
+}
+
+function makeMockIndexer(): CallGraphIndexer {
+  return {
+    getDb: vi.fn().mockReturnValue(makeMockDb()),
+    isReady: vi.fn().mockReturnValue(true),
+  } as unknown as CallGraphIndexer;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("executeGenerateWiki", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wiki-mcp-test-"));
+    vi.resetAllMocks();
+
+    workerState.callGraphIndexer = makeMockIndexer();
+    workerState.callGraphIndexedRoot = WORKSPACE;
+
+    vi.spyOn(workerState, "getConfig").mockReturnValue({
+      rootDir: WORKSPACE,
+      tsConfigPath: undefined,
+      excludeNodeModules: true,
+      maxDepth: 50,
+    } as unknown as ReturnType<typeof workerState.getConfig>);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+    workerState.callGraphIndexer = undefined as unknown as CallGraphIndexer;
+    workerState.callGraphIndexedRoot = undefined as unknown as string;
+  });
+
+  it("returns articlesCount 0 for empty db", async () => {
+    const result = await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+      topHubsLimit: 5,
+    });
+
+    expect(result.articlesCount).toBe(0);
+    expect(result.topHubs).toEqual([]);
+  });
+
+  it("creates index.md file", async () => {
+    await executeGenerateWiki({ workspaceRoot: WORKSPACE, outputDir: tmpDir });
+
+    const indexExists = await fs.stat(path.join(tmpDir, "index.md")).then(() => true).catch(() => false);
+    expect(indexExists).toBe(true);
+  });
+
+  it("indexPath and articlesDir do not contain absolute workspace path", async () => {
+    const result = await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+    });
+
+    expect(result.indexPath).not.toContain(WORKSPACE);
+    expect(result.articlesDir).not.toContain(WORKSPACE);
+  });
+
+  it("throws when callGraphIndexer not initialized", async () => {
+    workerState.callGraphIndexer = undefined as unknown as CallGraphIndexer;
+
+    await expect(
+      executeGenerateWiki({ workspaceRoot: WORKSPACE, outputDir: tmpDir }),
+    ).rejects.toThrow();
+  });
+
+  it("uses configured workspaceRoot when not provided", async () => {
+    const result = await executeGenerateWiki({ outputDir: tmpDir });
+
+    expect(result.articlesCount).toBeGreaterThanOrEqual(0);
+    expect(result.indexPath).toBeDefined();
+  });
+});

--- a/tests/mcp/tools/wiki.test.ts
+++ b/tests/mcp/tools/wiki.test.ts
@@ -1,15 +1,39 @@
 /**
  * Unit tests for the MCP wiki generation tool (executeGenerateWiki).
- * Uses a mock CallGraphIndexer (no sql.js WASM) — WikiGenerator runs for real.
+ * WikiGenerator is mocked via vi.mock so executeGenerateWiki runs for real.
  */
 
 import * as os from "node:os";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { CallGraphIndexer } from "../../../src/analyzer/callgraph/CallGraphIndexer";
-import { workerState } from "../../../src/mcp/shared/state";
-import { executeGenerateWiki } from "../../../src/mcp/tools/wiki";
+import type { CallGraphIndexer } from "../../../src/analyzer/callgraph/CallGraphIndexer.js";
+
+// ---------------------------------------------------------------------------
+// Hoist mocks — must run before any imports of the modules under test
+// ---------------------------------------------------------------------------
+
+const mockGenerate = vi.fn();
+
+const MockWikiGeneratorClass = vi.fn().mockImplementation(function () {
+  return { generate: mockGenerate };
+});
+
+vi.mock("../../../src/analyzer/wiki/WikiGenerator.js", () => ({
+  WikiGenerator: MockWikiGeneratorClass,
+}));
+
+// Mock dynamic import of callgraph used by ensureCallGraphReady
+vi.mock("../../../src/mcp/tools/callgraph.js", () => ({
+  executeQueryCallGraph: vi.fn().mockResolvedValue({}),
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { workerState } from "../../../src/mcp/shared/state.js";
+import { executeGenerateWiki } from "../../../src/mcp/tools/wiki.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,6 +60,20 @@ function makeMockIndexer(): CallGraphIndexer {
   } as unknown as CallGraphIndexer;
 }
 
+function makeGenerateResult(overrides = {}) {
+  return {
+    articlesCount: 5,
+    indexPath: path.join(WORKSPACE, "wiki", "index.md"),
+    articlesDir: path.join(WORKSPACE, "wiki", "articles"),
+    topHubs: [
+      { name: "CallGraphIndexer.ts", score: 42 },
+      { name: "Spider.ts", score: 30 },
+    ],
+    scopeNote: undefined,
+    ...overrides,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -45,8 +83,14 @@ describe("executeGenerateWiki", () => {
 
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "wiki-mcp-test-"));
-    vi.resetAllMocks();
 
+    // Default generate mock
+    mockGenerate.mockResolvedValue(makeGenerateResult({
+      indexPath: path.join(tmpDir, "index.md"),
+      articlesDir: path.join(tmpDir, "articles"),
+    }));
+
+    // Wire up workerState
     workerState.callGraphIndexer = makeMockIndexer();
     workerState.callGraphIndexedRoot = WORKSPACE;
 
@@ -60,51 +104,168 @@ describe("executeGenerateWiki", () => {
 
   afterEach(async () => {
     vi.restoreAllMocks();
+    mockGenerate.mockReset();
     await fs.rm(tmpDir, { recursive: true, force: true });
     workerState.callGraphIndexer = undefined as unknown as CallGraphIndexer;
     workerState.callGraphIndexedRoot = undefined as unknown as string;
   });
 
-  it("returns articlesCount 0 for empty db", async () => {
+  // -------------------------------------------------------------------------
+  // Basic shape
+  // -------------------------------------------------------------------------
+
+  it("returns articlesCount from WikiGenerator result", async () => {
     const result = await executeGenerateWiki({
       workspaceRoot: WORKSPACE,
       outputDir: tmpDir,
       topHubsLimit: 5,
     });
 
-    expect(result.articlesCount).toBe(0);
-    expect(result.topHubs).toEqual([]);
+    expect(result.articlesCount).toBe(5);
   });
 
-  it("creates index.md file", async () => {
-    await executeGenerateWiki({ workspaceRoot: WORKSPACE, outputDir: tmpDir });
+  it("returns topHubs array", async () => {
+    const result = await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+    });
 
-    const indexExists = await fs.stat(path.join(tmpDir, "index.md")).then(() => true).catch(() => false);
-    expect(indexExists).toBe(true);
+    expect(result.topHubs).toHaveLength(2);
+    expect(result.topHubs[0]).toMatchObject({ name: "CallGraphIndexer.ts", score: 42 });
   });
 
-  it("indexPath and articlesDir do not contain absolute workspace path", async () => {
+  // -------------------------------------------------------------------------
+  // Path relativization
+  // -------------------------------------------------------------------------
+
+  it("indexPath is relative to workspaceRoot", async () => {
     const result = await executeGenerateWiki({
       workspaceRoot: WORKSPACE,
       outputDir: tmpDir,
     });
 
     expect(result.indexPath).not.toContain(WORKSPACE);
-    expect(result.articlesDir).not.toContain(WORKSPACE);
+    expect(path.isAbsolute(result.indexPath)).toBe(false);
   });
 
-  it("throws when callGraphIndexer not initialized", async () => {
+  it("articlesDir is relative to workspaceRoot", async () => {
+    const result = await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+    });
+
+    expect(result.articlesDir).not.toContain(WORKSPACE);
+    expect(path.isAbsolute(result.articlesDir)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // scopeNote propagation
+  // -------------------------------------------------------------------------
+
+  it("propagates scopeNote when WikiGenerator returns one", async () => {
+    mockGenerate.mockResolvedValue(makeGenerateResult({
+      indexPath: path.join(tmpDir, "index.md"),
+      articlesDir: path.join(tmpDir, "articles"),
+      scopeNote: "Scoped to src/",
+    }));
+
+    const result = await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+      scope: "src/",
+    });
+
+    expect(result.scopeNote).toBe("Scoped to src/");
+  });
+
+  it("scopeNote is undefined when not returned", async () => {
+    const result = await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+    });
+
+    expect(result.scopeNote).toBeUndefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // WikiGenerator constructor args
+  // -------------------------------------------------------------------------
+
+  it("passes topHubsLimit to WikiGenerator", async () => {
+    const { WikiGenerator } = await import("../../../src/analyzer/wiki/WikiGenerator.js");
+    const WikiGeneratorMock = vi.mocked(WikiGenerator);
+    WikiGeneratorMock.mockClear();
+
+    await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+      topHubsLimit: 7,
+    });
+
+    expect(WikiGeneratorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ topHubsLimit: 7 }),
+    );
+  });
+
+  it("passes scope to WikiGenerator when provided", async () => {
+    const { WikiGenerator } = await import("../../../src/analyzer/wiki/WikiGenerator.js");
+    const WikiGeneratorMock = vi.mocked(WikiGenerator);
+    WikiGeneratorMock.mockClear();
+
+    await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+      scope: "src/analyzer",
+    });
+
+    expect(WikiGeneratorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "src/analyzer" }),
+    );
+  });
+
+  it("passes exclude array to WikiGenerator when provided", async () => {
+    const { WikiGenerator } = await import("../../../src/analyzer/wiki/WikiGenerator.js");
+    const WikiGeneratorMock = vi.mocked(WikiGenerator);
+    WikiGeneratorMock.mockClear();
+
+    await executeGenerateWiki({
+      workspaceRoot: WORKSPACE,
+      outputDir: tmpDir,
+      exclude: ["tests/", "dist/"],
+    });
+
+    expect(WikiGeneratorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ exclude: ["tests/", "dist/"] }),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Error: indexer not initialized
+  // -------------------------------------------------------------------------
+
+  it("throws when callGraphIndexer is not initialized", async () => {
     workerState.callGraphIndexer = undefined as unknown as CallGraphIndexer;
+    // Force callGraphIndexedRoot mismatch so ensureCallGraphReady tries to init
+    workerState.callGraphIndexedRoot = undefined as unknown as string;
 
     await expect(
       executeGenerateWiki({ workspaceRoot: WORKSPACE, outputDir: tmpDir }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(/not initialized/i);
   });
 
-  it("uses configured workspaceRoot when not provided", async () => {
-    const result = await executeGenerateWiki({ outputDir: tmpDir });
+  // -------------------------------------------------------------------------
+  // workspaceRoot fallback from config
+  // -------------------------------------------------------------------------
 
-    expect(result.articlesCount).toBeGreaterThanOrEqual(0);
-    expect(result.indexPath).toBeDefined();
+  it("uses config.rootDir when workspaceRoot is not provided", async () => {
+    const { WikiGenerator } = await import("../../../src/analyzer/wiki/WikiGenerator.js");
+    const WikiGeneratorMock = vi.mocked(WikiGenerator);
+    WikiGeneratorMock.mockClear();
+
+    await executeGenerateWiki({ outputDir: tmpDir });
+
+    expect(WikiGeneratorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceRoot: expect.stringContaining("wiki-mcp-workspace") }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Adds `graph-it wiki` CLI command, `/wiki` REPL slash command, and `graphitlive_generate_wiki` MCP tool
- **WikiGenerator** (`src/analyzer/wiki/`): reads call graph SQLite DB, applies scope/exclude filtering, writes per-file Markdown articles with hub scores
- **DiagramBuilder**: four Mermaid diagram types — *External calls* (up to 50 nodes, deduplicated), *Called by* (all files), *Architecture overview* (index), *Control flow* per function
- **ControlFlowAnalyzer**: TypeScript AST (`ts.createSourceFile`) → `flowchart TD` for every exported function with complexity ≥ 2; covers if/else, switch/case, try/catch, loops
- Constraint: zero absolute paths in generated Markdown (all links relative to workspaceRoot)
- Truncation limits and scope notes rendered as `> ⚠️` / `> ℹ️` blockquotes in articles

## Notable fixes

- `sanitize()`: strips `"`, `&&`→`and`, `&`→`and`, `|`→`or`, `\n`/`\r` in Mermaid condition text
- `mermaidLabel()`: strips `\n`/`\r` from node labels
- Markdown table cells: `|` in symbol/caller names escaped as `\|`
- `.gitignore`: anchor `/wiki/` to root (was silently ignoring `src/analyzer/wiki/`)
- Architecture + dep + caller diagrams: deduplicated edges, self-loops filtered

## Test plan

- [ ] `npx vitest run tests/analyzer/wiki/ tests/mcp/tools/wiki.test.ts tests/cli/commands/wiki.test.ts` → 75 pass
- [ ] `node dist/graph-it.js wiki --scope src/ --output wiki/` → 179 articles, no Mermaid parse errors
- [ ] Verify `wiki/index.md` architecture diagram renders in VS Code Mermaid preview
- [ ] Verify a complex file article (e.g. `CallGraphIndexer.ts`) shows External calls, Called by, and control-flow diagrams
- [ ] MCP: `graphitlive_generate_wiki` returns relative `indexPath` and `articlesDir`