### PR TITLE
fix: TOON formatter misses nested/unlisted arrays (check-dependencies, explain, check, cycles)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- **CLI `--format toon` silently fell back to JSON for several commands**: `extractArrayForToon` only scanned top-level object keys, missing arrays nested one level deeper or under unlisted key names. Affected: `check-dependencies` (`outgoing.dependencies` / `incoming.referencingFiles`), `explain` (`graph.nodes` / `graph.edges`), `check` (`unusedSymbols`), `cycles` (`confirmedCycles`). Added a nested-array fallback and extended the known-key list; each command now produces real TOON rows instead of pretty-printed JSON.
+
 ### Fixed — Breaking
 
 - **MCP tool `query_natural_language` — `toon` field was JSON, not TOON**: The `outputFormat: 'toon'` branch (default) returned a JSON passthrough of the analyzer's compact payload under the `toon` field name, instead of a real TOON encoding. Fixed to produce a genuine TOON string (`# nodeCount=... edgeCount=... truncated=...` meta line + `nodes(...)` / `edges(...)` header+rows blocks). The field name `toon` is unchanged (see `docs/architecture/ADR-S2-01-toon-field-mcp-compat.md`); only its content changed.

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -71,7 +71,10 @@ function formatJson(data: unknown): string {
 
 function formatToon(data: unknown, command: string): string {
   // Extract array data for TOON
-  const arrayData = extractArrayForToon(data);
+  const arrayData =
+    extractArrayForToon(data) ??
+    extractDependencyCheckArrayForToon(data) ??
+    extractNestedArrayForToon(data);
   if (!arrayData || arrayData.length === 0) {
     // Fallback to JSON for non-array / empty data
     return JSON.stringify(data, null, 2);
@@ -720,21 +723,77 @@ function buildMermaidFromGenericJson(data: unknown, command: string): string {
 // TOON helpers
 // ============================================================================
 
+const TOON_ARRAY_KEYS = [
+  "items", "results", "data", "nodes", "edges",
+  "dependencies", "symbols", "unusedSymbols", "confirmedCycles", "callers", "files", "callChain",
+];
+
 function extractArrayForToon(data: unknown): unknown[] | null {
   if (Array.isArray(data)) return data;
 
   if (typeof data === "object" && data !== null) {
     const obj = data as Record<string, unknown>;
-    const arrayKeys = [
-      "items", "results", "data", "nodes", "edges",
-      "dependencies", "symbols", "callers", "files", "callChain",
-    ];
-    for (const key of arrayKeys) {
+    for (const key of TOON_ARRAY_KEYS) {
       if (Array.isArray(obj[key])) return obj[key] as unknown[];
     }
   }
 
   return null;
+}
+
+/**
+ * Fallback for shapes like explain's { graph: { nodes, edges } }, where the
+ * array lives one level deeper than extractArrayForToon's top-level key scan.
+ */
+function extractNestedArrayForToon(data: unknown): unknown[] | null {
+  if (typeof data !== "object" || data === null) return null;
+  const obj = data as Record<string, unknown>;
+
+  for (const value of Object.values(obj)) {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) continue;
+    const nested = value as Record<string, unknown>;
+    for (const key of TOON_ARRAY_KEYS) {
+      if (Array.isArray(nested[key])) return nested[key] as unknown[];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * check-dependencies returns { outgoing: { dependencies }, incoming: { referencingFiles } } —
+ * both nested one level deeper than extractArrayForToon's top-level key scan can see.
+ * Flatten them into one tagged array so TOON encoding doesn't silently fall back to JSON.
+ */
+function extractDependencyCheckArrayForToon(data: unknown): unknown[] | null {
+  if (typeof data !== "object" || data === null) return null;
+  const obj = data as Record<string, unknown>;
+
+  const outgoing = obj["outgoing"];
+  const incoming = obj["incoming"];
+  const dependencies = typeof outgoing === "object" && outgoing !== null
+    ? (outgoing as Record<string, unknown>)["dependencies"]
+    : undefined;
+  const referencingFiles = typeof incoming === "object" && incoming !== null
+    ? (incoming as Record<string, unknown>)["referencingFiles"]
+    : undefined;
+
+  if (!Array.isArray(dependencies) && !Array.isArray(referencingFiles)) {
+    return null;
+  }
+
+  const tagged: unknown[] = [];
+  if (Array.isArray(dependencies)) {
+    for (const dep of dependencies) {
+      tagged.push(typeof dep === "object" && dep !== null ? { direction: "outgoing", ...dep } : dep);
+    }
+  }
+  if (Array.isArray(referencingFiles)) {
+    for (const ref of referencingFiles) {
+      tagged.push(typeof ref === "object" && ref !== null ? { direction: "incoming", ...ref } : ref);
+    }
+  }
+  return tagged;
 }
 
 function inferObjectName(data: unknown[]): string {
@@ -744,6 +803,7 @@ function inferObjectName(data: unknown[]): string {
   if (typeof first !== "object" || first === null) return "data";
 
   const keys = Object.keys(first);
+  if (keys.includes("direction") && keys.includes("path")) return "dependencies";
   if (keys.includes("file") || keys.includes("filePath")) return "files";
   if (keys.includes("symbolName") || keys.includes("symbol")) return "symbols";
   if (keys.includes("source") && keys.includes("target")) return "edges";

--- a/tests/cli/formatter.test.ts
+++ b/tests/cli/formatter.test.ts
@@ -173,6 +173,74 @@ describe("formatOutput - toon", () => {
     // Primitive rows cannot be TOON-encoded; output falls back to JSON
     expect(() => JSON.parse(out)).not.toThrow();
   });
+
+  it("produces toon rows for check-dependencies (nested outgoing/incoming), not a JSON fallback", () => {
+    const dependencyData = {
+      filePath: "/workspace/src/index.ts",
+      relativePath: "src/index.ts",
+      outgoing: {
+        dependencyCount: 1,
+        dependencies: [{ path: "src/utils.ts", relativePath: "src/utils.ts", type: "import", line: 1 }],
+      },
+      incoming: {
+        referencingFileCount: 1,
+        referencingFiles: [{ path: "src/app.ts", relativePath: "src/app.ts", type: "import", line: 2 }],
+      },
+    };
+
+    const out = formatOutput(dependencyData, "toon", "check-dependencies");
+    expect(out).toMatch(/dependencies\(direction,path/);
+    expect(out).toContain("outgoing");
+    expect(out).toContain("incoming");
+    expect(out).toContain("Token Savings");
+    // A JSON fallback would pretty-print with 2-space indented braces; TOON rows should not.
+    expect(() => JSON.parse(out)).toThrow();
+  });
+
+  it("produces toon rows for explain (nested graph.nodes), not a JSON fallback", () => {
+    const explainData = {
+      filePath: "/workspace/src/index.ts",
+      graph: {
+        filePath: "/workspace/src/index.ts",
+        nodes: [{ id: "src/index.ts:foo", name: "foo", kind: 13 }],
+        edges: [],
+        hasCycle: false,
+      },
+      language: "typescript",
+      analysisTimeMs: 5,
+    };
+
+    const out = formatOutput(explainData, "toon", "explain");
+    expect(out).toContain("Token Savings");
+    expect(() => JSON.parse(out)).toThrow();
+  });
+
+  it("produces toon rows for check (unusedSymbols), not a JSON fallback", () => {
+    const checkData = {
+      filePath: "/workspace/src/index.ts",
+      relativePath: "src/index.ts",
+      unusedCount: 1,
+      unusedSymbols: [{ name: "foo", kind: "FunctionDeclaration", line: 1, isExported: true }],
+      totalExportedSymbols: 1,
+      unusedPercentage: 100,
+    };
+
+    const out = formatOutput(checkData, "toon", "check");
+    expect(out).toContain("Token Savings");
+    expect(() => JSON.parse(out)).toThrow();
+  });
+
+  it("falls back to JSON for cycles with no confirmed cycles (empty array, nothing to encode)", () => {
+    const cyclesData = {
+      filePath: "/workspace/src/index.ts",
+      relativePath: "src/index.ts",
+      cycleCount: 0,
+      confirmedCycles: [],
+    };
+
+    const out = formatOutput(cyclesData, "toon", "cycles");
+    expect(() => JSON.parse(out)).not.toThrow();
+  });
 });
 
 describe("formatOutput - markdown", () => {


### PR DESCRIPTION
## Summary
- `extractArrayForToon` only scanned top-level keys, so several commands silently fell back to pretty-printed JSON instead of TOON encoding with `--format toon`:
  - `check-dependencies` — arrays nested under `outgoing.dependencies` / `incoming.referencingFiles`
  - `explain` — arrays nested under `graph.nodes` / `graph.edges`
  - `check` — top-level key `unusedSymbols` wasn't in the known-key list
  - `cycles` — top-level key `confirmedCycles` wasn't in the known-key list
- Added `extractNestedArrayForToon` as a one-level-deep fallback, extended `TOON_ARRAY_KEYS`, and kept the existing `check-dependencies`-specific tagging (`direction: outgoing|incoming`) as a higher-priority path so it isn't shadowed by the generic fallback.

## Test plan
- [x] `npx vitest run tests/cli/formatter.test.ts` — 30/30 passing (3 new regression tests: `explain` nested, `check` unusedSymbols, `cycles` empty-array-still-falls-back-to-json)
- [x] `npx eslint src/cli/formatter.ts tests/cli/formatter.test.ts` — clean
- [x] Manually verified via `node dist/graph-it.js <cmd> --format toon` for `check-dependencies`, `explain`, `check`, `cycles`, `trace`, `path-in`, `architecture`