### PR TITLE
feat(graph-it-live): add new plugin for dependency and architecture analysis

### DIFF
--- a/.github/workflows/sync-agent-plugin-version.yml
+++ b/.github/workflows/sync-agent-plugin-version.yml
@@ -1,0 +1,40 @@
+name: Sync Agent Plugin Version
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_run:
+    workflows: ['Publish (Selective)']
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.x'
+
+      - name: Sync manifests with npm latest
+        run: node scripts/sync-agent-plugin-version.mjs
+
+      - name: Commit and push changes
+        run: |
+          if git diff --quiet -- plugins/graph-it-live; then
+            echo 'Plugin manifests are already current.'
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add plugins/graph-it-live
+          git commit -m 'chore(plugin): sync version with published CLI'
+          git push origin HEAD:main

--- a/.gitignore
+++ b/.gitignore
@@ -181,6 +181,9 @@ docs/AGENT_*
 codemaps/
 
 mcp.json
+!plugins/
+!plugins/graph-it-live/
+!plugins/graph-it-live/mcp.json
 
 # Playwright files
 playwright-report/

--- a/README.md
+++ b/README.md
@@ -209,7 +209,22 @@ For VS Code, add `.vscode/mcp.json`:
 }
 ```
 
-The same `graph-it serve` command works with Cursor, Claude Desktop, Windsurf, and Antigravity. See the [CLI/MCP documentation](docs/CLI.md) for client-specific configuration and environment variables.
+For Cursor, use `.cursor/mcp.json` with the same server definition under `mcpServers` instead of `servers`. The same `graph-it serve` command works with Claude Desktop, Claude Code, Windsurf, and Antigravity. See the [CLI/MCP documentation](docs/CLI.md) for client-specific configuration and environment variables.
+
+For Codex CLI:
+
+```bash
+codex mcp add graph-it-live --env WORKSPACE_ROOT=/path/to/project -- graph-it serve
+```
+
+### Portable agent plugin
+
+The [`plugins/graph-it-live/`](plugins/graph-it-live/) directory is an Agent Plugin package for
+Claude Code, GitHub Copilot, Cursor, VS Code, and Codex. It contains the portable `plugin.json`,
+`mcp.json`, and the four Graph-It-Live skills from [magic5644/skills](https://github.com/magic5644/skills),
+plus native manifests for Claude Code and Codex. Install that directory with the client’s plugin
+installer. The MCP entry resolves `@magic5644/graph-it-live@latest`, keeping the CLI and MCP server
+in the same npm release; a workflow synchronizes the plugin manifest version after each npm publish.
 
 ### Agent skill
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1243,7 +1243,7 @@ Launches the full 22-tool MCP server process on `stdio`. The server:
 # Claude Code CLI (adds to your Claude config)
 claude mcp add graph-it -- graph-it serve
 
-# VS Code / Cursor (.vscode/mcp.json or .cursor/mcp.json)
+# VS Code (.vscode/mcp.json)
 {
   "servers": {
     "graph-it-live": {
@@ -1254,6 +1254,29 @@ claude mcp add graph-it -- graph-it serve
     }
   }
 }
+
+# Cursor (.cursor/mcp.json)
+{
+  "mcpServers": {
+    "graph-it-live": {
+      "type": "stdio",
+      "command": "graph-it",
+      "args": ["serve"],
+      "env": { "WORKSPACE_ROOT": "${workspaceFolder}" }
+    }
+  }
+}
+
+# Codex CLI
+codex mcp add graph-it-live --env WORKSPACE_ROOT=/path/to/your/project -- graph-it serve
+
+# Codex config (~/.codex/config.toml or .codex/config.toml)
+[mcp_servers.graph-it-live]
+command = "graph-it"
+args = ["serve"]
+
+[mcp_servers.graph-it-live.env]
+WORKSPACE_ROOT = "/path/to/your/project"
 
 # Claude Desktop (~/Library/Application Support/Claude/claude_desktop_config.json)
 {
@@ -1266,6 +1289,11 @@ claude mcp add graph-it -- graph-it serve
   }
 }
 ```
+
+For a single installation that bundles the MCP server and Graph-It-Live
+skills across compatible clients, use the [portable Agent Plugin](../plugins/graph-it-live/).
+Its MCP entry resolves `@magic5644/graph-it-live@latest`; the repository workflow
+keeps its manifest version aligned with the latest npm CLI release.
 
 **Environment variables:**
 

--- a/plugins/graph-it-live/.claude-plugin/plugin.json
+++ b/plugins/graph-it-live/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "graph-it-live",
+  "displayName": "Graph-It-Live",
+  "version": "1.14.1",
+  "description": "Dependency, call-graph, impact, and architecture analysis for codebases.",
+  "author": {
+    "name": "Graph-It-Live Team",
+    "url": "https://github.com/magic5644"
+  },
+  "repository": "https://github.com/magic5644/Graph-It-Live",
+  "license": "MIT",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/graph-it-live/.codex-plugin/plugin.json
+++ b/plugins/graph-it-live/.codex-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "graph-it-live",
+  "version": "1.14.1",
+  "description": "Dependency, call-graph, impact, and architecture analysis for codebases.",
+  "author": {
+    "name": "Graph-It-Live Team",
+    "url": "https://github.com/magic5644"
+  },
+  "homepage": "https://github.com/magic5644/Graph-It-Live",
+  "repository": "https://github.com/magic5644/Graph-It-Live",
+  "license": "MIT",
+  "keywords": ["dependencies", "call-graph", "architecture", "mcp"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Graph-It-Live",
+    "shortDescription": "Explore dependencies and call graphs.",
+    "longDescription": "Analyze dependencies, symbols, call paths, impact, and architecture from your coding agent.",
+    "developerName": "Graph-It-Live Team",
+    "category": "Developer Tools",
+    "capabilities": ["Read"],
+    "websiteURL": "https://github.com/magic5644/Graph-It-Live",
+    "defaultPrompt": [
+      "Show the dependency path to this file.",
+      "Trace calls from this symbol.",
+      "Find the impact of changing this function."
+    ]
+  }
+}

--- a/plugins/graph-it-live/.mcp.json
+++ b/plugins/graph-it-live/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "graph-it-live": {
+      "command": "npx",
+      "args": ["-y", "@magic5644/graph-it-live@latest", "serve"]
+    }
+  }
+}

