### PR TITLE
fix npm cli and add documentation

### DIFF
--- a/.github/workflows/graph-it-review-gate.yml
+++ b/.github/workflows/graph-it-review-gate.yml
@@ -27,3 +27,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment: ${{ github.event.pull_request.head.repo.fork && 'false' || 'true' }}
           fail-on-risk: high
+          # TEMPORARY: v1.13.6 shipped a broken npm bin entry (CLI silently
+          # prints nothing — see changelog.md v1.14.0 "Fixed"). Pin to the
+          # last known-good published version until v1.14.0 is published,
+          # then remove this pin to go back to @latest.
+          cli-version: "1.13.5"

--- a/README.md
+++ b/README.md
@@ -440,6 +440,12 @@ graph-it update                 # Update graph-it to the latest version
 graph-it install                # Symlink the binary into your system PATH (opt-in)
 ```
 
+> **Troubleshooting:** if `graph-it` runs but prints nothing at all (versions
+> ≤ v1.13.6 shipped a broken npm `bin` wrapper), `graph-it update` can't help
+> — the CLI is silently dead on arrival. Reinstall directly instead:
+> `npm install -g @magic5644/graph-it-live@latest`. Fixed in v1.14.0; see
+> [`docs/CLI.md`](docs/CLI.md#installation) for details.
+
 **Without installing globally:**
 
 ```bash

