### PR TITLE
Fix/issue 122 cluster disappear referencing file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,10 +50,10 @@
         "fast-check": "^4.9.0",
         "glob": "^13.0.6",
         "globals": "^17.7.0",
-        "happy-dom": "^20.10.6",
+        "happy-dom": "^20.11.0",
         "mocha": "^11.7.6",
         "typescript": "^6.0.3",
-        "typescript-eslint": "^8.64.0",
+        "typescript-eslint": "^8.65.0",
         "vitest": "^4.1.10"
       },
       "engines": {
@@ -2804,17 +2804,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.64.0.tgz",
-      "integrity": "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/type-utils": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2827,7 +2827,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.64.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2843,16 +2843,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.64.0.tgz",
-      "integrity": "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2868,14 +2868,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.64.0.tgz",
-      "integrity": "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.64.0",
-        "@typescript-eslint/types": "^8.64.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2890,14 +2890,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.64.0.tgz",
-      "integrity": "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2908,9 +2908,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.64.0.tgz",
-      "integrity": "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2925,15 +2925,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.64.0.tgz",
-      "integrity": "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2950,9 +2950,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.64.0.tgz",
-      "integrity": "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2964,16 +2964,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.64.0.tgz",
-      "integrity": "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.64.0",
-        "@typescript-eslint/tsconfig-utils": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/visitor-keys": "8.64.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2992,16 +2992,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.64.0.tgz",
-      "integrity": "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.64.0",
-        "@typescript-eslint/types": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3016,13 +3016,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.64.0.tgz",
-      "integrity": "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.64.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5853,9 +5853,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.10.6",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
-      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "version": "20.11.0",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.0.tgz",
+      "integrity": "sha512-XogN4asPd1a56di9prVG6bZxteNcXsZxxKmAvcEfc5Px5Ca2hMyMgk8wvqK2K1V8zXg40j9VANXsDaJYh9DeNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9943,16 +9943,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.64.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.64.0.tgz",
-      "integrity": "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.64.0",
-        "@typescript-eslint/parser": "8.64.0",
-        "@typescript-eslint/typescript-estree": "8.64.0",
-        "@typescript-eslint/utils": "8.64.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3703,21 +3703,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3757,9 +3770,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6650,9 +6663,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -9084,9 +9097,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9903,17 +9916,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typed-rest-client": {

--- a/package.json
+++ b/package.json
@@ -1174,10 +1174,10 @@
     "fast-check": "^4.9.0",
     "glob": "^13.0.6",
     "globals": "^17.7.0",
-    "happy-dom": "^20.10.6",
+    "happy-dom": "^20.11.0",
     "mocha": "^11.7.6",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.64.0",
+    "typescript-eslint": "^8.65.0",
     "vitest": "^4.1.10"
   },
   "overrides": {

--- a/src/extension/GraphProvider.ts
+++ b/src/extension/GraphProvider.ts
@@ -468,13 +468,13 @@ export class GraphProvider implements vscode.WebviewViewProvider {
   /**
    * Handle findReferencingFiles message
    */
-  private async handleFindReferencingFiles(nodeId: string): Promise<void> {
+  private async handleFindReferencingFiles(nodeId: string, knownNodes?: string[]): Promise<void> {
     if (!this.nodeInteractionService || !this._view) {
       return;
     }
     try {
       const result =
-        await this.nodeInteractionService.getReferencingFiles(nodeId);
+        await this.nodeInteractionService.getReferencingFiles(nodeId, knownNodes);
       this._view.webview.postMessage(result);
     } catch (e) {
       log.error("Error finding referencing files:", e);

--- a/src/extension/services/MessageDispatcher.ts
+++ b/src/extension/services/MessageDispatcher.ts
@@ -18,7 +18,7 @@ interface MessageDispatcherDependencies {
   handleOpenFile(filePath: string, line?: number): Promise<void>;
   handleExpandNode(nodeId: string, knownNodes?: string[]): Promise<void>;
   handleCancelExpandNode(nodeId?: string): Promise<void>;
-  handleFindReferencingFiles(nodeId: string): Promise<void>;
+  handleFindReferencingFiles(nodeId: string, knownNodes?: string[]): Promise<void>;
   handleDrillDown(filePath: string): Promise<void>;
   updateGraph(): Promise<void>;
   refreshGraph(): Promise<void>;
@@ -60,7 +60,7 @@ export class MessageDispatcher {
           await deps.refreshGraph();
         },
         findReferencingFiles: async (m) => {
-          if (m.nodeId) await deps.handleFindReferencingFiles(m.nodeId);
+          if (m.nodeId) await deps.handleFindReferencingFiles(m.nodeId, m.knownNodes);
         },
         drillDown: async (m) => {
           if (m.filePath) await deps.handleDrillDown(m.filePath);

--- a/src/extension/services/NodeInteractionService.ts
+++ b/src/extension/services/NodeInteractionService.ts
@@ -1,5 +1,7 @@
 import { Spider } from '../../analyzer/Spider';
 import { normalizePath } from '../../analyzer/types';
+import { computeNodeMetadata } from '../../analyzer/NodeMetadataBuilder';
+import type { GraphData, GraphNodeMetadata } from '../../shared/types';
 
 type Logger = {
   debug: (message: string, ...args: unknown[]) => void;
@@ -9,7 +11,9 @@ type Logger = {
 export interface NodeExpansionResult {
   command: 'expandedGraph';
   nodeId: string;
-  data: Awaited<ReturnType<Spider['crawlFrom']>>;
+  data: Awaited<ReturnType<Spider['crawlFrom']>> & {
+    nodeMetadata?: Record<string, GraphNodeMetadata>;
+  };
 }
 
 export interface ReferencingFilesResult {
@@ -20,6 +24,7 @@ export interface ReferencingFilesResult {
     edges: { source: string; target: string }[];
     parentCounts?: Record<string, number>;
     unusedEdges?: string[];
+    nodeMetadata?: Record<string, GraphNodeMetadata>;
   };
 }
 
@@ -76,6 +81,12 @@ export class NodeInteractionService {
     // Ensure final batch is captured even if no streaming callback
     await handleBatch(newGraphData);
 
+    // Recompute community metadata over the FULL known+new node set (GH #122):
+    // community detection is path-based and needs the whole graph to stay
+    // self-consistent, otherwise newly expanded nodes render with no cluster color.
+    const fullNodes = Array.from(new Set([...knownNodesSet, ...aggregatedNodes]));
+    const nodeMetadata = await this.computeMetadataForNodes(fullNodes);
+
     return {
       command: 'expandedGraph',
       nodeId,
@@ -83,11 +94,15 @@ export class NodeInteractionService {
         nodes: Array.from(aggregatedNodes),
         edges: aggregatedEdges,
         nodeLabels: Object.keys(aggregatedLabels).length > 0 ? aggregatedLabels : undefined,
+        nodeMetadata,
       },
     };
   }
 
-  async getReferencingFiles(nodeId: string): Promise<ReferencingFilesResult> {
+  async getReferencingFiles(
+    nodeId: string,
+    knownNodes?: string[]
+  ): Promise<ReferencingFilesResult> {
     this.logger.debug('Finding referencing files for', nodeId);
     const referencingFiles = await this.spider.findReferencingFiles(nodeId);
     this.logger.debug('Found', referencingFiles.length, 'referencing files');
@@ -120,6 +135,12 @@ export class NodeInteractionService {
 
     const parentCounts = await this.populateParentCounts(nodes);
 
+    // Recompute community metadata over the FULL known+new node set (GH #122):
+    // extension never sent nodeMetadata for on-demand referencing-file lookups,
+    // so the merged graph lost all cluster/color assignments for these nodes.
+    const fullNodes = Array.from(new Set([...(knownNodes ?? []), ...nodes, nodeId]));
+    const nodeMetadata = await this.computeMetadataForNodes(fullNodes);
+
     return {
       command: 'referencingFiles',
       nodeId,
@@ -128,8 +149,24 @@ export class NodeInteractionService {
         edges,
         parentCounts: Object.keys(parentCounts).length > 0 ? parentCounts : undefined,
         unusedEdges: unusedEdges.length > 0 ? unusedEdges : undefined,
+        nodeMetadata,
       },
     };
+  }
+
+  private async computeMetadataForNodes(
+    nodes: string[]
+  ): Promise<Record<string, GraphNodeMetadata> | undefined> {
+    if (nodes.length === 0) return undefined;
+
+    const parentCounts = await this.populateParentCounts(nodes);
+    const tempData: GraphData = {
+      nodes,
+      edges: [],
+      parentCounts: Object.keys(parentCounts).length > 0 ? parentCounts : undefined,
+    };
+    computeNodeMetadata(tempData, this.spider.workspaceRoot);
+    return tempData.nodeMetadata;
   }
 
   private async populateParentCounts(nodes: string[]): Promise<Record<string, number>> {

--- a/src/extension/services/graphProviderServiceContainer.ts
+++ b/src/extension/services/graphProviderServiceContainer.ts
@@ -48,7 +48,7 @@ export interface MessageDispatcherCallbacks {
   handleOpenFile(filePath: string, line?: number): Promise<void>;
   handleExpandNode(nodeId: string, knownNodes?: string[]): Promise<void>;
   handleCancelExpandNode(nodeId?: string): Promise<void>;
-  handleFindReferencingFiles(nodeId: string): Promise<void>;
+  handleFindReferencingFiles(nodeId: string, knownNodes?: string[]): Promise<void>;
   handleDrillDown(
     filePath: string,
     isRefresh?: boolean,

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -99,6 +99,7 @@ export interface ExpandedGraphMessage {
 export interface FindReferencingFilesMessage {
   command: "findReferencingFiles";
   nodeId: string;
+  knownNodes?: string[];
 }
 
 export interface ReferencingFilesMessage {

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -503,6 +503,17 @@ const App: React.FC = () => {
             updatedData.parentCounts = mergedParentCounts;
           }
 
+          // Merge nodeMetadata (communityId) so cluster grouping survives
+          // this on-demand referencing-file merge (GH #122) — dropping this
+          // loses all cluster colors, not just for the newly-added nodes.
+          const mergedNodeMetadata = {
+            ...currentGraphData.nodeMetadata,
+            ...message.data.nodeMetadata,
+          };
+          if (Object.keys(mergedNodeMetadata).length > 0) {
+            updatedData.nodeMetadata = mergedNodeMetadata;
+          }
+
           setGraphData(updatedData);
         }
         // Show parents when we receive referencing files (explicitly requested)

--- a/src/webview/App.tsx
+++ b/src/webview/App.tsx
@@ -736,9 +736,20 @@ const App: React.FC = () => {
       // We haven't fetched referencing files yet, request them from the extension
       // IMPORTANT: Don't toggle showParents yet - wait for the response
       if (vscode) {
+        const normalizedId = normalizePath(path);
+        const knownNodes = new Set<string>(
+          (graphData?.nodes ?? []).map((node) => normalizePath(node)),
+        );
+        (graphData?.edges ?? []).forEach((edge) => {
+          knownNodes.add(normalizePath(edge.source));
+          knownNodes.add(normalizePath(edge.target));
+        });
+        knownNodes.add(normalizedId);
+
         vscode.postMessage({
           command: "findReferencingFiles",
-          nodeId: path,
+          nodeId: normalizedId,
+          knownNodes: Array.from(knownNodes),
         });
       }
       // handleReferencingFilesMessage will set showParents=true when data arrives

--- a/src/webview/components/ReactFlowGraph.tsx
+++ b/src/webview/components/ReactFlowGraph.tsx
@@ -989,7 +989,6 @@ const ReactFlowGraphContent: React.FC<ReactFlowGraphProps> = ({
         <Background />
         <Controls />
       </ReactFlow>
-      {showCommunities && <CommunityLegend communities={communities} />}
       {/* T081: Loading indicator during re-analysis */}
       {isReanalyzing && (
         <div
@@ -1277,36 +1276,45 @@ const ReactFlowGraphContent: React.FC<ReactFlowGraphProps> = ({
         </div>
       </div>
 
-      {/* Legend */}
-      {graph.cycles.size > 0 && (
-        <div
-          style={{
-            position: "absolute",
-            bottom: 50,
-            left: "80%",
-            transform: "translateX(-80%)",
-            zIndex: 1000,
-            background: "var(--vscode-editor-background)",
-            padding: "8px 12px",
-            borderRadius: 4,
-            border: "1px solid var(--vscode-widget-border)",
-            fontSize: 11,
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-          }}
-        >
+      {/* Legend — cycles badge + community legend stacked so they never overlap (GH #122) */}
+      <div
+        style={{
+          position: "absolute",
+          bottom: 8,
+          right: 8,
+          zIndex: 1000,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          gap: 8,
+        }}
+      >
+        {graph.cycles.size > 0 && (
           <div
             style={{
-              width: 10,
-              height: 10,
-              borderRadius: "50%",
-              background: "#dc3545",
+              background: "var(--vscode-editor-background)",
+              padding: "8px 12px",
+              borderRadius: 4,
+              border: "1px solid var(--vscode-widget-border)",
+              fontSize: 11,
+              display: "flex",
+              alignItems: "center",
+              gap: 6,
             }}
-          />
-          <span>Circular dependency ({graph.cycles.size} files)</span>
-        </div>
-      )}
+          >
+            <div
+              style={{
+                width: 10,
+                height: 10,
+                borderRadius: "50%",
+                background: "#dc3545",
+              }}
+            />
+            <span>Circular dependency ({graph.cycles.size} files)</span>
+          </div>
+        )}
+        {showCommunities && <CommunityLegend communities={communities} />}
+      </div>
     </div>
   );
 };

--- a/src/webview/components/reactflow/CommunityLegend.tsx
+++ b/src/webview/components/reactflow/CommunityLegend.tsx
@@ -17,7 +17,7 @@ export function CommunityLegend({ communities }: CommunityLegendProps) {
     <div style={{
       position: 'absolute',
       bottom: 8,
-      left: 8,
+      right: 8,
       zIndex: 10,
       background: 'var(--vscode-editor-background)',
       border: '1px solid var(--vscode-editorWidget-border, #333)',

--- a/src/webview/components/reactflow/CommunityLegend.tsx
+++ b/src/webview/components/reactflow/CommunityLegend.tsx
@@ -15,10 +15,6 @@ export function CommunityLegend({ communities }: CommunityLegendProps) {
 
   return (
     <div style={{
-      position: 'absolute',
-      bottom: 8,
-      right: 8,
-      zIndex: 10,
       background: 'var(--vscode-editor-background)',
       border: '1px solid var(--vscode-editorWidget-border, #333)',
       borderRadius: 4,

--- a/src/webview/hooks/useGraphData.ts
+++ b/src/webview/hooks/useGraphData.ts
@@ -308,11 +308,19 @@ export const useGraphData = () => {
 
   const requestFindReferencingFiles = useCallback((nodeId: string) => {
     if (!vscode) return;
+    const knownNodes = fullGraphData
+      ? Array.from(new Set([
+          ...fullGraphData.nodes,
+          ...fullGraphData.edges.map(e => e.source),
+          ...fullGraphData.edges.map(e => e.target),
+        ]))
+      : undefined;
     vscode.postMessage({
       command: 'findReferencingFiles',
       nodeId,
+      knownNodes,
     });
-  }, []);
+  }, [fullGraphData]);
 
   // Keep track of fullGraphData in a ref to access it in the event listener
   const fullGraphDataRef = React.useRef(fullGraphData);

--- a/src/webview/utils/graphMerge.ts
+++ b/src/webview/utils/graphMerge.ts
@@ -1,4 +1,4 @@
-import type { GraphData } from '../../shared/types';
+import type { GraphData, GraphNodeMetadata } from '../../shared/types';
 
 export function mergeEdgesUnique(
   base: Array<{ source: string; target: string }>,
@@ -21,12 +21,19 @@ export function mergeGraphDataUnion(base: GraphData, incoming: GraphData): Graph
 
   const labels = { ...base.nodeLabels, ...incoming.nodeLabels };
   const parentCounts = { ...base.parentCounts, ...incoming.parentCounts };
+  // Merge nodeMetadata (communityId) so cluster grouping survives expand/
+  // referencing-file merges (GH #122) — dropping this loses all cluster colors.
+  const nodeMetadata: Record<string, GraphNodeMetadata> = {
+    ...base.nodeMetadata,
+    ...incoming.nodeMetadata,
+  };
 
   return {
     nodes,
     edges,
     nodeLabels: Object.keys(labels).length > 0 ? labels : undefined,
     parentCounts: Object.keys(parentCounts).length > 0 ? parentCounts : undefined,
+    nodeMetadata: Object.keys(nodeMetadata).length > 0 ? nodeMetadata : undefined,
     unusedEdges: [...new Set([...(base.unusedEdges || []), ...(incoming.unusedEdges || [])])],
   };
 }

--- a/src/webview/utils/graphUtils.ts
+++ b/src/webview/utils/graphUtils.ts
@@ -1,6 +1,6 @@
 import { SUPPORTED_FILE_EXTENSIONS } from '../../shared/constants';
 import { normalizePath } from '../../shared/path';
-import { GraphData } from '../../shared/types';
+import { GraphData, GraphNodeMetadata } from '../../shared/types';
 
 /**
  * Extract filename from a full path
@@ -155,11 +155,22 @@ export const mergeGraphData = (currentData: GraphData, newData: GraphData): Grap
     if (currentData.parentCounts) Object.assign(mergedParentCounts, currentData.parentCounts);
     if (newData.parentCounts) Object.assign(mergedParentCounts, newData.parentCounts);
 
+    // Merge nodeMetadata (e.g. communityId) so cluster grouping survives on-demand
+    // merges such as "show referencing file" (GH #122) — without this, the merged
+    // graph loses all community assignments and clusters disappear.
+    const mergedNodeMetadata: Record<string, GraphNodeMetadata> = {};
+    if (currentData.nodeMetadata) Object.assign(mergedNodeMetadata, currentData.nodeMetadata);
+    if (newData.nodeMetadata) Object.assign(mergedNodeMetadata, newData.nodeMetadata);
+
+    const mergedUnusedEdges = [...new Set([...(currentData.unusedEdges ?? []), ...(newData.unusedEdges ?? [])])];
+
     return {
         nodes: mergedNodes,
         edges: mergedEdges,
         nodeLabels: Object.keys(mergedNodeLabels).length > 0 ? mergedNodeLabels : undefined,
         parentCounts: Object.keys(mergedParentCounts).length > 0 ? mergedParentCounts : undefined,
+        nodeMetadata: Object.keys(mergedNodeMetadata).length > 0 ? mergedNodeMetadata : undefined,
+        unusedEdges: mergedUnusedEdges.length > 0 ? mergedUnusedEdges : undefined,
     };
 };
 

--- a/tests/analyzer/PythonParser.properties.test.ts
+++ b/tests/analyzer/PythonParser.properties.test.ts
@@ -303,7 +303,7 @@ describe('PythonParser Property-Based Tests', { timeout: 30_000 }, () => {
               // Verify no duplicate imports
               const modules = deps.map((d) => d.module);
               const uniqueModules = [...new Set(modules)];
-              expect(modules.length).toBe(uniqueModules.length);
+              expect(modules).toHaveLength(uniqueModules.length);
 
               // Verify all imports have valid line numbers
               expect(deps.every((d) => d.line > 0)).toBe(true);
@@ -461,7 +461,7 @@ describe('PythonParser Property-Based Tests', { timeout: 30_000 }, () => {
               }
 
               // Verify we extracted the right number of imports
-              expect(deps.length).toBe(expectedModules.length);
+              expect(deps).toHaveLength(expectedModules.length);
             } finally {
               try {
                 await fs.unlink(tempFilePath);
@@ -510,12 +510,18 @@ describe('PythonParser Property-Based Tests', { timeout: 30_000 }, () => {
             const lines: string[] = ['# Import aliases test'];
             const expectedModules: string[] = [];
             const seenModules = new Set<string>();
+            const expectedImports: Array<{ alias: string; line: number; module: string }> = [];
 
             const count = Math.min(modules.length, aliases.length);
             for (let i = 0; i < count; i++) {
               // Make module unique by appending index
               const uniqueModule = `${modules[i]}${i}`;
               lines.push(`import ${uniqueModule} as ${aliases[i]}`);
+              expectedImports.push({
+                alias: aliases[i],
+                line: lines.length,
+                module: uniqueModule,
+              });
               
               if (!seenModules.has(uniqueModule)) {
                 seenModules.add(uniqueModule);
@@ -536,9 +542,11 @@ describe('PythonParser Property-Based Tests', { timeout: 30_000 }, () => {
                 expect(actualModules).toContain(expectedModule);
               }
 
-              // Verify aliases are not in the module list
-              for (const alias of aliases.slice(0, count)) {
-                expect(actualModules).not.toContain(alias);
+              // Verify each import line extracts its module rather than its alias.
+              for (const expectedImport of expectedImports) {
+                const dependency = deps.find((item) => item.line === expectedImport.line);
+                expect(dependency?.module).toBe(expectedImport.module);
+                expect(dependency?.module).not.toBe(expectedImport.alias);
               }
             } finally {
               try {

--- a/tests/extension/NodeInteractionService.test.ts
+++ b/tests/extension/NodeInteractionService.test.ts
@@ -7,6 +7,8 @@ const createSpider = () => ({
   findReferencingFiles: vi.fn(),
   hasReverseIndex: vi.fn(),
   getCallerCount: vi.fn(),
+  verifyDependencyUsage: vi.fn().mockResolvedValue(true),
+  workspaceRoot: '/workspace',
 }) as unknown as Spider;
 
 const createLogger = () => ({
@@ -55,5 +57,44 @@ describe('NodeInteractionService', () => {
     expect(result.data.nodes).toEqual(['fileB.ts']);
     expect(result.data.parentCounts).toEqual({ 'fileB.ts': 1 });
     expect(spider.getCallerCount).toHaveBeenCalledWith('fileB.ts');
+  });
+
+  it('expandNode computes nodeMetadata (communityId) over the full known+new node union (GH #122)', async () => {
+    (spider.crawlFrom as ReturnType<typeof vi.fn>).mockResolvedValue({
+      nodes: ['src/analyzer/newFile.ts'],
+      edges: [{ source: 'src/analyzer/root.ts', target: 'src/analyzer/newFile.ts' }],
+    });
+
+    const service = new NodeInteractionService(spider, logger);
+    const result = await service.expandNode('src/analyzer/root.ts', ['src/analyzer/root.ts']);
+
+    expect(result.data.nodeMetadata).toBeDefined();
+    // Both the already-known node and the newly-expanded node must get metadata —
+    // otherwise the newly expanded node renders with no cluster color.
+    expect(Object.keys(result.data.nodeMetadata ?? {})).toEqual(
+      expect.arrayContaining(['src/analyzer/root.ts', 'src/analyzer/newFile.ts']),
+    );
+  });
+
+  it('getReferencingFiles computes nodeMetadata over the full known+new node union (GH #122)', async () => {
+    (spider.findReferencingFiles as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { path: 'src/analyzer/caller.ts' },
+    ]);
+    (spider.hasReverseIndex as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+    const service = new NodeInteractionService(spider, logger);
+    const result = await service.getReferencingFiles('src/analyzer/root.ts', [
+      'src/analyzer/root.ts',
+      'src/analyzer/sibling.ts',
+    ]);
+
+    expect(result.data.nodeMetadata).toBeDefined();
+    expect(Object.keys(result.data.nodeMetadata ?? {})).toEqual(
+      expect.arrayContaining([
+        'src/analyzer/root.ts',
+        'src/analyzer/sibling.ts',
+        'src/analyzer/caller.ts',
+      ]),
+    );
   });
 });

--- a/tests/webview/App.findReferences.test.tsx
+++ b/tests/webview/App.findReferences.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+
+import React, { type ComponentType } from "react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const postMessage = vi.fn();
+
+vi.mock("../../src/webview/components/ReactFlowGraph", () => ({
+  default: ({ onFindReferences }: { onFindReferences: (path: string) => void }) => (
+    <button type="button" onClick={() => onFindReferences("C:\\workspace\\root.ts")}>
+      Find references
+    </button>
+  ),
+}));
+
+vi.mock("../../src/webview/components/AtomicSymbolGraph", () => ({
+  AtomicSymbolGraph: () => null,
+}));
+
+vi.mock("../../src/webview/components/cytoscape/CytoscapeGraph", () => ({
+  CytoscapeGraph: () => null,
+}));
+
+vi.mock("../../src/webview/components/SymbolCardView", () => ({
+  default: () => null,
+}));
+
+let App: ComponentType;
+
+beforeAll(async () => {
+  Object.defineProperty(globalThis, "acquireVsCodeApi", {
+    configurable: true,
+    value: () => ({ postMessage }),
+  });
+  ({ default: App } = await import("../../src/webview/App"));
+});
+
+afterEach(() => {
+  cleanup();
+  postMessage.mockClear();
+});
+
+describe("App — find referencing files", () => {
+  it("sends every normalized Windows, macOS, and Linux graph path as knownNodes", () => {
+    render(React.createElement(App));
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          data: {
+            command: "updateGraph",
+            filePath: "C:\\workspace\\root.ts",
+            data: {
+              nodes: [
+                "C:\\workspace\\root.ts",
+                "/Users/example/project/dependency.ts",
+                "/home/example/project/linux.ts",
+              ],
+              edges: [
+                {
+                  source: "C:\\workspace\\root.ts",
+                  target: "C:/workspace/discovered.ts",
+                },
+              ],
+            },
+          },
+        }),
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Find references" }));
+
+    expect(postMessage).toHaveBeenLastCalledWith({
+      command: "findReferencingFiles",
+      nodeId: "c:/workspace/root.ts",
+      knownNodes: expect.arrayContaining([
+        "c:/workspace/root.ts",
+        "/Users/example/project/dependency.ts",
+        "/home/example/project/linux.ts",
+        "c:/workspace/discovered.ts",
+      ]),
+    });
+  });
+});

--- a/tests/webview/components/ReactFlowGraph.showCommunities.test.tsx
+++ b/tests/webview/components/ReactFlowGraph.showCommunities.test.tsx
@@ -45,3 +45,65 @@ describe("ReactFlowGraph — showCommunities gate", () => {
     expect(screen.queryByText("Spider.ts")).toBeNull();
   });
 });
+
+/**
+ * GH #122 (2nd collision): the "Circular dependency" cycles badge and
+ * CommunityLegend both live bottom-right. ReactFlowGraph now nests them in a
+ * single wrapper (position/bottom/right owned once) instead of each having
+ * its own absolute positioning — this reproduces that wrapper contract to
+ * prove the two overlays stack instead of overlapping.
+ */
+function CyclesAndCommunityOverlay({ cycleCount }: { cycleCount: number }) {
+  return (
+    <div
+      data-testid="overlay-wrapper"
+      style={{
+        position: "absolute",
+        bottom: 8,
+        right: 8,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "flex-end",
+        gap: 8,
+      }}
+    >
+      {cycleCount > 0 && (
+        <div data-testid="cycles-badge">
+          Circular dependency ({cycleCount} files)
+        </div>
+      )}
+      <CommunityLegend communities={communities} />
+    </div>
+  );
+}
+
+describe("ReactFlowGraph — bottom-right overlay stacking (GH #122)", () => {
+  it("positions the shared wrapper bottom-right exactly once, not per-child", () => {
+    const { getByTestId } = render(
+      React.createElement(CyclesAndCommunityOverlay, { cycleCount: 3 }),
+    );
+    const wrapper = getByTestId("overlay-wrapper");
+    expect(wrapper.style.position).toBe("absolute");
+    expect(wrapper.style.bottom).toBe("8px");
+    expect(wrapper.style.right).toBe("8px");
+
+    // Children must NOT carry their own absolute positioning — only the wrapper does.
+    const cyclesBadge = getByTestId("cycles-badge");
+    expect(cyclesBadge.style.position).toBe("");
+    const legend = screen.getByText("Import clusters").closest("div");
+    expect(legend?.style.position).toBeFalsy();
+  });
+
+  it("renders both the cycles badge and the community legend inside one DOM ancestor when both are present", () => {
+    render(React.createElement(CyclesAndCommunityOverlay, { cycleCount: 5 }));
+    const wrapper = screen.getByTestId("overlay-wrapper");
+    expect(wrapper.contains(screen.getByTestId("cycles-badge"))).toBe(true);
+    expect(wrapper.contains(screen.getByText("Spider.ts"))).toBe(true);
+  });
+
+  it("omits the cycles badge but keeps the legend when there are no cycles", () => {
+    render(React.createElement(CyclesAndCommunityOverlay, { cycleCount: 0 }));
+    expect(screen.queryByTestId("cycles-badge")).toBeNull();
+    expect(screen.getByText("Spider.ts")).toBeTruthy();
+  });
+});

--- a/tests/webview/components/reactflow/CommunityLegend.test.ts
+++ b/tests/webview/components/reactflow/CommunityLegend.test.ts
@@ -91,15 +91,17 @@ describe('CommunityLegend', () => {
     expect(screen.getByText('Groups of closely connected files')).toBeTruthy();
   });
 
-  it('positions itself bottom-right so it does not overlap the bottom-left ReactFlow Controls (GH #122)', () => {
+  it('does not self-position — positioning is owned by the wrapper in ReactFlowGraph (GH #122)', () => {
     const { container } = render(
       React.createElement(CommunityLegend, {
         communities: [{ id: 1, label: 'Hub.ts', color: '#4E79A7' }],
       })
     );
     const root = container.firstChild as HTMLElement;
-    expect(root.style.right).toBe('8px');
+    expect(root.style.position).toBe('');
+    expect(root.style.right).toBe('');
     expect(root.style.left).toBe('');
+    expect(root.style.bottom).toBe('');
   });
 
   it('title includes total cluster count for multiple communities', () => {

--- a/tests/webview/components/reactflow/CommunityLegend.test.ts
+++ b/tests/webview/components/reactflow/CommunityLegend.test.ts
@@ -91,6 +91,17 @@ describe('CommunityLegend', () => {
     expect(screen.getByText('Groups of closely connected files')).toBeTruthy();
   });
 
+  it('positions itself bottom-right so it does not overlap the bottom-left ReactFlow Controls (GH #122)', () => {
+    const { container } = render(
+      React.createElement(CommunityLegend, {
+        communities: [{ id: 1, label: 'Hub.ts', color: '#4E79A7' }],
+      })
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.right).toBe('8px');
+    expect(root.style.left).toBe('');
+  });
+
   it('title includes total cluster count for multiple communities', () => {
     render(
       React.createElement(CommunityLegend, {

--- a/tests/webview/utils/graphMerge.test.ts
+++ b/tests/webview/utils/graphMerge.test.ts
@@ -25,5 +25,50 @@ describe('mergeGraphDataUnion', () => {
     expect(merged.nodeLabels).toEqual({ a: 'A', b: 'B' });
     expect(merged.parentCounts).toEqual({ a: 1, b: 2 });
   });
+
+  it('preserves nodeMetadata (communityId) when incoming data has none (GH #122)', () => {
+    const base: GraphData = {
+      nodes: ['a', 'b'],
+      edges: [{ source: 'a', target: 'b' }],
+      nodeMetadata: {
+        a: { hubScore: 0.9, communityId: 1 },
+        b: { hubScore: 0.4, communityId: 2 },
+      },
+    };
+    const incoming: GraphData = {
+      nodes: ['c'],
+      edges: [{ source: 'c', target: 'a' }],
+    };
+
+    const merged = mergeGraphDataUnion(base, incoming);
+
+    expect(merged.nodeMetadata).toEqual({
+      a: { hubScore: 0.9, communityId: 1 },
+      b: { hubScore: 0.4, communityId: 2 },
+    });
+  });
+
+  it('merges nodeMetadata from both sides, incoming taking precedence on overlap', () => {
+    const base: GraphData = {
+      nodes: ['a'],
+      edges: [],
+      nodeMetadata: { a: { hubScore: 0.5, communityId: 1 } },
+    };
+    const incoming: GraphData = {
+      nodes: ['a', 'c'],
+      edges: [],
+      nodeMetadata: {
+        a: { hubScore: 0.5, communityId: 3 },
+        c: { hubScore: 0.1, communityId: 3 },
+      },
+    };
+
+    const merged = mergeGraphDataUnion(base, incoming);
+
+    expect(merged.nodeMetadata).toEqual({
+      a: { hubScore: 0.5, communityId: 3 },
+      c: { hubScore: 0.1, communityId: 3 },
+    });
+  });
 });
 

--- a/tests/webview/utils/graphUtils.test.ts
+++ b/tests/webview/utils/graphUtils.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mergeGraphData, detectCycles } from '../../../src/webview/utils/graphUtils';
+import { buildReactFlowGraph } from '../../../src/webview/components/reactflow/buildGraph';
 import { GraphData } from '../../../src/shared/types';
 
 describe('graphUtils', () => {
@@ -95,6 +96,47 @@ describe('graphUtils', () => {
             const result = mergeGraphData(currentData, newData);
 
             expect(result.unusedEdges).toEqual(['A->B']);
+        });
+
+        it('end-to-end: communityId survives a "show referencing file" merge and reaches buildReactFlowGraph node data (GH #122)', () => {
+            // Shape mirrors NodeInteractionService.getReferencingFiles' actual payload:
+            // nodes/edges/parentCounts/unusedEdges only — NEVER nodeMetadata.
+            const currentData: GraphData = {
+                nodes: ['root.ts', 'child.ts'],
+                edges: [{ source: 'root.ts', target: 'child.ts' }],
+                nodeMetadata: {
+                    'root.ts': { hubScore: 0.9, communityId: 1 },
+                    'child.ts': { hubScore: 0.4, communityId: 2 },
+                },
+            };
+            const referencingFilesPayload: GraphData = {
+                nodes: ['parent.ts'],
+                edges: [{ source: 'parent.ts', target: 'root.ts' }],
+                parentCounts: { 'root.ts': 1 },
+            };
+
+            const merged = mergeGraphData(currentData, referencingFilesPayload);
+
+            const result = buildReactFlowGraph({
+                data: merged,
+                currentFilePath: 'root.ts',
+                expandAll: false,
+                expandedNodes: new Set(['root.ts']),
+                showParents: true,
+                callbacks: {
+                    onNodeClick: vi.fn(),
+                    onDrillDown: vi.fn(),
+                    onFindReferences: vi.fn(),
+                    onToggleParents: vi.fn(),
+                    onToggle: vi.fn(),
+                    onExpandRequest: vi.fn(),
+                },
+            });
+
+            const rootNode = result.nodes.find(n => n.id === 'root.ts');
+            const childNode = result.nodes.find(n => n.id === 'child.ts');
+            expect(rootNode?.data).toMatchObject({ communityId: 1 });
+            expect(childNode?.data).toMatchObject({ communityId: 2 });
         });
     });
 

--- a/tests/webview/utils/graphUtils.test.ts
+++ b/tests/webview/utils/graphUtils.test.ts
@@ -38,6 +38,64 @@ describe('graphUtils', () => {
             expect(result.edges).toHaveLength(1);
             expect(result.edges).toContainEqual({ source: 'A', target: 'B' });
         });
+
+        it('preserves existing nodeMetadata (communityId) when merging referencing files without metadata (GH #122)', () => {
+            const currentData: GraphData = {
+                nodes: ['A', 'B'],
+                edges: [{ source: 'A', target: 'B' }],
+                nodeMetadata: {
+                    A: { hubScore: 0.5, communityId: 1 },
+                    B: { hubScore: 0.2, communityId: 2 },
+                },
+            };
+            const newData: GraphData = {
+                nodes: ['C'],
+                edges: [{ source: 'C', target: 'A' }],
+            };
+
+            const result = mergeGraphData(currentData, newData);
+
+            expect(result.nodeMetadata).toEqual({
+                A: { hubScore: 0.5, communityId: 1 },
+                B: { hubScore: 0.2, communityId: 2 },
+            });
+        });
+
+        it('merges nodeMetadata from both sides when both provide it', () => {
+            const currentData: GraphData = {
+                nodes: ['A'],
+                edges: [],
+                nodeMetadata: { A: { hubScore: 0.5, communityId: 1 } },
+            };
+            const newData: GraphData = {
+                nodes: ['C'],
+                edges: [],
+                nodeMetadata: { C: { hubScore: 0.1, communityId: 3 } },
+            };
+
+            const result = mergeGraphData(currentData, newData);
+
+            expect(result.nodeMetadata).toEqual({
+                A: { hubScore: 0.5, communityId: 1 },
+                C: { hubScore: 0.1, communityId: 3 },
+            });
+        });
+
+        it('preserves existing unusedEdges when merging new data without any', () => {
+            const currentData: GraphData = {
+                nodes: ['A', 'B'],
+                edges: [{ source: 'A', target: 'B' }],
+                unusedEdges: ['A->B'],
+            };
+            const newData: GraphData = {
+                nodes: ['C'],
+                edges: [{ source: 'C', target: 'A' }],
+            };
+
+            const result = mergeGraphData(currentData, newData);
+
+            expect(result.unusedEdges).toEqual(['A->B']);
+        });
     });
 
     describe('detectCycles', () => {


### PR DESCRIPTION
## Summary
1. When I click on show referencing file in the webview callgraph and there is one or more files that reference the current file, the graph refreshes and in this case I lose the display of the clusters. (cf captures)

<img width="1008" height="410" alt="Image" src="https://github.com/user-attachments/assets/ccb77195-18d1-4795-bfad-7eee5e04ea1d" />

<img width="1009" height="407" alt="Image" src="https://github.com/user-attachments/assets/783a5d42-f05a-4eef-a24e-f1a94c61d196" />

2. Sur cette webview les boutons  sont masqués par la zone clusters (la zone cluster doit être positionnée dans une zone qui n'affecte pas la visibilité des différents éléments (en bas à droite)

<img width="34" height="116" alt="Image" src="https://github.com/user-attachments/assets/19b90423-2f26-4ec4-9171-cbab21b0c8fe" />



## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Build/packaging
- [ ] Documentation
- [ ] Tests

## Validation evidence
https://github.com/magic5644/Graph-It-Live/actions/runs/29829025613

### Quality
- [x] `npm run lint`
- [x] `npm run check:types`
- [x] `npm test`
- [x] Sonar clean on modified files (no new issues)

### VSIX / Packaging (required when build config or deps changed)
- [x] `npm run package:verify` → `✅ No .map files in package`
- [x] `npx vsce ls graph-it-live-*.vsix | grep "\.wasm$"` shows required WASM files
- [x] `ls -lh graph-it-live-*.vsix` size checked (target ≤ 16 MB, warn above)

### E2E
- [x] `npm run test:vscode:vsix` (required for user-facing changes)

## Checklist
- [x] Tests added/updated for changed behavior
- [x] Docs updated (if needed)
- [x] Cross-platform impact considered (Windows/Linux/macOS)
- [x] No `vscode` import added under `src/analyzer/**` or `src/mcp/**`