--- a/plugins/graph-it-live/README.md
+++ b/plugins/graph-it-live/README.md
@@ -1,0 +1,26 @@
+# Graph-It-Live agent plugin
+
+This portable Agent Plugin bundles the Graph-It-Live MCP server and the
+Graph-It-Live skills (`graph-it-live`, `onboarding-express`, `dead-code-hunter`,
+and `pr-review`) from [magic5644/skills](https://github.com/magic5644/skills).
+
+Install the plugin from its repository with the installation mechanism provided
+by your client. Agent Plugins compatible clients use `plugin.json`, `mcp.json`,
+and `skills/`; Claude Code and Codex also find their native manifests in
+`.claude-plugin/` and `.codex-plugin/`.
+
+Examples:
+
+- Claude Code: `claude --plugin-dir ./plugins/graph-it-live` (or install it from a marketplace).
+- GitHub Copilot CLI: `copilot plugin install ./plugins/graph-it-live`.
+- VS Code: run **Chat: Install Plugin From Source** and select this directory.
+- Cursor: install the directory from the Plugins panel.
+- Codex: add the directory to a configured plugin marketplace, then use `/plugins`.
+
+The MCP command deliberately uses `@latest`, so the CLI and its bundled MCP
+server are always resolved from the same published npm package. The CLI also
+checks for updates and reports `graph-it update`; run `scripts/update-cli.sh`
+when an explicit update is needed.
+
+The three plugin manifests carry the current published CLI version. The
+repository workflow updates them automatically after an npm publish.

--- a/plugins/graph-it-live/mcp.json
+++ b/plugins/graph-it-live/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "graph-it-live": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@magic5644/graph-it-live@latest", "serve"]
+    }
+  }
+}

--- a/plugins/graph-it-live/plugin.json
+++ b/plugins/graph-it-live/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "graph-it-live",
+  "version": "1.14.1",
+  "description": "Dependency, call-graph, impact, and architecture analysis for codebases.",
+  "author": {
+    "name": "Graph-It-Live Team",
+    "url": "https://github.com/magic5644"
+  },
+  "homepage": "https://github.com/magic5644/Graph-It-Live",
+  "repository": "https://github.com/magic5644/Graph-It-Live",
+  "license": "MIT",
+  "keywords": ["dependencies", "call-graph", "architecture", "mcp"]
+}

--- a/plugins/graph-it-live/scripts/update-cli.sh
+++ b/plugins/graph-it-live/scripts/update-cli.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if command -v graph-it >/dev/null 2>&1; then
+  exec graph-it update
+fi
+
+exec npx -y @magic5644/graph-it-live@latest update

--- a/plugins/graph-it-live/skills/dead-code-hunter/SKILL.md
+++ b/plugins/graph-it-live/skills/dead-code-hunter/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: dead-code-hunter
+description: |
+  Scan the dependency graph for orphan nodes (uncalled symbols and unreferenced files) and produce
+  a safe, ranked deletion plan. Use this skill whenever the user asks about dead code, unused code,
+  orphan symbols, unreferenced files, code cleanup, or code hygiene — even if they don't say "dead code"
+  explicitly. Also trigger for: "remove unused exports", "find unused functions", "find unused classes",
+  "clean up before a refactor", "clean up after removing a feature", "what code is never called",
+  "what files are never imported", "before merging this PR let me clean up", "reduce bundle size by
+  removing dead code", supprimer code mort, code inutilisé, nettoyer le code, symboles non utilisés,
+  exports inutiles.
+argument-hint: 'Which project, folder, or file do you want to scan for dead code?'
+context: fork
+---
+
+# Dead Code Hunter
+
+Systematic scan of the dependency graph to surface orphan symbols and unreferenced files.
+Produces a ranked, safety-annotated deletion plan powered by Graph-It-Live.
+
+## Requires
+
+Graph-It-Live CLI installed and indexed:
+
+```bash
+npm install -g @magic5644/graph-it-live
+graph-it scan
+```
+
+Check updates:
+
+```bash
+graph-it update
+```
+
+## When to Use
+
+- Before a major refactor — clean up before you restructure
+- After removing a feature — confirm nothing is left dangling
+- Periodic code hygiene pass on a growing codebase
+- Before onboarding a new developer — reduce noise in the codebase
+
+---
+
+## Workflow — Step by Step
+
+### Step 1 — Build/refresh the index
+
+```bash
+graph-it scan
+```
+
+The reverse lookup index (who imports what, who calls what) is always built automatically — no extra flags needed.
+
+For a large or unfamiliar workspace, take a compact baseline before scanning:
+
+```bash
+graph-it architecture --format toon
+```
+
+Use it to identify packages, public entry points, and generated areas that require review rather than automatic deletion.
+
+### Step 2 — Run workspace-wide dead code scan
+
+```bash
+graph-it check                     # scan entire workspace
+graph-it check src/                # scope to a specific folder
+graph-it check src/ --format toon  # toon format saves 30-60% tokens
+```
+
+Or via the MCP tool directly (supports `scopePath` param):
+
+```bash
+graph-it tool scan_dead_code
+graph-it tool scan_dead_code --scopePath=/abs/path/src
+graph-it tool scan_dead_code --scopePath=/abs/path/src --format=toon
+```
+
+This returns a ranked list of dead symbols and ghost files in a single pass. **No per-file loop needed for discovery — use Step 3 to confirm high-priority candidates before deleting.**
+
+---
+
+### Step 3 — Per-file confirmation (avoid false positives)
+
+`scan_dead_code` uses static analysis. A symbol may be called **dynamically** or **from outside the indexed workspace** (e.g. a published library). For high-confidence verification on specific candidates:
+
+```bash
+# Who calls this symbol? (0 callers = confirmed dead)
+graph-it tool get_symbol_callers --filePath=<absolutePath> --symbolName=<symbol>
+
+# Is this file imported by anything? (0 refs + not an entry point = ghost file)
+graph-it tool find_referencing_files --targetPath=<absolutePath>
+```
+
+- **0 callers** → confirmed dead code candidate
+- **1+ callers** → false positive, discard
+- **Only test-file callers** → flag as "test-only symbol", handle separately
+
+A ghost file may contain multiple symbols — mark the entire file for deletion rather than symbol-by-symbol.
+
+---
+
+### Step 4 — Rank candidates by deletion safety
+
+Apply this risk classification:
+
+| Risk Level | Criteria | Action |
+|---|---|---|
+| **Safe** | 0 callers, 0 referencing files, not a public API export | Delete freely |
+| **Ghost file** | 0 referencing files, not an entry point | Delete entire file |
+| **Likely safe** | 0 callers confirmed, file has other live symbols | Remove symbol, keep file |
+| **Review first** | Symbol is exported from a barrel (`index.ts`) | Check if barrel is consumed externally |
+| **Do not delete** | Dynamic call patterns detected (`eval`, string-based dispatch) | Flag only |
+| **Test-only** | Only called from test files | Evaluate — may be intentional |
+
+---
+
+## Output Format
+
+Produce a **Deletion Plan** in this format:
+
+---
+
+### Dead Code Scan Report
+
+**Scanned**: `<N>` files | **Candidates found**: `<M>` symbols + `<K>` ghost files
+
+#### Ghost Files (entire file can be deleted)
+
+| File | Last modified | Reason |
+|------|--------------|--------|
+| `src/utils/oldMigration.ts` | 2022-03-11 | 0 imports, 0 callers, not an entry point |
+
+**Suggested command:**
+```bash
+# Review first, then:
+rm src/utils/oldMigration.ts
+```
+
+#### Orphan Symbols — Safe to Remove
+
+| Symbol | File | Kind | Callers |
+|--------|------|------|---------|
+| `formatLegacyCurrency` | `src/utils/format.ts` | function | 0 |
+| `MD5Hash` | `src/services/auth.ts` | function | 0 |
+
+#### Orphan Symbols — Review First
+
+| Symbol | File | Risk | Note |
+|--------|------|------|------|
+| `createReport` | `src/api/index.ts` | Barrel export | Check if consumed by external packages |
+
+#### Test-Only Symbols
+
+| Symbol | File | Test callers |
+|--------|------|-------------|
+| `mockPaymentGateway` | `src/mocks/payment.ts` | 3 test files |
+
+---
+
+### Recommended Deletion Order
+
+1. Ghost files first — highest impact, no surgical precision needed
+2. Orphan symbols in non-barrel files — safe, isolated changes
+3. Barrel exports — requires checking external consumers
+4. Test-only symbols — discuss with the team
+
+---
+
+## Safety Checklist Before Deleting
+
+- [ ] Re-run `graph-it scan` + `graph-it check` after any refactor that modified imports
+- [ ] Check if the project is a **published library** — unused exports may be part of the public API
+- [ ] Check `package.json` `exports` field — symbols exported via package entry points are always live
+- [ ] Run the test suite after each deletion batch to catch dynamic usage not visible to static analysis
+- [ ] Commit in small batches — one file or one symbol group per commit for easy revert
+
+---
+
+## Quick Scan (Single File or Folder)
+
+```bash
+graph-it scan                                                                     # build/refresh index
+graph-it check src/utils/format.ts                                               # per-file unused symbols
+graph-it check src/utils/                                                        # scoped folder scan
+graph-it tool find_unused_symbols --filePath=/abs/path/src/utils/format.ts       # same as above, MCP tool
+```
+
+---
+
+## Limitations & Future Improvements
+
+- **Dynamic dispatch** (`obj[methodName]()`, `require(variable)`) is invisible to static analysis — always review before deleting
+- **Monorepos**: scan per package, not at root, to avoid cross-package false positives
+- **Framework magic**: decorators (`@Component`, `@Injectable`) may make symbols appear unused but they're resolved at runtime — exclude framework entry files from the scan
+- **`graph-it check` is the native single-pass dead code scanner** — `graph-it check` (no args) runs `scan_dead_code` across the whole workspace. Use `graph-it check <folder>` to scope by directory.
+
+## Related Skills
+
+- **graph-it-live** — lower-level access to the full dependency intelligence toolkit: impact analysis, call graphs, codemaps, and more. Use it when you want to explore rather than clean up.
+- **onboarding-express** — run a codebase architecture tour before (or after) the dead code sweep, especially when a new developer is joining.
+- **pr-review** — review a cleanup diff before merge and inspect its impact evidence.

