### PR TITLE
feat: Typescript ignore type imports setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1859,6 +1859,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1876,6 +1879,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1893,6 +1899,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1910,6 +1919,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1927,6 +1939,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1944,6 +1959,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1859,9 +1859,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1879,9 +1876,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1899,9 +1893,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1919,9 +1910,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1939,9 +1927,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1959,9 +1944,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -943,6 +943,11 @@
           "default": true,
           "description": "Exclude node_modules from graph"
         },
+        "graph-it-live.ignoreTypeImports": {
+          "type": "boolean",
+          "default": false,
+          "description": "Ignore TypeScript type-only imports and exports in the dependency graph. You might need to restart VS Code for this setting to take effect."
+        },
         "graph-it-live.enableMcpServer": {
           "type": "boolean",
           "default": false,

--- a/src/analyzer/IndexerWorker.ts
+++ b/src/analyzer/IndexerWorker.ts
@@ -62,6 +62,8 @@ interface WorkerConfig {
    * Example: context.extensionPath from VS Code extension activation
    */
   extensionPath?: string;
+  /** When true, type-only imports/exports are not treated as file dependencies. */
+  ignoreTypeImports?: boolean;
 }
 
 interface WorkerMessage {
@@ -218,6 +220,7 @@ async function runIndexing(config: WorkerConfig): Promise<void> {
       config.rootDir,
       config.tsConfigPath,
       config.extensionPath,
+      config.ignoreTypeImports,
     );
 
     // Phase 1: Count files without loading paths into memory

--- a/src/analyzer/IndexerWorkerHost.ts
+++ b/src/analyzer/IndexerWorkerHost.ts
@@ -15,6 +15,7 @@ interface WorkerConfig {
   excludeNodeModules?: boolean;
   tsConfigPath?: string;
   extensionPath?: string;
+  ignoreTypeImports?: boolean;
   /**
    * Maximum ms to wait for indexing before forcefully terminating the worker.
    * Protects against hangs due to WASM initialization failures or silent crashes.

--- a/src/analyzer/LanguageService.ts
+++ b/src/analyzer/LanguageService.ts
@@ -41,10 +41,12 @@ export class LanguageService {
 
   private readonly rootDir?: string;
   private readonly extensionPath?: string;
+  private readonly ignoreTypeImports?: boolean;
 
-  constructor(rootDir?: string, _tsConfigPath?: string, extensionPath?: string) {
+  constructor(rootDir?: string, _tsConfigPath?: string, extensionPath?: string, ignoreTypeImports?: boolean) {
     this.rootDir = rootDir;
     this.extensionPath = extensionPath;
+    this.ignoreTypeImports = ignoreTypeImports;
   }
 
   /**
@@ -52,7 +54,7 @@ export class LanguageService {
    */
   getAnalyzer(filePath: string): ILanguageAnalyzer {
     const actualPath = extractFilePath(filePath);
-    return LanguageService.getAnalyzer(actualPath, this.rootDir, this.extensionPath);
+    return LanguageService.getAnalyzer(actualPath, this.rootDir, this.extensionPath, this.ignoreTypeImports);
   }
 
   /**
@@ -111,18 +113,18 @@ export class LanguageService {
    * Get the appropriate parser for the given file path.
    * Lazy-loads parsers only when needed.
    */
-  static getAnalyzer(filePath: string, rootDir?: string, extensionPath?: string): ILanguageAnalyzer {
+  static getAnalyzer(filePath: string, rootDir?: string, extensionPath?: string, ignoreTypeImports?: boolean): ILanguageAnalyzer {
     const actualPath = extractFilePath(filePath);
     const language = this.detectLanguage(actualPath);
 
     switch (language) {
       case Language.TypeScript: {
-        const cacheKey = this.buildCacheKey(rootDir);
+        const cacheKey = this.buildCacheKey(rootDir, ignoreTypeImports ? "ignore-types" : "");
         const cached = this.typeScriptParsers.get(cacheKey);
         if (cached) {
           return cached;
         }
-        const created = new Parser(rootDir);
+        const created = new Parser(rootDir, ignoreTypeImports);
         this.typeScriptParsers.set(cacheKey, created);
         return created;
       }

--- a/src/analyzer/Parser.ts
+++ b/src/analyzer/Parser.ts
@@ -180,8 +180,23 @@ export class Parser implements ILanguageAnalyzer {
       // Skip type-only imports if configured to ignore them
       if (this.ignoreTypeImports) {
         const fullMatch = match[0].trim();
-        if (fullMatch.startsWith("import type") || fullMatch.startsWith("export type")) {
+
+        // `import type ...` / `export type ...`
+        if (/^(import|export)\s+type\b/.test(fullMatch)) {
           continue;
+        }
+
+        // TS 5+ type-only named imports/exports: `import { type Foo } from '...'`
+        const braceMatch = fullMatch.match(/^(import|export)\s+\{([\s\S]*?)\}\s+from\b/);
+        if (braceMatch) {
+          const specifiers = braceMatch[2]
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+
+          if (specifiers.length > 0 && specifiers.every((s) => /^type\b/.test(s))) {
+            continue;
+          }
         }
       }
 

--- a/src/analyzer/Parser.ts
+++ b/src/analyzer/Parser.ts
@@ -24,9 +24,11 @@ export class Parser implements ILanguageAnalyzer {
       "g",
     );
   })();
-  constructor(rootDir?: string) {
+  private readonly ignoreTypeImports: boolean;
+  constructor(rootDir?: string, ignoreTypeImports?: boolean) {
     this.fileReader = new FileReader();
     this.pathResolver = new PathResolver(rootDir);
+    this.ignoreTypeImports = ignoreTypeImports ?? false;
   }
   // Regex patterns for different import types
   private readonly patterns = {
@@ -173,6 +175,14 @@ export class Parser implements ILanguageAnalyzer {
       // Skip if already processed
       if (seen.has(module)) {
         continue;
+      }
+
+      // Skip type-only imports if configured to ignore them
+      if (this.ignoreTypeImports) {
+        const fullMatch = match[0].trim();
+        if (fullMatch.startsWith("import type") || fullMatch.startsWith("export type")) {
+          continue;
+        }
       }
 
       seen.add(module);

--- a/src/analyzer/SpiderBuilder.ts
+++ b/src/analyzer/SpiderBuilder.ts
@@ -276,6 +276,7 @@ export class SpiderBuilder {
   private maxSymbolCacheSize: number = 200;
   private maxSymbolAnalyzerFiles: number = 100;
   private indexingProgressInterval?: number;
+  private ignoreTypeImports: boolean = false;
 
   // Service overrides (for testing)
   private customCache?: Cache<Dependency[]>;
@@ -390,6 +391,17 @@ export class SpiderBuilder {
    */
   withExcludeNodeModules(exclude: boolean): this {
     this.excludeNodeModules = exclude;
+    return this;
+  }
+
+  /**
+   * Set whether to ignore type-only imports and exports when parsing dependencies (default: false).
+   * 
+   * @param ignore - Whether to ignore type-only imports/exports
+   * @returns This builder instance for method chaining
+   */
+  withIgnoreTypeImports(ignore: boolean): this {
+    this.ignoreTypeImports = ignore;
     return this;
   }
 
@@ -558,6 +570,9 @@ export class SpiderBuilder {
     }
     if (config.excludeNodeModules !== undefined) {
       this.excludeNodeModules = config.excludeNodeModules;
+    }
+    if (config.ignoreTypeImports !== undefined) {
+      this.ignoreTypeImports = config.ignoreTypeImports;
     }
     if (config.enableReverseIndex !== undefined) {
       this.enableReverseIndex = config.enableReverseIndex;
@@ -781,7 +796,7 @@ export class SpiderBuilder {
 
     // Phase 1: Core services (no dependencies)
     const languageService = this.customLanguageService ?? 
-      new LanguageService(this.rootDir!, this.tsConfigPath, this.extensionPath);
+      new LanguageService(this.rootDir!, this.tsConfigPath, this.extensionPath, this.ignoreTypeImports);
     
     const resolver = this.customPathResolver ?? 
       new PathResolver(this.tsConfigPath, this.excludeNodeModules, this.rootDir!);
@@ -946,6 +961,7 @@ export class SpiderBuilder {
       extensionPath: this.extensionPath,
       maxDepth: this.maxDepth,
       excludeNodeModules: this.excludeNodeModules,
+      ignoreTypeImports: this.ignoreTypeImports,
       enableReverseIndex: this.enableReverseIndex,
       indexingConcurrency: this.indexingConcurrency,
       maxCacheSize: this.maxCacheSize,

--- a/src/analyzer/spider/SpiderIndexingService.ts
+++ b/src/analyzer/spider/SpiderIndexingService.ts
@@ -155,6 +155,7 @@ export class SpiderIndexingService {
         tsConfigPath: config.tsConfigPath,
         progressInterval: config.indexingProgressInterval,
         extensionPath: config.extensionPath,
+        ignoreTypeImports: config.ignoreTypeImports,
       },
     });
   }

--- a/src/analyzer/spider/SpiderWorkerManager.ts
+++ b/src/analyzer/spider/SpiderWorkerManager.ts
@@ -12,6 +12,7 @@ interface WorkerBuildOptions {
     tsConfigPath?: string;
     progressInterval?: number;
     extensionPath?: string;
+    ignoreTypeImports?: boolean;
   };
   progressCallback?: IndexingProgressCallback;
 }
@@ -74,6 +75,7 @@ export class SpiderWorkerManager {
         excludeNodeModules: config.excludeNodeModules,
         tsConfigPath: config.tsConfigPath,
         extensionPath: config.extensionPath,
+        ignoreTypeImports: config.ignoreTypeImports,
       });
 
       this.importWorkerResult(result);

--- a/src/analyzer/types.ts
+++ b/src/analyzer/types.ts
@@ -158,6 +158,8 @@ export interface SpiderConfig {
   extensionPath?: string;
   maxDepth?: number;
   excludeNodeModules?: boolean;
+  /** Ignore type-only imports/exports on TypeScript files */
+  ignoreTypeImports?: boolean;
   /** Interval for worker progress reporting (defaults to 100 files) */
   indexingProgressInterval?: number;
   /** Enable reverse index for O(1) reverse dependency lookups */

--- a/src/analyzer/wiki/WikiGenerator.ts
+++ b/src/analyzer/wiki/WikiGenerator.ts
@@ -140,7 +140,6 @@ export class WikiGenerator {
   private readonly externalNodeMetadata: Record<string, GraphNodeMetadata> | undefined;
 
   constructor(opts: WikiGeneratorOptions) {
-     
     this.db = opts.db;
     this.outputDir = opts.outputDir;
     this.workspaceRoot = opts.workspaceRoot;

--- a/src/extension/services/ProviderStateManager.ts
+++ b/src/extension/services/ProviderStateManager.ts
@@ -9,6 +9,7 @@ export interface ProviderConfigSnapshot extends BackgroundIndexingConfig {
   excludeNodeModules: boolean;
   maxDepth: number;
   indexingConcurrency: number;
+  ignoreTypeImports: boolean;
   unusedDependencyMode: UnusedDependencyMode;
   unusedAnalysisConcurrency: number;
   unusedAnalysisMaxEdges: number;
@@ -56,6 +57,7 @@ export class ProviderStateManager {
         : profileDefaults.indexingConcurrency,
       indexingStartDelay: config.get<number>('indexingStartDelay', this.defaultIndexingDelay),
       persistIndex: config.get<boolean>('persistIndex', false),
+      ignoreTypeImports: config.get<boolean>('ignoreTypeImports', false),
       unusedDependencyMode: config.get<'none' | 'hide' | 'dim'>('unusedDependencyMode', 'none'),
       unusedAnalysisConcurrency: isCustomProfile
         ? config.get<number>('unusedAnalysisConcurrency', profileDefaults.unusedAnalysisConcurrency)

--- a/src/extension/services/graphProviderServiceContainer.ts
+++ b/src/extension/services/graphProviderServiceContainer.ts
@@ -140,6 +140,7 @@ export function createGraphProviderServiceContainer(
         .withTsConfigPath(path.join(workspaceRoot, "tsconfig.json"))
         .withExtensionPath(options.context.extensionPath)
         .withExcludeNodeModules(configSnapshot.excludeNodeModules)
+        .withIgnoreTypeImports(configSnapshot.ignoreTypeImports)
         .withMaxDepth(configSnapshot.maxDepth)
         .withReverseIndex(configSnapshot.enableBackgroundIndexing)
         .withIndexingConcurrency(configSnapshot.indexingConcurrency)

--- a/tests/analyzer/LanguageService.test.ts
+++ b/tests/analyzer/LanguageService.test.ts
@@ -194,6 +194,25 @@ describe("LanguageService", () => {
       expect(analyzer1).toBe(analyzer2);
     });
 
+    it("should use a separate TypeScript parser when ignoreTypeImports changes", () => {
+      const analyzer1 = LanguageService.getAnalyzer("/project/file1.ts");
+      const analyzer2 = LanguageService.getAnalyzer(
+        "/project/file2.ts",
+        undefined,
+        undefined,
+        true,
+      );
+      const analyzer3 = LanguageService.getAnalyzer(
+        "/project/file3.ts",
+        undefined,
+        undefined,
+        true,
+      );
+
+      expect(analyzer1).not.toBe(analyzer2);
+      expect(analyzer2).toBe(analyzer3);
+    });
+
     it("should throw error for Python files (not yet implemented)", () => {
       const analyzer = LanguageService.getAnalyzer("/project/main.py");
       expect(analyzer).toBeDefined();

--- a/tests/analyzer/SpiderBuilder.test.ts
+++ b/tests/analyzer/SpiderBuilder.test.ts
@@ -18,11 +18,12 @@ describe('SpiderBuilder', () => {
       const result1 = builder.withRootDir(fixturesPath);
       const result2 = result1.withMaxDepth(50);
       const result3 = result2.withExcludeNodeModules(true);
-      const result4 = result3.withReverseIndex(false);
-      const result5 = result4.withIndexingConcurrency(4);
-      const result6 = result5.withCacheConfig({ maxCacheSize: 500 });
-      const result7 = result6.withTsConfigPath(path.join(fixturesPath, 'tsconfig.json'));
-      const result8 = result7.withIndexingProgressInterval(100);
+      const result4 = result3.withIgnoreTypeImports(true);
+      const result5 = result4.withReverseIndex(false);
+      const result6 = result5.withIndexingConcurrency(4);
+      const result7 = result6.withCacheConfig({ maxCacheSize: 500 });
+      const result8 = result7.withTsConfigPath(path.join(fixturesPath, 'tsconfig.json'));
+      const result9 = result8.withIndexingProgressInterval(100);
       
       // All methods should return the same builder instance
       expect(result1).toBe(builder);
@@ -33,6 +34,7 @@ describe('SpiderBuilder', () => {
       expect(result6).toBe(builder);
       expect(result7).toBe(builder);
       expect(result8).toBe(builder);
+      expect(result9).toBe(builder);
     });
 
     it('should support method chaining in a single expression', () => {
@@ -277,6 +279,7 @@ describe('SpiderBuilder', () => {
         tsConfigPath: path.join(fixturesPath, 'tsconfig.json'),
         maxDepth: 30,
         excludeNodeModules: false,
+        ignoreTypeImports: true,
         enableReverseIndex: true,
         indexingConcurrency: 8,
         maxCacheSize: 1000,

--- a/tests/analyzer/parser-type-imports.test.ts
+++ b/tests/analyzer/parser-type-imports.test.ts
@@ -38,4 +38,38 @@ export { Quux } from './quux';
       './quux',
     ]);
   });
+
+  it('should skip TS 5+ per-specifier type-only imports when configured', () => {
+    const parser = new Parser(undefined, true);
+
+    const content = `
+import { type Foo } from './foo';
+import { type Bar, type Baz } from './types';
+import { Quux } from './quux';
+export { type Corge } from './corge';
+`;
+
+    const imports = parser.parse(content, '/project/file.ts');
+
+    expect(imports).toHaveLength(1);
+    expect(imports.map((entry) => entry.module)).toEqual(['./quux']);
+  });
+
+  it('should NOT skip mixed imports (type + value specifiers) when configured', () => {
+    const parser = new Parser(undefined, true);
+
+    const content = `
+import { type Foo, Bar } from './mixed';
+import { type Baz, type Qux } from './types-only';
+import { Value } from './value';
+`;
+
+    const imports = parser.parse(content, '/project/file.ts');
+
+    // './mixed' has a value specifier (Bar) → must be kept
+    // './types-only' has only type specifiers → skipped
+    // './value' is a value import → kept
+    expect(imports).toHaveLength(2);
+    expect(imports.map((entry) => entry.module)).toEqual(['./mixed', './value']);
+  });
 });

--- a/tests/analyzer/parser-type-imports.test.ts
+++ b/tests/analyzer/parser-type-imports.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { Parser } from '../../src/analyzer/Parser';
+
+describe('Parser - Type-Only Imports', () => {
+  it('should skip type-only imports and exports when configured', () => {
+    const parser = new Parser(undefined, true);
+
+    const content = `
+import type { Foo } from './foo';
+import { Bar } from './bar';
+export type { Baz } from './baz';
+export { Quux } from './quux';
+`;
+
+    const imports = parser.parse(content, '/project/file.ts');
+
+    expect(imports).toHaveLength(2);
+    expect(imports.map((entry) => entry.module)).toEqual(['./bar', './quux']);
+  });
+
+  it('should keep type-only imports and exports when not configured to ignore them', () => {
+    const parser = new Parser();
+
+    const content = `
+import type { Foo } from './foo';
+import { Bar } from './bar';
+export type { Baz } from './baz';
+export { Quux } from './quux';
+`;
+
+    const imports = parser.parse(content, '/project/file.ts');
+
+    expect(imports).toHaveLength(4);
+    expect(imports.map((entry) => entry.module)).toEqual([
+      './foo',
+      './bar',
+      './baz',
+      './quux',
+    ]);
+  });
+});

--- a/tests/extension/ProviderStateManager.test.ts
+++ b/tests/extension/ProviderStateManager.test.ts
@@ -8,6 +8,7 @@ const configValues: Record<string, unknown> = {
   indexingConcurrency: 8,
   indexingStartDelay: 2000,
   persistIndex: true,
+  ignoreTypeImports: true,
 };
 
 vi.mock('vscode', () => ({
@@ -51,6 +52,7 @@ describe('ProviderStateManager', () => {
     expect(snapshot.maxDepth).toBe(25);
     expect(snapshot.enableBackgroundIndexing).toBe(true);
     expect(snapshot.indexingStartDelay).toBe(2000);
+    expect(snapshot.ignoreTypeImports).toBe(true);
   });
 
   it('tracks current symbol path', () => {


### PR DESCRIPTION
## Summary
React and Typescript developer here. I use this extension on my projects to check and fix circular dependencies in my codebase. Sometimes i just want to import a type, thing that many bundlers like vite ignore. I don't want a "cycle" error to show up in that cases. This feature adds a new boolean configuration item (`graph-it-live.ignoreTypeImports`) that defaults to false. When toggled on, type imports and exports are completely ignored on the graph, giving a cleaner view which closer to what bundlers see when packaging.

## Type of change
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Build/packaging
- [ ] Documentation
- [ ] Tests

## Validation evidence
Every test passed.
**The only error I'm getting:**
```bash
⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯ Failed Suites 1 ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯

 FAIL  tests/integration/BuildVerification.test.ts > Build Verification > .vsix package WASM files
Error: spawnSync npx.cmd EINVAL
 ❯ tests/integration/BuildVerification.test.ts:122:24
    120|       // --no-dependencies skips @types/vscode vs engines.vscode …
    121|       try {
    122|         const output = execFileSync(
       |                        ^
    123|           process.platform === 'win32' ? 'npx.cmd' : 'npx',
    124|           ['vsce', 'ls', '--no-dependencies'],

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/1]⎯
```
> I think it is related with Windows rather than the implementation of the feature.


### Quality
- [x] `npm run lint`
- [x] `npm run check:types`
- [x] `npm test` (Only 1 error: related with windows, it existed with a clean clone)
- [x] Sonar clean on modified files (no new issues)

### VSIX / Packaging (required when build config or deps changed)
- [x] `npm run package:verify` → `✅ No .map files in package`
- [ ] `npx vsce ls graph-it-live-*.vsix | grep "\.wasm$"` shows required WASM files (windows doesnt have grep command, I couldn't test it)
- [x] `ls -lh graph-it-live-*.vsix` size checked (target ≤ 16 MB, warn above)

### E2E
- [x] `npm run test:vscode:vsix` (required for user-facing changes)

## Checklist
- [x] Tests added/updated for changed behavior
- [ ] Docs updated (if needed)
- [ ] Cross-platform impact considered (Windows/Linux/macOS)
- [x] No `vscode` import added under `src/analyzer/**` or `src/mcp/**`

## Note
Sometimes, i need to restart the extension for the changes to apply. It also happens to me with the exclude node modules setting.