--- a/bin/graph-it
+++ b/bin/graph-it
@@ -1,2 +1,0 @@
-#!/usr/bin/env node
-require('../dist/graph-it.js');

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.14.0
+
+### Fixed
+
+- **Broken CLI on npm global install**: `npm install -g @magic5644/graph-it-live` produced a CLI that silently exited `0` with no output on every command (`--version`, `--help`, `scan`, etc.). Caused by the `bin/graph-it` wrapper's `require('../dist/graph-it.js')` indirection defeating the `require.main === module` entry-point guard in `src/cli/index.ts`. The npm `bin` field now points directly at `dist/graph-it.js`, matching the pattern already used by `graph-it install`. Users on v1.13.6 or earlier must reinstall manually (`npm install -g @magic5644/graph-it-live@latest`) since the broken CLI cannot run its own `update` command to fix itself.
+
+### Documentation
+
+- **CLI troubleshooting note**: Documented the broken-install recovery steps in `README.md` and `docs/CLI.md`.
+
 ## v1.13.6
 
 ### Changed

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -74,6 +74,21 @@ If you have the VS Code extension installed, you can expose the bundled binary t
 graph-it install     # adds graph-it to your system PATH
 ```
 
+**Troubleshooting: `graph-it` runs but prints nothing (fixed in v1.14.0)**
+
+Versions v1.13.6 and earlier shipped a `bin/graph-it` wrapper that silently
+broke `npm install -g` installs — every command exited `0` with no output at
+all. If you're stuck on an affected version, `graph-it update` can't fix
+itself (the whole CLI is dead on arrival, including the update command).
+Reinstall manually instead:
+
+```bash
+npm install -g @magic5644/graph-it-live@latest
+```
+
+Once you're on v1.14.0+, `graph-it update` works normally again for future
+releases.
+
 ---
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -1102,7 +1102,7 @@
     }
   },
   "bin": {
-    "graph-it": "./bin/graph-it"
+    "graph-it": "./dist/graph-it.js"
   },
   "scripts": {
     "vscode:prepublish": "npm run build -- --production",

--- a/scripts/publish-npm.sh
+++ b/scripts/publish-npm.sh
@@ -81,7 +81,7 @@ node -e "
 const fs = require('fs');
 const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 p.name = '@magic5644/graph-it-live';
-p.files = ['bin/', 'dist/graph-it.js', 'dist/astWorker.js', 'dist/mcpServer.mjs', 'dist/mcpWorker.js', 'dist/indexerWorker.js', 'dist/wasm/', 'dist/queries/', 'README.md', 'LICENSE', 'docs/CLI.md'];
+p.files = ['dist/graph-it.js', 'dist/astWorker.js', 'dist/mcpServer.mjs', 'dist/mcpWorker.js', 'dist/indexerWorker.js', 'dist/wasm/', 'dist/queries/', 'README.md', 'LICENSE', 'docs/CLI.md'];
 fs.writeFileSync('package.json', JSON.stringify(p, null, 2) + '\n');
 "
 echo "  ✓ name  → @magic5644/graph-it-live"

--- a/scripts/test-cli-e2e.sh
+++ b/scripts/test-cli-e2e.sh
@@ -40,7 +40,7 @@ node -e "
 const fs = require('fs');
 const p = '$WORKSPACE/package.json';
 const pkg = JSON.parse(fs.readFileSync(p, 'utf8'));
-pkg.files = ['bin/', 'dist/graph-it.js', 'dist/astWorker.js', 'dist/mcpServer.mjs', 'dist/mcpWorker.js', 'dist/indexerWorker.js', 'dist/wasm/', 'dist/queries/', 'README.md', 'LICENSE', 'docs/CLI.md'];
+pkg.files = ['dist/graph-it.js', 'dist/astWorker.js', 'dist/mcpServer.mjs', 'dist/mcpWorker.js', 'dist/indexerWorker.js', 'dist/wasm/', 'dist/queries/', 'README.md', 'LICENSE', 'docs/CLI.md'];
 fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + '\n');
 "
 echo "  package.json patched with CLI files field"
@@ -63,7 +63,7 @@ BINARY=$(which graph-it || echo "")
 
 # ── 3. Basic commands ────────────────────────────────────────────────────────
 section "Basic commands"
-graph-it --version   && pass "--version"       || fail "--version"
+graph-it --version | grep -q "graph-it-live v"  && pass "--version"       || fail "--version"
 graph-it --help | grep -q "Commands:"          && pass "--help"         || fail "--help"
 graph-it tool --list | grep -q "analyze_dependencies" && pass "tool --list" || fail "tool --list"
 graph-it tool --help | grep -q "Usage:"        && pass "tool --help"   || fail "tool --help"

--- a/tests/cli/binEntry.e2e.test.ts
+++ b/tests/cli/binEntry.e2e.test.ts
@@ -1,0 +1,54 @@
+/**
+ * E2E regression test for the npm bin entry point.
+ *
+ * Root cause of the bug this guards against: `src/cli/index.ts` gates its
+ * `main()` call behind `if (require.main === module)`. That check only
+ * holds when `dist/graph-it.js` is the process's *own* entry point. A thin
+ * wrapper script doing `require('../dist/graph-it.js')` (the old
+ * `bin/graph-it`) makes `require.main` the *wrapper's* module instead — so
+ * the guard is false, `main()` never runs, and the CLI silently exits 0 with
+ * no output. This only reproduces against the built artifact; importing
+ * `src/cli/index.ts` via Vitest never exercises it.
+ *
+ * Fix: npm's `bin` field points straight at `dist/graph-it.js` (no wrapper
+ * indirection) — see package.json `bin.graph-it`. This test pins both sides:
+ * the packaging config itself, and that the built entry actually produces
+ * output when invoked the way npm invokes `bin` entries (as its own process
+ * entry point, not `require()`d from another script).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const DIST_ENTRY = path.join(REPO_ROOT, "dist/graph-it.js");
+const distExists = fs.existsSync(DIST_ENTRY);
+
+describe.skipIf(!distExists)("CLI bin entry point (E2E)", () => {
+  beforeAll(() => {
+    if (!distExists) {
+      // eslint-disable-next-line no-console
+      console.warn(`Skipping binEntry.e2e.test.ts: ${DIST_ENTRY} not built. Run "npm run build:cli" first.`);
+    }
+  });
+
+  it("package.json bin field points directly at dist/graph-it.js (no wrapper indirection)", () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf-8"));
+    // A wrapper (e.g. "./bin/graph-it" doing require('../dist/graph-it.js'))
+    // breaks the require.main === module guard in src/cli/index.ts — see
+    // module doc comment above.
+    expect(pkg.bin["graph-it"]).toBe("./dist/graph-it.js");
+  });
+
+  it("prints the version when run directly as the process entry point", () => {
+    const out = execFileSync(process.execPath, [DIST_ENTRY, "--version"], { encoding: "utf-8" });
+    expect(out).toMatch(/graph-it-live v/);
+  });
+
+  it("prints usage help when run directly as the process entry point", () => {
+    const out = execFileSync(process.execPath, [DIST_ENTRY, "--help"], { encoding: "utf-8" });
+    expect(out).toContain("Usage:");
+  });
+});


### PR DESCRIPTION
## Summary
Fix npm cli problems and add documentation

## Type of change
- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Build/packaging
- [X] Documentation
- [X] Tests

## Validation evidence
<!-- Paste short command outputs (or links to CI jobs) -->

### Quality
- [ X] `npm run lint`
- [ X] `npm run check:types`
- [ X] `npm test`
- [ X] Sonar clean on modified files (no new issues)

### VSIX / Packaging (required when build config or deps changed)
- [X ] `npm run package:verify` → `✅ No .map files in package`
- [ X] `npx vsce ls graph-it-live-*.vsix | grep "\.wasm$"` shows required WASM files
- [X ] `ls -lh graph-it-live-*.vsix` size checked (target ≤ 16 MB, warn above)

### E2E
- [ ] `npm run test:vscode:vsix` (required for user-facing changes)

## Checklist
- [ X] Tests added/updated for changed behavior
- [ X] Docs updated (if needed)
- [ X] Cross-platform impact considered (Windows/Linux/macOS)
- [ X] No `vscode` import added under `src/analyzer/**` or `src/mcp/**`