--- a/plugins/graph-it-live/skills/graph-it-live/SKILL.md
+++ b/plugins/graph-it-live/skills/graph-it-live/SKILL.md
@@ -1,0 +1,465 @@
+---
+name: graph-it-live
+description: |
+  Analyze code dependencies, call graphs, and architecture using the graph-it CLI. Use this skill
+  whenever the user wants to understand how their code is connected — even if they don't say
+  "dependency graph" explicitly. Trigger for: "what calls this function", "who uses this class",
+  "is it safe to delete X", "what breaks if I change Y", "show me the architecture", "trace the
+  execution from main", "find circular imports", "give me an overview of this module", "what imports
+  this file", "impact analysis", "refactoring safety", "review this PR", "review this diff",
+  "is this change risky", breaking changes, unused exports, dead code detection, codemap, file logic,
+  module resolution, graph-it, dependency graph, reverse dependencies.
+argument-hint: 'What do you want to analyze in your codebase?'
+context: fork
+---
+
+# Graph-It-Live
+
+AI-first dependency intelligence CLI for codebase analysis.
+Analyze dependencies, call graphs, symbols, impact, and architecture from any agent-compatible IDE or CLI.
+
+## When to Use
+
+- Analyze file dependencies and imports
+- Trace function execution across files
+- Find all callers of a symbol (function, class, method)
+- Detect breaking changes before refactoring
+- Find unused exports / dead code
+- Generate a codemap (structural overview) of any file
+- Analyze intra-file call hierarchy and logic flow
+- Crawl the full dependency tree from an entry point
+- Find all files that import a given file (reverse lookup)
+- Detect circular dependencies / cycles
+- Check impact of changing a function signature
+- Get a workspace architecture overview
+- Review a Git diff for breaking signatures, impact, cycles, and test candidates
+
+## Quick Start — Installation
+
+**Requires Node.js v22+.**
+
+```bash
+# Install globally
+npm install -g @magic5644/graph-it-live
+
+# Or run without installing
+npx @magic5644/graph-it-live <command>
+```
+
+After global install, `graph-it` is available on PATH. Verify:
+
+```bash
+graph-it --version
+```
+
+Check updates:
+
+```bash
+graph-it update
+```
+
+## Supported Languages
+
+TypeScript, JavaScript, Python, Rust, C#, Go, Java, Vue, Svelte, GraphQL.
+
+## CLI Commands Reference
+
+### First Full Codebase Pass (Agent Bootstrap)
+
+Use this workflow at the start of broad tasks (feature work, audits, refactors, onboarding):
+
+```bash
+# 1) Build/refresh the index
+graph-it scan
+
+# 2) Generate the agent-optimized global map
+graph-it architecture --format toon
+```
+
+This TOON result is the **primary context** for agents: `nodes`, `edges`, `failedFiles`, `nodeCount`, `edgeCount`.
+
+Only after that, run targeted analysis:
+
+```bash
+graph-it tool generate_codemap --filePath=/abs/path/to/file.ts
+graph-it tool query_call_graph --filePath=/abs/path/to/file.ts --symbolName=mySymbol --depth=3
+graph-it tool analyze_file_logic --filePath=/abs/path/to/file.ts
+```
+
+For open-ended architecture questions, use natural language query:
+
+```bash
+graph-it query "how does authentication flow through this project"
+```
+
+If the global graph is too large:
+
+```bash
+graph-it architecture --maxFiles 300 --format toon
+```
+
+Visual option for humans (not for LLM context):
+
+```bash
+graph-it architecture --format mermaid
+```
+
+### Index the Workspace
+
+**Run `scan` before analysis commands** to build the dependency index. Most analysis commands depend on it.
+The `review-pr` command is the exception: it indexes automatically, so do not run a
+separate `scan` first unless you need to refresh the index for another command.
+
+```bash
+graph-it scan
+```
+
+Re-run after significant file changes to refresh the index.
+
+### Workspace Overview
+
+```bash
+graph-it summary                   # Full workspace overview
+graph-it summary src/api.ts        # Per-file codemap
+```
+
+The per-file codemap returns: exports, internals, dependencies, dependents, call flow, cycles.
+
+### Trace Execution Flow
+
+Trace the complete call chain starting from a function:
+
+```bash
+graph-it trace src/index.ts#main
+graph-it trace src/auth.ts#validateToken
+```
+
+Format: `<filePath>#<functionName>`. Use absolute or relative paths.
+
+### Analyze File Logic
+
+Show the intra-file call hierarchy — which functions call which, in what order:
+
+```bash
+graph-it explain src/server.ts
+```
+
+Returns entry points, call tree, and internal cycles.
+
+### Dependency Graph
+
+Crawl the full dependency tree from an entry file:
+
+```bash
+graph-it path src/index.ts
+```
+
+Shows all transitive imports and detects circular dependencies.
+
+### Find Unused Exports
+
+Detect dead code — exported symbols that no other file imports:
+
+```bash
+graph-it check src/api.ts
+```
+
+Workspace-wide dead code scan:
+
+```bash
+graph-it check
+```
+
+Generate a markdown wiki from call graph relationships:
+
+```bash
+graph-it wiki
+```
+
+### Review a Pull Request or Diff
+
+Use the dedicated command for deterministic local diff analysis. It requires a Git base ref and
+indexes automatically:
+
+```bash
+graph-it review-pr --base origin/main --format markdown
+graph-it review-pr --base origin/main --head feature/my-change --depth 3 --max-files 200 --format toon
+```
+
+Read `risk`, `score`, `limitations`, and `isPartial` before making a merge recommendation:
+
+- `low`, `medium`, `high`, `critical` classify the highest-risk changed symbol.
+- `isPartial: true` means file, parser, or impact-depth limits prevented a complete result.
+- No breaking signature does **not** prove that a behavioral change is safe; inspect tests and affected flows.
+
+Use the **pr-review** skill for the full review workflow and GitHub Actions gate.
+
+### Output Formats
+
+All commands support `--format`:
+
+| Format     | Best for                                     |
+|------------|----------------------------------------------|
+| `text`     | Quick human reading in the terminal (default) |
+| `json`     | Programmatic processing, scripts             |
+| `toon`     | AI consumption — same data as JSON but 30–60% fewer tokens |
+| `markdown` | Embedding structured output in a document   |
+| `mermaid`  | **Visual diagrams shown to a human** — renders as a flowchart in VS Code, GitHub, Obsidian, or any Markdown preview. Only supported by `trace` and `path`. |
+
+**Choosing the right format:**
+- Processing output inside an agent or script → `--format toon`
+- Showing a call graph or dependency tree to a human in chat or a preview pane → `--format mermaid`
+- All other programmatic use → `--format json`
+
+```bash
+graph-it summary src/api.ts --format toon          # AI reads it
+graph-it trace src/index.ts#main --format mermaid  # human sees the diagram
+graph-it path src/index.ts --format mermaid        # dependency tree as flowchart
+```
+
+## Advanced: MCP Tool Invocation
+
+`graph-it tool` can invoke **21 analysis tools** directly from CLI.
+Server-management tool `set_workspace` is MCP-server only and intentionally excluded from `graph-it tool`.
+
+```bash
+graph-it tool --list                    # List all available tools
+graph-it tool <tool_name> [--params]    # Invoke a specific tool
+```
+
+### Available MCP Tools
+
+| Tool | Description |
+|------|-------------|
+| `analyze_dependencies` | Direct imports and exports of a file |
+| `crawl_dependency_graph` | Full dependency tree from an entry file |
+| `find_referencing_files` | All files that import a given file (reverse lookup) |
+| `expand_node` | Expand a node to discover dependencies beyond known paths |
+| `parse_imports` | Parse raw import statements without path resolution |
+| `verify_dependency_usage` | Check whether a specific import is actually used |
+| `resolve_module_path` | Resolve a module specifier to an absolute file path |
+| `get_symbol_graph` | Symbol-level dependencies within a file |
+| `find_unused_symbols` | Dead code detection — unused exported symbols |
+| `get_symbol_dependents` | All symbols that depend on a specific symbol |
+| `trace_function_execution` | Full recursive call chain from a function |
+| `get_symbol_callers` | All callers of a symbol (O(1) instant lookup) |
+| `analyze_breaking_changes` | Detect breaking changes when modifying function signatures |
+| `get_impact_analysis` | Full impact: callers + breaking changes combined |
+| `get_index_status` | Current state of the dependency index |
+| `invalidate_files` | Flush cache for specific files after modifications |
+| `rebuild_index` | Rebuild the entire dependency index from scratch |
+| `analyze_file_logic` | Intra-file call hierarchy and code flow |
+| `generate_codemap` | Comprehensive structural overview of any source file |
+| `query_call_graph` | BFS callers/callees via the SQLite call graph index |
+| `scan_dead_code` | Workspace-wide dead code scan across all files |
+
+> `query_natural_language` and `generate_wiki` are available as dedicated CLI commands (`graph-it query`, `graph-it wiki`) and as MCP server tools, but **not** in `graph-it tool --list`.
+> Run `graph-it tool --list` for the installed CLI's authoritative tool inventory; releases can add tools over time.
+
+### Tool Invocation Examples
+
+```bash
+# Analyze a single file's dependencies
+graph-it tool analyze_dependencies --filePath=/abs/path/to/file.ts
+
+# Find all files importing a specific file
+graph-it tool find_referencing_files --targetPath=/abs/path/to/file.ts
+
+# Get all callers of a symbol
+graph-it tool get_symbol_callers --filePath=/abs/path/to/file.ts --symbolName=myFunction
+
+# Full impact analysis
+graph-it tool get_impact_analysis --filePath=/abs/path/to/file.ts --symbolName=myFunction
+
+# Detect breaking changes (use --args JSON for large content payloads)
+graph-it tool --args '{"filePath":"/abs/path/to/file.ts","symbolName":"myFunction","oldContent":"...old source...","newContent":"...new source..."}' analyze_breaking_changes
+
+# Generate codemap
+graph-it tool generate_codemap --filePath=/abs/path/to/file.ts
+
+# Query call graph (BFS) — requires filePath; depth param is 'depth', NOT 'maxDepth'
+graph-it tool query_call_graph --filePath=/abs/path/server.ts --symbolName=handleRequest --depth=3
+
+# Workspace-wide dead code scan (across all files, unlike find_unused_symbols which is per-file)
+graph-it tool scan_dead_code
+
+# Natural-language architecture question
+graph-it query "what calls the MCP worker and how"
+
+# Generate wiki docs from call graph
+graph-it wiki --output docs/wiki
+```
+
+**Important:** Tool `--filePath` arguments require **absolute paths**.
+
+## Critical Rules (NEVER)
+
+- **NEVER** call analysis tool commands without running `graph-it scan` first — all tools depend on the index. `review-pr` is the sole exception because it indexes automatically.
+- **NEVER** use relative paths with `--filePath` — all file args must be absolute paths
+- **NEVER** confuse `find_unused_symbols` (per-file) with `scan_dead_code` (workspace-wide); use `scan_dead_code` when you need a project-wide dead code report
+- **NEVER** use `--maxDepth` with `query_call_graph` — the correct parameter is `--depth`
+- **NEVER** invoke `set_workspace` from the CLI — it is MCP server only; the CLI uses `WORKSPACE_ROOT` env var or `graph-it scan` from the project root
+- **NEVER** use `--format json` for large dependency graphs sent to an LLM — use `--format toon` to save 30-60% tokens
+- **NEVER** pass `--filePath` to `find_referencing_files`; the expected parameter is `--targetPath`
+- **NEVER** call `analyze_breaking_changes` with `--newFilePath`; it expects `oldContent` / `newContent`
+
+## MCP Server Mode
+
+Launch as an MCP server for AI client integration (no VS Code required):
+
+```bash
+graph-it serve
+```
+
+MCP server currently exposes **24 tools**:
+- 21 analysis tools from `graph-it tool --list`
+- `set_workspace` (server management)
+- `query_natural_language`
+- `generate_wiki`
+
+### MCP Client Configuration
+
+**VS Code / Cursor** (`.vscode/mcp.json` or `.cursor/mcp.json`):
+
+```json
+{
+  "servers": {
+    "graph-it-live": {
+      "type": "stdio",
+      "command": "graph-it",
+      "args": ["serve"],
+      "env": { "WORKSPACE_ROOT": "${workspaceFolder}" }
+    }
+  }
+}
+```
+
+**Claude Desktop** (`~/.config/claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "graph-it-live": {
+      "command": "graph-it",
+      "args": ["serve"],
+      "env": { "WORKSPACE_ROOT": "/path/to/project" }
+    }
+  }
+}
+```
+
+**Claude Code CLI:**
+
+```bash
+claude mcp add graph-it -- graph-it serve
+```
+
+**Windsurf** (`~/.codeium/windsurf/mcp_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "graph-it-live": {
+      "command": "graph-it",
+      "args": ["serve"],
+      "env": { "WORKSPACE_ROOT": "${workspaceFolder}" }
+    }
+  }
+}
+```
+
+## VS Code Extension (Alternative)
+
+Graph-It-Live is also a VS Code extension with native LM Tools for Copilot Agent mode (no MCP setup needed).
+
+Install from Marketplace: search "Graph-It-Live" in Extensions (`Ctrl+Shift+X`).
+
+Enable MCP server in extension: set `graph-it-live.enableMcpServer` to `true` in VS Code settings.
+
+## Common Workflows
+
+**"What breaks if I change this function?"**
+
+```bash
+graph-it scan
+graph-it tool get_impact_analysis --filePath=/abs/path/src/auth/index.ts --symbolName=myFunction
+```
+
+**"Give me an overview of this module"**
+
+```bash
+# Outgoing: what this file imports and calls
+graph-it summary src/auth/index.ts --format toon
+
+# Incoming: who depends on this file
+graph-it tool find_referencing_files --targetPath=/abs/path/src/auth/index.ts
+```
+
+Always check both directions: knowing what a module calls (outgoing) and who calls it (incoming) gives the full picture of its role and blast radius.
+
+**"Find dead code in my project"**
+
+```bash
+# Outgoing: symbols this file exports that nobody imports
+graph-it check src/utils.ts
+graph-it tool find_unused_symbols --filePath=/abs/path/src/utils.ts
+
+# Incoming: confirm the file itself is not orphaned (nothing imports it)
+graph-it tool find_referencing_files --targetPath=/abs/path/src/utils.ts
+```
+
+Both directions are needed: a file can export symbols that appear used internally while still being completely unreachable from the rest of the project.
+
+**"Trace the execution from main()"**
+
+```bash
+graph-it trace src/index.ts#main --format mermaid
+```
+
+**"Are there circular dependencies?"**
+
+```bash
+graph-it path src/index.ts
+```
+
+Cycles are auto-detected and reported.
+
+**"Who calls this function across the project?"**
+
+```bash
+graph-it tool get_symbol_callers --filePath=/abs/path/src/utils/formatDate.ts --symbolName=formatDate
+```
+
+**"Answer architecture questions in natural language"**
+
+```bash
+graph-it query "how does the dependency index get rebuilt"
+```
+
+**"Generate a wiki for onboarding"**
+
+```bash
+graph-it wiki --output wiki
+```
+
+**"Review a pull request before merge"**
+
+```bash
+graph-it review-pr --base origin/main --format markdown
+```
+
+Escalate every high/critical symbol with `get_impact_analysis` or `get_symbol_callers`. Treat any
+reported limitation as a manual-review item.
+
+## Update
+
+```bash
+graph-it update
+```
+
+## Related Skills
+
+- **dead-code-hunter** — uses Graph-It-Live under the hood to produce a full project-wide dead code deletion plan with safety rankings. Use it when you want to delete, not just inspect.
+- **onboarding-express** — runs a structured Graph-It-Live tour of any codebase for a new developer: entry points, business logic, most complex module, and critical path diagram.
+- **pr-review** — reviews a Git diff locally or in GitHub Actions, then turns Graph-It-Live evidence into merge-ready findings.
+- **skill-manager** — manage installed skills interactively (list/uninstall). Useful when curating or cleaning a local skill stack.

--- a/plugins/graph-it-live/skills/onboarding-express/SKILL.md
+++ b/plugins/graph-it-live/skills/onboarding-express/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: onboarding-express
+description: |
+  AI-guided architectural tour of any codebase — entry points, business logic, and the most complex
+  module in one structured pass, powered by Graph-It-Live. Use this skill whenever someone is new to
+  a codebase or wants a quick orientation. Trigger for: "I just joined this team", "explain this repo
+  to me", "give me a project overview", "where is the main logic", "what is the entry point",
+  "I need to understand the architecture before starting", "walk me through this codebase",
+  "which module is the most complex", "find the business logic", "I'm about to refactor and need
+  to understand the structure first", onboarding, project walkthrough, architecture tour,
+  découvrir le projet, visite guidée, point d'entrée, logique métier, module complexe.
+argument-hint: 'Which project or folder do you want to explore?'
+context: fork
+---
+
+# Onboarding Express
+
+AI-guided architectural tour of any codebase for a new developer.
+Powered by Graph-It-Live — extracts entry points, business logic, and the most complex module in one structured pass.
+
+## Requires
+
+Graph-It-Live CLI installed and indexed:
+
+```bash
+npm install -g @magic5644/graph-it-live
+graph-it scan
+```
+
+## When to Use
+
+- A developer joins the team and needs a codebase overview
+- You want to understand an unfamiliar project quickly
+- You need to identify where business logic lives before a refactor
+- You want to find the most complex/risky module before making changes
+
+---
+
+## Workflow — Step by Step
+
+### Step 1 — Build the index
+
+```bash
+graph-it scan
+```
+
+Always run first. All subsequent commands depend on it.
+
+---
+
+### Step 2 — Workspace overview
+
+```bash
+graph-it architecture --format toon
+```
+
+Parse the output to identify:
+- Top-level files and their role
+- Candidate **entry point files** (look for: `index`, `main`, `app`, `server`, `cli`, `bootstrap`, `startup` in filenames or in exported symbols)
+- Candidate **business logic folders** (look for: `services`, `domain`, `core`, `usecases`, `business`, `handlers`, `controllers`)
+
+If the graph is too large, restrict the initial pass:
+
+```bash
+graph-it architecture --maxFiles 300 --format toon
+```
+
+---
+
+### Step 3 — Identify the 3 main entry points
+
+For each candidate entry file (max 5), run both directions:
+
+```bash
+# Outgoing: what this file calls and imports
+graph-it explain <filePath> --format toon
+
+# Incoming: who imports/calls this file
+graph-it tool find_referencing_files --targetPath=<absolutePath>
+```
+
+Rank by:
+1. **Highest fan-out** (outgoing) + **0 fan-in** (nothing imports it) → true root entry points
+2. **High fan-out** + **few importers** → secondary entry points (e.g., CLI, alternative bootstraps)
+3. **High fan-in** (imported by many) + **exports many symbols** → shared core, not an entry point
+4. Presence of bootstrap / initialization patterns in the call tree
+
+Select the **top 3** and for each, produce:
+
+> **Entry point `<filename>`** — `<one-line role description>`
+> Called by: `<callers or "root — no callers (true entry point)">` 
+> Calls into: `<top 3–5 downstream modules>`
+
+---
+
+### Step 4 — Locate the business logic
+
+For each candidate business logic file, run **both directions** to build a complete dependency picture:
+
+```bash
+# Outgoing: what this file exports, imports, and calls internally
+graph-it tool generate_codemap --filePath=<absolutePath> --format toon
+
+# Incoming: who depends on this file across the project
+graph-it tool find_referencing_files --targetPath=<absolutePath>
+```
+
+The combination of both tells you:
+- **generate_codemap** → what the file does (exported symbols, internal call depth, its own dependencies)
+- **find_referencing_files** → how central it is (how many other files rely on it)
+
+Look for files that score high on both axes: many exports **and** many importers. A file with rich exports but no importers is dead code; a file with many importers but few exports is a utility hub. The real business logic sits at the intersection.
+
+Pick the **1–3 files** with the highest combination of fan-in + exported symbol count. These are the business logic core.
+
+---
+
+### Step 5 — Find the most complex module
+
+For a representative sample of files (top 20 by size, or all files for small projects under 50 files), run:
+
+```bash
+graph-it tool analyze_file_logic --filePath=<absolutePath>
+```
+
+Score each file using this heuristic:
+
+| Signal | Weight |
+|---|---|
+| Internal call depth (max recursion level) | High |
+| Number of internal cycles (circular calls) | High |
+| Number of exported symbols | Medium |
+| Number of distinct callers (fan-in) | Medium |
+| Number of distinct callees (fan-out) | Medium |
+
+The file with the highest combined score is the **most complex module**.
+
+For an open-ended follow-up, use the natural-language query as a hypothesis generator, then
+verify the answer with the deterministic scores above:
+
+```bash
+graph-it query "which module has the deepest call stack and widest impact"
+```
+
+---
+
+### Step 6 — Trace the critical path
+
+From the highest-scored entry point, trace the full execution chain:
+
+```bash
+graph-it trace <entryFile>#<mainFunction> --format mermaid
+```
+
+Use `--format mermaid` here because the output is intended for a human — the Mermaid diagram renders as a visual flowchart in VS Code, GitHub, Obsidian, and most Markdown preview panes. For all other graph-it calls in this workflow, prefer `--format toon` (token-efficient, AI-readable).
+
+---
+
+## Output Format
+
+Synthesize steps 3–6 into this structured report:
+
+---
+
+### Project Tour — `<ProjectName>`
+
+**3 Main Entry Points**
+
+| # | File | Role | Type |
+|---|------|------|------|
+| 1 | `src/index.ts` | Application bootstrap, wires all modules | True entry (no callers) |
+| 2 | `src/api/router.ts` | HTTP routing, dispatches to controllers | Called by index.ts |
+| 3 | `src/cli.ts` | CLI interface, alternative entry point | True entry (no callers) |
+
+**Business Logic Core**
+
+| File | Exported Symbols | Referenced By |
+|------|-----------------|---------------|
+| `src/services/orderService.ts` | 12 | 8 files |
+| `src/domain/pricing.ts` | 7 | 5 files |
+
+**Most Complex Module**
+
+> `src/services/orderService.ts` — 4 levels of internal call depth, 2 internal cycles, imported by 8 files.
+> **Recommendation**: Any change here has high blast radius. Run `get_impact_analysis` before modifying.
+
+**Critical Path (Mermaid)**
+
+```mermaid
+<trace output here>
+```
+
+---
+
+## Tips
+
+- On a **monorepo**, scope the tour per package: `cd packages/api && graph-it scan` then repeat the workflow.
+- If the architecture graph returns too much data, lower `--maxFiles` or tour one package/folder at a time.
+- If indexing is incomplete, rerun `graph-it scan` from the package root and report the unanalysed area rather than guessing.
+- The "most complex module" heuristic is architectural, not cyclomatic. For line-level complexity, combine with a linter.
+- After the tour, run the **dead-code-hunter** skill to find safe cleanup targets before the new developer starts writing code — a clean codebase is much easier to onboard into.
+- For deeper call-graph questions ("what calls this function?", "what breaks if I change X?"), use the **graph-it-live** skill directly.
+- Before merging an onboarding-driven change, use **pr-review** to inspect its diff and static-impact limitations.

--- a/plugins/graph-it-live/skills/pr-review/SKILL.md
+++ b/plugins/graph-it-live/skills/pr-review/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: pr-review
+description: |
+  Review pull requests and Git diffs with Graph-It-Live risk, breaking-change, dependency-impact,
+  cycle, unused-export, and test-candidate evidence. Use when asked to review a PR, inspect a diff,
+  assess merge risk, check a branch before merging, create a Graph-It-Live review gate, or explain
+  review-pr results. Trigger for: "review this PR", "review this diff", "is this safe to merge",
+  "check merge risk", "analyze changed files", "PR review", "code review my branch", "revoir cette PR",
+  "analyser ce diff", "risque de merge".
+argument-hint: 'Which Git base ref or pull request diff should be reviewed?'
+context: fork
+---
+
+# Graph-It-Live PR Review
+
+Use deterministic local diff analysis first. Deepen only findings that need additional evidence.
+
+## Prerequisites
+
+```bash
+npm install -g @magic5644/graph-it-live
+git fetch origin main
+```
+
+Run commands from the repository root. The CLI indexes automatically for `review-pr`.
+
+## Local Review Workflow
+
+### 1. Analyze the diff
+
+```bash
+graph-it review-pr --base origin/main --format markdown
+```
+
+Use explicit limits when needed:
+
+```bash
+graph-it review-pr --base origin/main --head HEAD --depth 3 --max-files 200 --format toon
+```
+
+- `--base` is required.
+- `--head` defaults to `HEAD`.
+- `--depth` limits transitive dependent traversal; use an integer from 1 to 10.
+- `--max-files` limits changed files; use an integer from 1 to 1000.
+- Use `--format markdown` for a human report; use `toon` or `json` for structured agent analysis.
+
+### 2. Interpret evidence before concluding
+
+The report includes a top-level `risk`, `score`, `changedFiles`, `symbols`, `limitations`, and `isPartial`.
+
+| Risk | Meaning | Review action |
+| --- | --- | --- |
+| `low` | No high-scoring static concern | Review behavioral changes and tests normally |
+| `medium` | Inspect changed symbol and direct dependents | Request focused validation when evidence is unresolved |
+| `high` | Breaking or broad-impact evidence | Block until compatibility, callers, and tests are addressed |
+| `critical` | Highest static risk | Block; require explicit mitigation and targeted verification |
+
+Never call a review complete when `isPartial` is `true` or `limitations` is non-empty. Limitations can
+mean unsupported file types, added/deleted/unreadable files, parser failures, unavailable cycle/unused
+analysis, configured file limits, or an impact traversal that reached its depth limit.
+
+No reported breaking signature does **not** establish behavioral safety. Static evidence supplements;
+it does not replace tests, security review, or domain review.
+
+### 3. Deepen high-risk findings
+
+Use absolute paths for all `graph-it tool` file parameters:
+
+```bash
+# Blast radius and known dependent symbols
+graph-it tool get_impact_analysis --filePath=/absolute/path/src/api.ts --symbolName=updateUser --format=toon
+
+# Direct callers for a specific symbol
+graph-it tool get_symbol_callers --filePath=/absolute/path/src/api.ts --symbolName=updateUser --format=toon
+
+# Broader caller/callee neighbourhood
+graph-it tool query_call_graph --filePath=/absolute/path/src/api.ts --symbolName=updateUser --depth=3 --format=toon
+
+# Understand a changed implementation and its local call flow
+graph-it tool generate_codemap --filePath=/absolute/path/src/api.ts --format=toon
+```
+
+Check conventional test candidates reported by `review-pr`, then inspect the actual tests. Missing test
+candidates mean manual test selection is required, not that testing is unnecessary.
+
+## Required Review Output
+
+Produce findings in this order:
+
+1. **Verdict** — approve, approve with follow-ups, or changes requested. State whether analysis was partial.
+2. **Blocking findings** — risk, file/symbol, concrete evidence, requested fix.
+3. **Non-blocking findings** — risk, evidence, and follow-up.
+4. **Test assessment** — existing candidates, missing coverage, checks still required.
+5. **Limitations** — every limitation verbatim or faithfully summarized; list the manual check that closes it.
+
+Do not invent runtime behavior from graph data. Cite the command output that supports each claim.
+
+## GitHub Actions Gate
+
+Use the published composite action in a consumer workflow:
+
+```yaml
+name: Graph-It Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: magic5644/Graph-It-Live/.github/actions/graph-it-review-gate@v1.13.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment: ${{ github.event.pull_request.head.repo.fork && 'false' || 'true' }}
+          fail-on-risk: high
+          max-depth: "3"
+          max-files: "200"
+```
+
+Action inputs:
+
+- `token` — required only when `comment: true`.
+- `base-ref` — optional; defaults to the pull request base SHA when available.
+- `comment` — updates a sticky pull-request comment; disable for fork PRs.
+- `fail-on-risk` — optional `high` or `critical` threshold; leave empty for an informative gate.
+- `cli-version` — optional npm version, tag, or range; empty installs `latest`.
+- `max-depth` and `max-files` — control bounded analysis.
+
+Action outputs: `risk`, `score`, `cli-version`.
+
+Use least privilege: remove `pull-requests: write` and set `comment: false` if comments are not needed.
+Do not expose write tokens to untrusted fork code.
+
+## Boundaries
+
+- Review `review-pr` as a Git-diff risk signal, not a replacement for unit, integration, security, or human domain review.
+- Verify changed non-JS/TS files manually when they appear in limitations; signature analysis supports TypeScript and JavaScript extensions.
+- Run `graph-it scan` before unrelated follow-up tool calls if the repository changed after the review run.
+- Use **graph-it-live** for architecture and impact questions outside a diff, and **dead-code-hunter** for an intentional cleanup sweep.

--- a/scripts/sync-agent-plugin-version.mjs
+++ b/scripts/sync-agent-plugin-version.mjs
@@ -1,0 +1,65 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import https from 'node:https';
+
+const packageName = '@magic5644/graph-it-live';
+const manifestPaths = [
+  'plugins/graph-it-live/plugin.json',
+  'plugins/graph-it-live/.codex-plugin/plugin.json',
+  'plugins/graph-it-live/.claude-plugin/plugin.json',
+];
+
+function isSemver(version) {
+  return /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version);
+}
+
+function fetchLatestVersion() {
+  return new Promise((resolve, reject) => {
+    const request = https.get(`https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`, (response) => {
+      if (response.statusCode !== 200) {
+        response.resume();
+        reject(new Error(`npm registry returned HTTP ${response.statusCode}`));
+        return;
+      }
+      let body = '';
+      response.setEncoding('utf8');
+      response.on('data', (chunk) => { body += chunk; });
+      response.on('end', () => {
+        try {
+          resolve(JSON.parse(body).version);
+        } catch {
+          reject(new Error('npm registry returned invalid JSON'));
+        }
+      });
+    }).on('error', reject);
+    request.setTimeout(10_000, () => request.destroy(new Error('npm registry request timed out')));
+  });
+}
+
+const args = process.argv.slice(2);
+const checkOnly = args.includes('--check');
+const requestedVersion = args.find((arg) => !arg.startsWith('--'));
+const version = requestedVersion ?? await fetchLatestVersion();
+
+if (!isSemver(version)) {
+  throw new Error(`Invalid plugin version: ${version}`);
+}
+
+const mismatches = [];
+for (const path of manifestPaths) {
+  const manifest = JSON.parse(await readFile(path, 'utf8'));
+  if (manifest.version !== version) mismatches.push(`${path}: ${manifest.version} -> ${version}`);
+  if (!checkOnly && manifest.version !== version) {
+    manifest.version = version;
+    await writeFile(path, `${JSON.stringify(manifest, null, 2)}\n`);
+  }
+}
+
+if (checkOnly && mismatches.length > 0) {
+  console.error(`Plugin manifests do not match ${packageName}@${version}:`);
+  console.error(mismatches.join('\n'));
+  process.exitCode = 1;
+} else if (mismatches.length > 0) {
+  console.log(`Updated plugin manifests to ${version}`);
+} else {
+  console.log(`Plugin manifests already match ${version}`);
+}

--- a/src/cli/commandHelp.ts
+++ b/src/cli/commandHelp.ts
@@ -291,7 +291,7 @@ MCP Client Configuration:
   Claude Code CLI:
     claude mcp add graph-it -- graph-it serve
 
-  VS Code / Cursor (.vscode/mcp.json):
+  VS Code (.vscode/mcp.json):
     {
       "servers": {
         "graph-it-live": {
@@ -302,6 +302,29 @@ MCP Client Configuration:
         }
       }
     }
+
+  Cursor (.cursor/mcp.json):
+    {
+      "mcpServers": {
+        "graph-it-live": {
+          "type": "stdio",
+          "command": "graph-it",
+          "args": ["serve"],
+          "env": { "WORKSPACE_ROOT": "\${workspaceFolder}" }
+        }
+      }
+    }
+
+  Codex CLI:
+    codex mcp add graph-it-live --env WORKSPACE_ROOT=/path/to/project -- graph-it serve
+
+  Codex config (~/.codex/config.toml or .codex/config.toml):
+    [mcp_servers.graph-it-live]
+    command = "graph-it"
+    args = ["serve"]
+
+    [mcp_servers.graph-it-live.env]
+    WORKSPACE_ROOT = "/path/to/project"
 
 Examples:
   graph-it serve

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -144,7 +144,7 @@ MCP Client Integration:
       }
     }
 
-  VS Code / Cursor (.vscode/mcp.json or .cursor/mcp.json):
+  VS Code (.vscode/mcp.json):
     {
       "servers": {
         "graph-it-live": {
@@ -155,6 +155,29 @@ MCP Client Integration:
         }
       }
     }
+
+  Cursor (.cursor/mcp.json):
+    {
+      "mcpServers": {
+        "graph-it-live": {
+          "type": "stdio",
+          "command": "graph-it",
+          "args": ["serve"],
+          "env": { "WORKSPACE_ROOT": "\${workspaceFolder}" }
+        }
+      }
+    }
+
+  Codex CLI:
+    codex mcp add graph-it-live --env WORKSPACE_ROOT=/path/to/project -- graph-it serve
+
+  Codex config (~/.codex/config.toml or .codex/config.toml):
+    [mcp_servers.graph-it-live]
+    command = "graph-it"
+    args = ["serve"]
+
+    [mcp_servers.graph-it-live.env]
+    WORKSPACE_ROOT = "/path/to/project"
 
   Claude Code CLI:
     claude mcp add graph-it -- graph-it serve


### PR DESCRIPTION
- Introduced `graph-it-live` plugin with mcp configuration for CLI integration.
- Added `update-cli.sh` script for updating the CLI tool.
- Created `dead-code-hunter` skill for scanning and generating deletion plans for unused code.
- Implemented `graph-it-live` skill for analyzing code dependencies and call graphs.
- Developed `onboarding-express` skill for guided architectural tours of codebases.
- Added `pr-review` skill for reviewing pull requests with risk and impact analysis.
- Implemented version synchronization script for plugin manifests.
- Updated CLI documentation for integration with various clients including VS Code, Cursor, and Codex.

## Summary
<!-- What changed and why -->

## Type of change
- [ ] Bug fix
- [X] Feature
- [ ] Refactor
- [ ] Build/packaging
- [X] Documentation
- [ ] Tests

## Validation evidence
<!-- Paste short command outputs (or links to CI jobs) -->

### Quality
- [X] `npm run lint`
- [X] `npm run check:types`
- [X] `npm test`
- [X] Sonar clean on modified files (no new issues)

### VSIX / Packaging (required when build config or deps changed)
- [X] `npm run package:verify` → `✅ No .map files in package`
- [X] `npx vsce ls graph-it-live-*.vsix | grep "\.wasm$"` shows required WASM files
- [X] `ls -lh graph-it-live-*.vsix` size checked (target ≤ 16 MB, warn above)

### E2E
- [X] `npm run test:vscode:vsix` (required for user-facing changes)

## Checklist
- [ ] Tests added/updated for changed behavior
- [X] Docs updated (if needed)
- [X] Cross-platform impact considered (Windows/Linux/macOS)
- [X] No `vscode` import added under `src/analyzer/**` or `src/mcp/**`
