### PR TITLE
feat(cli): persist cache and preserve graph cursors between commands

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -138,6 +138,8 @@ These options are available for every command:
 | `--format <format>` | `-f` | `text` | Output format: `text`, `json`, `toon`, `markdown`, `mermaid` |
 | `--help` | `-h` | — | Show help for the current command |
 | `--version` | `-v` | — | Print the installed version |
+| `--reindex` | — | — | Discard the cached index and rebuild it from scratch |
+| `--no-cache` | — | — | Neither read nor write the index cache for this run |
 
 **Workspace auto-detection:** If `--workspace` is omitted, `graph-it` looks for a `package.json`, `tsconfig.json`, `pyproject.toml`, or `Cargo.toml` in the current directory and its ancestors.
 
@@ -148,6 +150,30 @@ graph-it scan --workspace /abs/path/to/project
 # Let it auto-detect from cwd
 cd /path/to/project && graph-it scan
 ```
+
+### Index cache
+
+Each command runs in its own process, so without a cache every invocation would
+re-parse the whole workspace. `graph-it` persists its indexes under
+`.graph-it/cache/` in the workspace and reuses them on the next run, re-analyzing
+only the files that changed:
+
+| File | Contents |
+|------|----------|
+| `meta.json` | Guard: cache layout version, CLI version, workspace root |
+| `reverse-index.json` | File-level dependency / reverse-dependency index |
+| `callgraph.db` | SQLite call graph (written by `context`, `query`, `wiki`) |
+
+The cache is invalidated automatically when the CLI version changes, when a
+language query file is updated, per file by modification time and size, and
+whenever more than 20% of the workspace changed — that last case triggers a full
+rebuild. Added, deleted and renamed files are all detected.
+
+Turn it off with `--no-cache` (or `GRAPH_IT_NO_CACHE=1`), and force a clean
+rebuild with `--reindex`. `.graph-it/` is disposable; delete it at any time.
+
+> Global options must appear **before** the command name:
+> `graph-it --reindex summary`, not `graph-it summary --reindex`.
 
 ---
 

--- a/src/analyzer/ReverseIndex.ts
+++ b/src/analyzer/ReverseIndex.ts
@@ -339,9 +339,16 @@ export class ReverseIndex {
   /**
    * Validate the index by checking if files are stale
    * @param staleThreshold Percentage of stale files (0-1) above which to reject
+   * @param filesOnDisk Current source files on disk. Without it, only already-indexed
+   *   files are checked, so a file created since the index was built stays invisible.
+   *   The extension papers over that with a file watcher; the CLI has no watcher
+   *   because its process dies between commands, so it must pass this list.
    * @returns Object with validation results
    */
-  async validateIndex(staleThreshold: number = 0.2): Promise<{
+  async validateIndex(
+    staleThreshold: number = 0.2,
+    filesOnDisk?: readonly string[]
+  ): Promise<{
     isValid: boolean;
     staleFiles: string[];
     stalePercentage: number;
@@ -352,7 +359,7 @@ export class ReverseIndex {
 
     for (const filePath of this.fileHashes.keys()) {
       const currentHash = await ReverseIndex.getFileHashFromDisk(filePath);
-      
+
       if (!currentHash) {
         missingFiles.push(filePath);
         continue;
@@ -363,7 +370,19 @@ export class ReverseIndex {
       }
     }
 
-    const totalFiles = this.fileHashes.size;
+    let newFiles = 0;
+    if (filesOnDisk) {
+      for (const filePath of filesOnDisk) {
+        const normalized = normalizePath(filePath);
+        if (!this.fileHashes.has(normalized)) {
+          staleFiles.push(normalized);
+          newFiles++;
+        }
+      }
+    }
+
+    // Denominator covers every distinct file considered: indexed ∪ on-disk.
+    const totalFiles = this.fileHashes.size + newFiles;
     const staleCount = staleFiles.length + missingFiles.length;
     const stalePercentage = totalFiles > 0 ? staleCount / totalFiles : 0;
 

--- a/src/analyzer/ReverseIndexManager.ts
+++ b/src/analyzer/ReverseIndexManager.ts
@@ -76,8 +76,8 @@ export class ReverseIndexManager {
     return this.reverseIndex ? JSON.stringify(this.reverseIndex.serialize()) : null;
   }
 
-  validate(staleThreshold = 0.2) {
-    return this.reverseIndex?.validateIndex(staleThreshold) ?? null;
+  validate(staleThreshold = 0.2, filesOnDisk?: readonly string[]) {
+    return this.reverseIndex?.validateIndex(staleThreshold, filesOnDisk) ?? null;
   }
 
   getStats() {

--- a/src/analyzer/ReviewGateAnalyzer.ts
+++ b/src/analyzer/ReviewGateAnalyzer.ts
@@ -24,17 +24,32 @@ export interface ReviewGateOptions {
 }
 
 export interface ReviewEvidence {
-  kind: "breaking-change" | "impact" | "cycle" | "unused-export" | "test-candidate" | "partial";
+  kind: "breaking-change" | "impact" | "consumers" | "cycle" | "unused-export" | "test-candidate" | "partial";
   detail: string;
 }
 
 export interface ReviewScoreFactors {
   breakingChanges: number;
-  dependents: number;
+  /** Weight of consumers that are neither updated in this diff nor covered by a test. */
+  unverifiedConsumers: number;
   cycles: number;
   unusedExport: number;
   missingTestCandidate: number;
   partialImpact: number;
+}
+
+/**
+ * Where a changed contract's consumers stand. A consumer that the diff already
+ * updates, or that a test exercises, is accounted for; what is left is the
+ * surface nobody has checked.
+ */
+export interface ConsumerStanding {
+  /** Consumer files the diff already touches. */
+  updated: string[];
+  /** Consumer files a test reaches, so a real incompatibility fails loudly. */
+  covered: string[];
+  /** Neither — the risk this gate exists to report. */
+  unverified: string[];
 }
 
 export interface ReviewSymbol {
@@ -44,6 +59,7 @@ export interface ReviewSymbol {
   risk: ReviewRiskLevel;
   breakingChanges: BreakingChange[];
   impactedSymbolCount: number;
+  consumers: ConsumerStanding;
   cycleEvidence: string[];
   unusedExportEvidence: boolean;
   testCandidates: string[];
@@ -91,6 +107,7 @@ export class ReviewGateAnalyzer {
     const maxDepth = this.validateLimit(options.maxDepth, DEFAULT_MAX_DEPTH, MAX_MAX_DEPTH, "maxDepth");
     const headRef = options.headRef ?? "HEAD";
     const changedFiles = await this.getChangedFiles(options.baseRef, headRef, maxFiles);
+    const changedFileSet = new Set(changedFiles);
     const symbols: ReviewSymbol[] = [];
     const limitations: string[] = [];
     const analysisAvailability = { cycle: false, unused: false };
@@ -100,7 +117,7 @@ export class ReviewGateAnalyzer {
     }
 
     for (const relativePath of changedFiles) {
-      symbols.push(...await this.analyzeChangedFile(relativePath, options.baseRef, headRef, maxDepth, limitations, analysisAvailability));
+      symbols.push(...await this.analyzeChangedFile(relativePath, options.baseRef, headRef, maxDepth, limitations, analysisAvailability, changedFileSet));
     }
 
     symbols.sort((a, b) => b.score - a.score || a.filePath.localeCompare(b.filePath) || a.name.localeCompare(b.name));
@@ -132,6 +149,7 @@ export class ReviewGateAnalyzer {
     maxDepth: number,
     limitations: string[],
     availability: { cycle: boolean; unused: boolean },
+    changedFiles: ReadonlySet<string>,
   ): Promise<ReviewSymbol[]> {
     if (!SIGNATURE_ANALYSIS_EXTENSIONS.has(path.extname(relativePath).toLowerCase())) {
       limitations.push(`Signature and symbol evidence unavailable for unsupported file type: ${relativePath}.`);
@@ -148,7 +166,7 @@ export class ReviewGateAnalyzer {
     }
     const fileEvidence = await this.collectFileEvidence(absolutePath, relativePath, limitations, availability);
     const comparisons = this.analyzeSignatures(absolutePath, relativePath, oldContent, newContent, limitations);
-    return Promise.all(comparisons.map((comparison) => this.createReviewSymbol(comparison, absolutePath, relativePath, maxDepth, fileEvidence)));
+    return Promise.all(comparisons.map((comparison) => this.createReviewSymbol(comparison, absolutePath, relativePath, maxDepth, fileEvidence, changedFiles)));
   }
 
   private analyzeSignatures(absolutePath: string, relativePath: string, oldContent: string, newContent: string, limitations: string[]): Array<{ symbolName: string; breakingChanges: BreakingChange[] }> {
@@ -167,6 +185,7 @@ export class ReviewGateAnalyzer {
     relativePath: string,
     maxDepth: number,
     fileEvidence: FileEvidence,
+    changedFiles: ReadonlySet<string>,
   ): Promise<ReviewSymbol> {
     const errorBreakingChanges = comparison.breakingChanges.filter(
       (change) => change.severity === "error",
@@ -178,9 +197,9 @@ export class ReviewGateAnalyzer {
     const isMemberLevelChange = errorBreakingChanges.length > 0
       && errorBreakingChanges.every((change) => change.type === "member-removed" || change.type === "member-type-changed" || change.type === "member-optional-to-required");
     const effectiveMaxDepth = isMemberLevelChange ? 1 : maxDepth;
-    const impact = errorBreakingChanges.length > 0
+    const impact: SymbolImpact = errorBreakingChanges.length > 0
       ? await this.getImpact(absolutePath, comparison.symbolName, effectiveMaxDepth)
-      : { count: 0, partial: false, testDependents: [] };
+      : EMPTY_IMPACT;
     const cycles = fileEvidence.cycleSymbols.has(this.toSymbolId(absolutePath, comparison.symbolName));
     const unusedExport = fileEvidence.unusedSymbols.has(comparison.symbolName);
     // A dependents provider that actually ran and found zero live consumers (not just
@@ -192,28 +211,88 @@ export class ReviewGateAnalyzer {
     // coverage, distinct from "no provider configured" (unknown) or "confirmed zero" (untested by definition).
     const hasTestCoverage = impact.testDependents.length > 0;
     const allTestCandidates = [...new Set([...fileEvidence.testCandidates, ...impact.testDependents])];
-    const scoreFactors = this.getScoreFactors(errorBreakingChanges.length, impact, cycles, unusedExport, allTestCandidates.length, hasConfirmedZeroImpact, hasTestCoverage);
+    const consumers = this.getConsumerStanding(impact, changedFiles);
+    const consumersMustAct = this.requiresConsumerUpdate(errorBreakingChanges);
+    const scoreFactors = this.getScoreFactors(errorBreakingChanges.length, impact, consumers, consumersMustAct, cycles, unusedExport, allTestCandidates.length, hasConfirmedZeroImpact, hasTestCoverage);
     const score = Math.min(100, Object.values(scoreFactors).reduce((total, value) => total + value, 0));
     return {
       name: comparison.symbolName, filePath: relativePath, score, risk: riskForScore(score),
-      breakingChanges: comparison.breakingChanges, impactedSymbolCount: impact.count,
+      breakingChanges: comparison.breakingChanges, impactedSymbolCount: impact.count, consumers,
       cycleEvidence: cycles ? [comparison.symbolName] : [], unusedExportEvidence: unusedExport,
       testCandidates: allTestCandidates, scoreFactors,
-      evidence: this.getEvidence(comparison.breakingChanges, impact, cycles, unusedExport, allTestCandidates, hasTestCoverage),
+      evidence: this.getEvidence(comparison.breakingChanges, impact, consumers, consumersMustAct, cycles, unusedExport, allTestCandidates, hasTestCoverage),
     };
   }
 
-  private getScoreFactors(breakingChangeCount: number, impact: { count: number; partial: boolean }, cycles: boolean, unusedExport: boolean, testCandidateCount: number, hasConfirmedZeroImpact: boolean, hasTestCoverage: boolean): ReviewScoreFactors {
-    const breakingChangeWeight = hasConfirmedZeroImpact ? 5 : hasTestCoverage ? 25 : 50;
+  /**
+   * Whether consumers have to be edited for this change, or merely re-checked.
+   *
+   * A call site breaks when what it *passes in* no longer fits — changed
+   * parameters, or a changed member of a type it constructs. A changed return
+   * type leaves every call valid: the consumer only receives a different shape,
+   * which breaks it only if it reads a part that went away.
+   *
+   * Deciding that last case needs the direction of the change (members added vs
+   * removed), which a textual signature comparison cannot see — so a return-type
+   * change is reported and weighted, but its consumers are not counted against
+   * the author as unhandled work.
+   */
+  private requiresConsumerUpdate(errorBreakingChanges: BreakingChange[]): boolean {
+    return errorBreakingChanges.some((change) => change.type !== "return-type-changed");
+  }
+
+  /**
+   * Split the consumers of a changed contract into the ones this diff already
+   * updates, the ones a test exercises, and the ones nobody checked. Only the
+   * last group is a risk: a consumer the author touched has been considered, and
+   * a consumer under test fails loudly if the contract no longer fits.
+   */
+  private getConsumerStanding(impact: SymbolImpact, changedFiles: ReadonlySet<string>): ConsumerStanding {
+    const covered = new Set(impact.coveredFiles);
+    const standing: ConsumerStanding = { updated: [], covered: [], unverified: [] };
+    for (const file of [...impact.consumerFiles].sort((a, b) => a.localeCompare(b))) {
+      if (changedFiles.has(file)) standing.updated.push(file);
+      else if (covered.has(file)) standing.covered.push(file);
+      else standing.unverified.push(file);
+    }
+    return standing;
+  }
+
+  private getScoreFactors(breakingChangeCount: number, impact: SymbolImpact, consumers: ConsumerStanding, consumersMustAct: boolean, cycles: boolean, unusedExport: boolean, testCandidateCount: number, hasConfirmedZeroImpact: boolean, hasTestCoverage: boolean): ReviewScoreFactors {
+    // Residual weight: the change is real and worth a look, but nothing downstream
+    // has to be edited for it, so it must not drown the findings that do need work.
+    // Kept non-zero on purpose — at zero the symbol would vanish from the report.
+    const RESIDUAL_WEIGHT = 5;
+    const breakingChangeWeight = hasConfirmedZeroImpact || !consumersMustAct
+      ? RESIDUAL_WEIGHT
+      : hasTestCoverage ? 25 : 50;
     return {
-      breakingChanges: breakingChangeCount * breakingChangeWeight, dependents: impact.count * 5, cycles: cycles ? 20 : 0,
-      unusedExport: unusedExport ? 10 : 0, missingTestCandidate: testCandidateCount === 0 ? 10 : 0, partialImpact: impact.partial ? 10 : 0,
+      breakingChanges: breakingChangeCount * breakingChangeWeight,
+      // Scored on what nobody checked, not on how widely the contract is used: a
+      // heavily used contract whose consumers are all updated or under test is
+      // exactly the well-handled change this gate should wave through.
+      unverifiedConsumers: consumersMustAct ? consumers.unverified.length * 5 : 0, cycles: cycles ? 20 : 0,
+      unusedExport: unusedExport ? 10 : 0, missingTestCandidate: testCandidateCount === 0 ? 10 : 0,
+      // An incomplete impact walk means "there may be consumers I did not see" —
+      // a risk only when consumers actually have to be updated. Charging it
+      // otherwise bills the author for the analyzer's own precision limits.
+      partialImpact: impact.partial && consumersMustAct ? 10 : 0,
     };
   }
 
-  private getEvidence(breakingChanges: BreakingChange[], impact: { count: number; partial: boolean }, cycles: boolean, unusedExport: boolean, testCandidates: string[], hasTestCoverage: boolean): ReviewEvidence[] {
+  private getEvidence(breakingChanges: BreakingChange[], impact: SymbolImpact, consumers: ConsumerStanding, consumersMustAct: boolean, cycles: boolean, unusedExport: boolean, testCandidates: string[], hasTestCoverage: boolean): ReviewEvidence[] {
     const evidence: ReviewEvidence[] = breakingChanges.map((change) => ({ kind: "breaking-change", detail: change.description }));
     if (impact.count > 0) evidence.push({ kind: "impact", detail: `${impact.count} known dependent symbol(s).` });
+    const consumerTotal = consumers.updated.length + consumers.covered.length + consumers.unverified.length;
+    if (consumerTotal > 0) {
+      const unhandled = consumersMustAct
+        ? `${consumers.unverified.length} unverified${consumers.unverified.length > 0 ? `: ${consumers.unverified.join(", ")}` : ""}`
+        : `${consumers.unverified.length} neither, but this change requires no call-site update`;
+      evidence.push({
+        kind: "consumers",
+        detail: `${consumerTotal} consumer file(s): ${consumers.updated.length} updated in this diff, ${consumers.covered.length} covered by tests, ${unhandled}.`,
+      });
+    }
     if (cycles) evidence.push({ kind: "cycle", detail: "Changed symbol participates in a detected symbol dependency cycle." });
     if (unusedExport) evidence.push({ kind: "unused-export", detail: "Changed exported symbol is currently reported as unused." });
     if (testCandidates.length > 0) {
@@ -222,7 +301,14 @@ export class ReviewGateAnalyzer {
       evidence.push({ kind: "test-candidate", detail: "No conventional test candidate found; manual test selection is required." });
     }
     if (hasTestCoverage) evidence.push({ kind: "test-candidate", detail: "Symbol is directly depended on by an existing test — a real incompatibility would fail that test." });
-    if (impact.partial) evidence.push({ kind: "partial", detail: "Impact traversal reached its configured depth limit." });
+    if (impact.containerScoped) {
+      evidence.push({
+        kind: "partial",
+        detail: "Dependents are tracked per exported symbol, not per member: the count covers consumers of the containing symbol, only some of which touch this member.",
+      });
+    } else if (impact.partial) {
+      evidence.push({ kind: "partial", detail: "Impact traversal reached its configured depth limit." });
+    }
     return evidence;
   }
 
@@ -237,6 +323,14 @@ export class ReviewGateAnalyzer {
       .slice(0, maxFiles)
       .map((filePath) => normalizePath(filePath))
       .sort((left, right) => left.localeCompare(right));
+  }
+
+  /** Render an absolute path the way the rest of the report does: workspace-relative. */
+  private toWorkspaceRelative(absolutePath: string): string {
+    const normalized = normalizePath(absolutePath);
+    return normalized.startsWith(`${this.normalizedRoot}/`)
+      ? normalized.slice(this.normalizedRoot.length + 1)
+      : normalized;
   }
 
   private resolveWorkspacePath(relativePath: string): string {
@@ -270,18 +364,82 @@ export class ReviewGateAnalyzer {
     return this.gitShow(headRef, relativePath);
   }
 
-  private async getImpact(filePath: string, symbolName: string, maxDepth: number): Promise<{ count: number; partial: boolean; testDependents: string[] }> {
-    if (!this.dependents) return { count: 0, partial: false, testDependents: [] };
+  private async getImpact(filePath: string, symbolName: string, maxDepth: number): Promise<SymbolImpact> {
+    if (!this.dependents) return EMPTY_IMPACT;
+
+    const direct = await this.walkDependents(filePath, symbolName, maxDepth);
+    if (direct.count > 0) return direct;
+
+    // The dependent index is keyed on exported symbols, not on class members, so
+    // a member lookup yields 0 whether the member truly has no callers or is
+    // simply not tracked. Falling back to the container gives a real consumer
+    // count, reported as partial: those consumers touch the class, and only some
+    // of them touch this member. Without this, every method signature change
+    // reads as "confirmed zero impact" and is scored ten times too low.
+    const separator = symbolName.indexOf(".");
+    if (separator <= 0) return direct;
+
+    const viaContainer = await this.walkDependents(filePath, symbolName.slice(0, separator), maxDepth);
+    return viaContainer.count > 0
+      ? { ...viaContainer, partial: true, containerScoped: true }
+      : direct;
+  }
+
+  private async walkDependents(filePath: string, symbolName: string, maxDepth: number): Promise<SymbolImpact> {
     const seen = new Set<string>();
     const testDependents = new Set<string>();
+    const consumerFiles = new Set<string>();
+    // File-level "who depends on whom", recorded even for symbols already visited,
+    // so test coverage can be traced back to the consumer it protects.
+    const edges = new Map<string, Set<string>>();
     let frontier = [{ filePath, symbolName }];
+
     for (let depth = 0; depth < maxDepth && frontier.length > 0; depth += 1) {
-      frontier = await this.collectDependentFrontier(frontier, seen);
-      for (const { filePath: dependentPath } of frontier) {
-        if (this.isTestFilePath(dependentPath)) testDependents.add(dependentPath);
+      const next: Array<{ filePath: string; symbolName: string }> = [];
+      for (const current of frontier) {
+        const parent = this.toWorkspaceRelative(current.filePath);
+        for (const dependent of await this.dependents!.getSymbolDependents(current.filePath, current.symbolName)) {
+          const separator = dependent.sourceSymbolId.lastIndexOf(":");
+          if (separator <= 0) continue;
+          const dependentPath = normalizePath(dependent.sourceSymbolId.slice(0, separator));
+          const child = this.toWorkspaceRelative(dependentPath);
+          if (child !== parent) {
+            let children = edges.get(parent);
+            if (!children) { children = new Set(); edges.set(parent, children); }
+            children.add(child);
+          }
+          if (this.isTestFilePath(dependentPath)) testDependents.add(child);
+          else consumerFiles.add(child);
+
+          const target = this.parseDependent(dependent.sourceSymbolId, seen);
+          if (target) next.push(target);
+        }
+      }
+      frontier = next;
+    }
+
+    return {
+      count: seen.size,
+      partial: frontier.length > 0,
+      testDependents: [...testDependents],
+      consumerFiles: [...consumerFiles],
+      coveredFiles: [...consumerFiles].filter((file) => this.reachesTestFile(file, edges)),
+    };
+  }
+
+  /** Whether any test file is reachable from `file` through the recorded dependent edges. */
+  private reachesTestFile(file: string, edges: Map<string, Set<string>>): boolean {
+    const visited = new Set([file]);
+    const queue = [file];
+    while (queue.length > 0) {
+      for (const child of edges.get(queue.pop()!) ?? []) {
+        if (visited.has(child)) continue;
+        if (this.isTestFilePath(child)) return true;
+        visited.add(child);
+        queue.push(child);
       }
     }
-    return { count: seen.size, partial: frontier.length > 0, testDependents: [...testDependents] };
+    return false;
   }
 
   // A test file that directly depends on the changed symbol will fail to compile/run
@@ -290,20 +448,6 @@ export class ReviewGateAnalyzer {
     return /(^|\/)tests\//.test(filePath) || /\.(test|spec)\.[^/]+$/.test(filePath);
   }
 
-  private async collectDependentFrontier(
-    frontier: Array<{ filePath: string; symbolName: string }>,
-    seen: Set<string>,
-  ): Promise<Array<{ filePath: string; symbolName: string }>> {
-    const next: Array<{ filePath: string; symbolName: string }> = [];
-    for (const current of frontier) {
-      const dependents = await this.dependents!.getSymbolDependents(current.filePath, current.symbolName);
-      for (const dependent of dependents) {
-        const target = this.parseDependent(dependent.sourceSymbolId, seen);
-        if (target) next.push(target);
-      }
-    }
-    return next;
-  }
 
   private parseDependent(symbolId: string, seen: Set<string>): { filePath: string; symbolName: string } | null {
     const separator = symbolId.lastIndexOf(":");
@@ -360,12 +504,21 @@ export class ReviewGateAnalyzer {
     const extension = path.extname(relativePath);
     const stem = relativePath.slice(0, -extension.length);
     const baseName = path.basename(stem);
+    const sourceDir = path.dirname(relativePath);
+    // Most repos mirror src/<area>/x.ts as tests/<area>/x.test.ts. Keeping the
+    // "src/" segment would look under tests/src/<area>/, which such a layout
+    // never has — so the lookup could never succeed and every symbol was scored
+    // as untested.
+    const segments = sourceDir.split("/");
+    const mirroredDir = segments[0] === "src" ? segments.slice(1).join("/") : sourceDir;
     const candidates = [
       `${stem}.test${extension}`,
       `${stem}.spec${extension}`,
-      path.join("tests", `${relativePath}.test${extension}`),
-      path.join("tests", path.dirname(relativePath), `${baseName}.test${extension}`),
-      path.join("tests", path.dirname(relativePath), `${baseName}.spec${extension}`),
+      path.join("tests", `${stem}.test${extension}`),
+      path.join("tests", sourceDir, `${baseName}.test${extension}`),
+      path.join("tests", sourceDir, `${baseName}.spec${extension}`),
+      path.join("tests", mirroredDir, `${baseName}.test${extension}`),
+      path.join("tests", mirroredDir, `${baseName}.spec${extension}`),
     ].map(normalizePath);
     const found: string[] = [];
     for (const candidate of [...new Set(candidates)].sort((left, right) => left.localeCompare(right))) {
@@ -387,6 +540,24 @@ export class ReviewGateAnalyzer {
   }
 }
 
+const EMPTY_IMPACT: SymbolImpact = {
+  count: 0, partial: false, testDependents: [], consumerFiles: [], coveredFiles: [],
+};
+
+/** Result of walking the dependent graph for one changed symbol. */
+interface SymbolImpact {
+  count: number;
+  /** The count is an over- or under-estimate; see containerScoped. */
+  partial: boolean;
+  /** Counted against the containing symbol because members are not tracked. */
+  containerScoped?: boolean;
+  testDependents: string[];
+  /** Production consumer files found in the walk, workspace-relative. */
+  consumerFiles: string[];
+  /** Consumer files from which a test file is reachable in the walk. */
+  coveredFiles: string[];
+}
+
 export function riskForScore(score: number): ReviewRiskLevel {
   if (score >= 80) return "critical";
   if (score >= 50) return "high";
@@ -396,18 +567,27 @@ export function riskForScore(score: number): ReviewRiskLevel {
 
 export function renderReviewMarkdown(result: ReviewGateResult): string {
   const safe = (value: string): string => value.replaceAll(/[\r\n|<>]/g, " ").replaceAll("`", "'").trim();
+  // The consumer columns are the point of the report: a reviewer needs to see what
+  // the change still leaves unchecked, not how widely the contract is used.
   const rows = result.symbols.slice(0, 20).map((symbol) =>
-    `| ${safe(symbol.risk)} | ${symbol.score} | ${safe(symbol.filePath)} | ${safe(symbol.name)} | ${symbol.impactedSymbolCount} |`,
+    `| ${safe(symbol.risk)} | ${symbol.score} | ${safe(symbol.filePath)} | ${safe(symbol.name)} | ${symbol.consumers.updated.length} | ${symbol.consumers.covered.length} | ${symbol.consumers.unverified.length} |`,
   );
+
+  const unverified = result.symbols
+    .filter((symbol) => symbol.consumers.unverified.length > 0 && symbol.scoreFactors.unverifiedConsumers > 0)
+    .slice(0, 10)
+    .map((symbol) => `- ${safe(symbol.name)}: ${symbol.consumers.unverified.map(safe).join(", ")}`);
+
   return [
     "<!-- graph-it-review-gate -->",
     `## Graph-It Review Gate: ${result.risk.toUpperCase()} (${result.score}/100)`,
     "",
     `Changed files: ${result.changedFiles.length}. ${result.isPartial ? "Partial analysis; see limitations." : "Complete within configured limits."}`,
     "",
-    "| Risk | Score | File | Symbol | Dependents |",
-    "| --- | ---: | --- | --- | ---: |",
-    ...(rows.length > 0 ? rows : ["| low | 0 | — | No breaking signatures detected | 0 |"]),
+    "| Risk | Score | File | Symbol | Updated | Covered | Unverified |",
+    "| --- | ---: | --- | --- | ---: | ---: | ---: |",
+    ...(rows.length > 0 ? rows : ["| low | 0 | — | No breaking signatures detected | 0 | 0 | 0 |"]),
+    ...(unverified.length > 0 ? ["", "### Consumers to check", ...unverified] : []),
     ...(result.limitations.length > 0 ? ["", "### Limitations", ...result.limitations.map((item) => `- ${safe(item)}`)] : []),
   ].join("\n");
 }

--- a/src/analyzer/Spider.ts
+++ b/src/analyzer/Spider.ts
@@ -464,13 +464,13 @@ export class Spider {
     return this.reverseIndexManager.getSerialized();
   }
 
-  async validateReverseIndex(staleThreshold = 0.2): Promise<{
+  async validateReverseIndex(staleThreshold = 0.2, filesOnDisk?: readonly string[]): Promise<{
     isValid: boolean;
     staleFiles: string[];
     stalePercentage: number;
     missingFiles: string[];
   } | null> {
-    return this.reverseIndexManager.validate(staleThreshold);
+    return this.reverseIndexManager.validate(staleThreshold, filesOnDisk);
   }
 
   getIndexStatus(): IndexerStatusSnapshot {

--- a/src/analyzer/callgraph/CallGraphIndexer.ts
+++ b/src/analyzer/callgraph/CallGraphIndexer.ts
@@ -463,7 +463,7 @@ export class CallGraphIndexer {
     // return rows in any order, and pickBestCandidate's first-wins tie handling
     // would resolve the same workspace differently from one run to the next.
     const candidateRows = db.exec(`
-      SELECT name, id, path, is_exported, indexed_at, lang
+      SELECT name, id, path, is_exported, lang
       FROM nodes
       WHERE name IN (
         SELECT DISTINCT SUBSTR(target_id, 12) FROM edges WHERE target_id LIKE '@@external:%'
@@ -472,16 +472,16 @@ export class CallGraphIndexer {
     `);
 
     // Build (lang + "\0" + name) → candidates map so lookups are language-scoped.
-    const candidateMap = new Map<string, Array<{ id: string; path: string; isExported: number; indexedAt: number }>>();
+    const candidateMap = new Map<string, NodeCandidate[]>();
     if (candidateRows[0]) {
-      for (const row of candidateRows[0].values as [string, string, string, number, number, string][]) {
-        const [name, id, nodePath, isExported, indexedAt, lang] = row;
+      for (const row of candidateRows[0].values as [string, string, string, number, string][]) {
+        const [name, id, nodePath, isExported, lang] = row;
         const key = `${lang}\0${name}`;
         const existing = candidateMap.get(key);
         if (existing) {
-          existing.push({ id, path: nodePath, isExported, indexedAt });
+          existing.push({ id, path: nodePath, isExported });
         } else {
-          candidateMap.set(key, [{ id, path: nodePath, isExported, indexedAt }]);
+          candidateMap.set(key, [{ id, path: nodePath, isExported }]);
         }
       }
     }
@@ -740,7 +740,7 @@ export function getSqlJsWasmPath(extensionPath: string): string {
 // Module-level helpers for resolveExternalEdges
 // ---------------------------------------------------------------------------
 
-type NodeCandidate = { id: string; path: string; isExported: number; indexedAt: number };
+type NodeCandidate = { id: string; path: string; isExported: number };
 
 /**
  * Count the number of leading directory segments two file paths share.
@@ -760,7 +760,16 @@ function sharedPathSegments(pathA: string, pathB: string): number {
 
 /**
  * From a list of candidate nodes, return the one whose path best matches
- * the caller's source path.  Tie-breaking: exported > recently indexed.
+ * the caller's source path. Tie-breaking: exported > lowest node id.
+ *
+ * The final tie-break used to be `indexed_at`, which is a wall-clock stamp taken
+ * once per indexed file. Which files land in the same millisecond varies between
+ * runs, so the same unchanged workspace resolved homonymous symbols differently
+ * from one indexing run to the next — enough to change the graph-context index
+ * revision and invalidate pagination cursors across CLI processes.
+ *
+ * Recency carried no signal about which homonym is the real target anyway: it is
+ * an arbitrary choice either way, so the id is used instead because it is stable.
  */
 function pickBestCandidate(sourcePath: string, candidates: NodeCandidate[]): NodeCandidate {
   let best = candidates[0];
@@ -771,14 +780,8 @@ function pickBestCandidate(sourcePath: string, candidates: NodeCandidate[]): Nod
     const betterSim = sim > bestSim;
     const sameSim = sim === bestSim;
     const betterExport = sameSim && c.isExported > best.isExported;
-    const sameExport = sameSim && c.isExported === best.isExported;
-    const betterRecent = sameExport && c.indexedAt > best.indexedAt;
-    // indexed_at is a wall-clock stamp taken once per indexed file, so candidates
-    // indexed within the same millisecond tie here — and which files share a
-    // millisecond varies between runs. Falling back to the id keeps resolution
-    // reproducible instead of letting the clock decide.
-    const lowerId = sameExport && c.indexedAt === best.indexedAt && c.id < best.id;
-    if (betterSim || betterExport || betterRecent || lowerId) {
+    const lowerId = sameSim && c.isExported === best.isExported && c.id < best.id;
+    if (betterSim || betterExport || lowerId) {
       best = c;
       bestSim = sim;
     }

--- a/src/analyzer/callgraph/CallGraphIndexer.ts
+++ b/src/analyzer/callgraph/CallGraphIndexer.ts
@@ -459,12 +459,16 @@ export class CallGraphIndexer {
 
     // Fetch all candidate target nodes that could satisfy any stub.
     // Include lang so we can restrict resolution to same-language candidates only.
+    // ORDER BY id keeps the candidate order stable: without it SQLite is free to
+    // return rows in any order, and pickBestCandidate's first-wins tie handling
+    // would resolve the same workspace differently from one run to the next.
     const candidateRows = db.exec(`
       SELECT name, id, path, is_exported, indexed_at, lang
       FROM nodes
       WHERE name IN (
         SELECT DISTINCT SUBSTR(target_id, 12) FROM edges WHERE target_id LIKE '@@external:%'
       )
+      ORDER BY id ASC
     `);
 
     // Build (lang + "\0" + name) → candidates map so lookups are language-scoped.
@@ -528,6 +532,21 @@ export class CallGraphIndexer {
     }
     stmt.free();
     return result;
+  }
+
+  /**
+   * Row counts for the three tables, via COUNT(*) rather than materializing rows.
+   * Cheap enough to call on every status query, unlike getIndexSnapshot().
+   */
+  getCounts(): { files: number; symbols: number; relations: number } {
+    const db = this.getDb();
+    const count = (table: string): number =>
+      (db.exec(`SELECT COUNT(*) FROM ${table}`)[0]?.values[0]?.[0] as number) ?? 0;
+    return {
+      files: count("file_index"),
+      symbols: count("nodes"),
+      relations: count("edges"),
+    };
   }
 
   /**
@@ -752,8 +771,14 @@ function pickBestCandidate(sourcePath: string, candidates: NodeCandidate[]): Nod
     const betterSim = sim > bestSim;
     const sameSim = sim === bestSim;
     const betterExport = sameSim && c.isExported > best.isExported;
-    const betterRecent = sameSim && c.isExported === best.isExported && c.indexedAt > best.indexedAt;
-    if (betterSim || betterExport || betterRecent) {
+    const sameExport = sameSim && c.isExported === best.isExported;
+    const betterRecent = sameExport && c.indexedAt > best.indexedAt;
+    // indexed_at is a wall-clock stamp taken once per indexed file, so candidates
+    // indexed within the same millisecond tie here — and which files share a
+    // millisecond varies between runs. Falling back to the id keeps resolution
+    // reproducible instead of letting the clock decide.
+    const lowerId = sameExport && c.indexedAt === best.indexedAt && c.id < best.id;
+    if (betterSim || betterExport || betterRecent || lowerId) {
       best = c;
       bestSim = sim;
     }

--- a/src/analyzer/callgraph/GraphExtractor.ts
+++ b/src/analyzer/callgraph/GraphExtractor.ts
@@ -534,6 +534,121 @@ export function fileExtToLang(filePath: string): SupportedLang | null {
 }
 
 // ---------------------------------------------------------------------------
+// Incremental indexing helpers (shared by the extension and the CLI)
+// ---------------------------------------------------------------------------
+
+/** Minimal view of a `file_index` row — avoids a CallGraphIndexer import cycle. */
+export interface IndexedFileRecord {
+  lastModified: number;
+  indexedAt: number;
+}
+
+/** Lookup of the persisted index record for a file, or null when never indexed. */
+export type IndexedFileLookup = (filePath: string) => IndexedFileRecord | null;
+
+/** One file that needs (re-)extraction. */
+export interface ExtractionJob {
+  filePath: string;
+  lang: SupportedLang;
+  mtime: number;
+}
+
+/** Batch size for `fs.stat` fan-out when checking freshness. */
+const STAT_BATCH = 32;
+
+/**
+ * Returns per-language freshness cutoffs derived from query-file mtimes.
+ * A file indexed before its language query was updated must be re-extracted
+ * even when the source file itself is unchanged.
+ *
+ * @param extensionPath Package root containing `dist/queries/*.scm`.
+ */
+export async function getQueryFreshnessCutoffs(
+  extensionPath: string,
+): Promise<Record<SupportedLang, number>> {
+  const queryDir = path.join(extensionPath, "dist", "queries");
+  const queryFiles: Record<SupportedLang, string> = {
+    typescript: path.join(queryDir, "typescript.scm"),
+    javascript: path.join(queryDir, "typescript.scm"),
+    python: path.join(queryDir, "python.scm"),
+    rust: path.join(queryDir, "rust.scm"),
+    csharp: path.join(queryDir, "csharp.scm"),
+    go: path.join(queryDir, "go.scm"),
+    java: path.join(queryDir, "java.scm"),
+  };
+
+  const entries = await Promise.all(
+    (Object.entries(queryFiles) as Array<[SupportedLang, string]>).map(
+      async ([lang, queryPath]) => {
+        try {
+          const stat = await fs.stat(queryPath);
+          return [lang, Math.floor(stat.mtimeMs)] as const;
+        } catch {
+          // A missing query file must not block indexing.
+          return [lang, 0] as const;
+        }
+      },
+    ),
+  );
+
+  return Object.fromEntries(entries) as Record<SupportedLang, number>;
+}
+
+/**
+ * Batch-`fs.stat` the given files and drop the ones already fresh in the index.
+ *
+ * A file is skipped only when both the source file AND the extractor rules that
+ * produced its rows are still fresh.
+ *
+ * @param files    Candidate source files (normalized absolute paths).
+ * @param lookup   Reads the persisted index record for a file.
+ * @param cutoffs  Per-language query freshness cutoffs.
+ * @param langOf   Maps a path to its language; files mapping to null are skipped.
+ */
+export async function collectChangedFiles(
+  files: readonly string[],
+  lookup: IndexedFileLookup,
+  cutoffs: Record<SupportedLang, number>,
+  langOf: (filePath: string) => SupportedLang | null = fileExtToLang,
+): Promise<{ jobs: ExtractionJob[]; skipped: number }> {
+  const jobs: ExtractionJob[] = [];
+  let skipped = 0;
+
+  for (let i = 0; i < files.length; i += STAT_BATCH) {
+    const batch = files.slice(i, i + STAT_BATCH);
+    const stats = await Promise.all(
+      batch.map(async (filePath) => {
+        try {
+          const s = await fs.stat(filePath);
+          return { filePath, mtime: Math.floor(s.mtimeMs), ok: true as const };
+        } catch {
+          return { filePath, mtime: 0, ok: false as const };
+        }
+      }),
+    );
+
+    for (const s of stats) {
+      const lang = s.ok ? langOf(s.filePath) : null;
+      if (!lang) {
+        skipped++;
+        continue;
+      }
+
+      const record = lookup(s.filePath);
+      const queryCutoff = cutoffs[lang] ?? 0;
+      if (record && record.lastModified >= s.mtime && record.indexedAt >= queryCutoff) {
+        skipped++;
+        continue;
+      }
+
+      jobs.push({ filePath: s.filePath, lang, mtime: s.mtime });
+    }
+  }
+
+  return { jobs, skipped };
+}
+
+// ---------------------------------------------------------------------------
 // SFC script extraction (Vue / Svelte)
 // ---------------------------------------------------------------------------
 

--- a/src/analyzer/graph-context/GraphContextFederator.ts
+++ b/src/analyzer/graph-context/GraphContextFederator.ts
@@ -251,7 +251,9 @@ function createRevision(
     documentNodes,
     documentEdges,
   };
-  return createHash('sha256').update(JSON.stringify(state)).digest('hex');
+  // Rebuilding unchanged indexes in a new CLI process must preserve continuation cursors.
+  const serialized = JSON.stringify(state, (key, value: unknown) => key === 'indexedAt' ? undefined : value);
+  return createHash('sha256').update(serialized).digest('hex');
 }
 
 function hasDocumentSeed(request: GraphContextRequest): boolean {

--- a/src/analyzer/spider/SpiderDependencyAnalyzer.ts
+++ b/src/analyzer/spider/SpiderDependencyAnalyzer.ts
@@ -99,9 +99,15 @@ export class SpiderDependencyAnalyzer {
     normalizedFilePath: string,
     dependencies: Dependency[]
   ): Promise<void> {
-    if (!this.reverseIndexManager.isEnabled() || dependencies.length === 0) {
+    if (!this.reverseIndexManager.isEnabled()) {
       return;
     }
+
+    // A file with no dependencies still gets a hash recorded. fileHashes is the
+    // "which files have been analyzed" set, so skipping dependency-less files
+    // would make them permanently indistinguishable from never-indexed ones —
+    // they would never be detected as stale, and a restored index would look
+    // massively incomplete to validateIndex().
 
     const fileHash = await ReverseIndex.getFileHashFromDisk(diskFilePath);
     if (fileHash) {

--- a/src/analyzer/spider/SpiderIndexingService.ts
+++ b/src/analyzer/spider/SpiderIndexingService.ts
@@ -167,6 +167,13 @@ export class SpiderIndexingService {
 
     log.info(`Re-indexing ${staleFiles.length} stale files`);
 
+    // Drive the same status lifecycle as buildFullIndex: callers that restored a
+    // persisted index reach a ready state through here, and would otherwise keep
+    // reporting "idle" forever.
+    this.indexerStatus.startCounting();
+    this.indexerStatus.setTotal(staleFiles.length);
+    this.indexerStatus.startIndexing();
+
     const concurrency = this.getConfig().indexingConcurrency ?? 8;
     let processed = 0;
 
@@ -191,10 +198,12 @@ export class SpiderIndexingService {
       );
 
       processed += batch.length;
+      this.indexerStatus.updateProgress(processed, batch.at(-1));
       progressCallback?.(processed, staleFiles.length, batch.at(-1));
       await this.yieldToEventLoop();
     }
 
+    this.indexerStatus.complete();
     log.info(`Completed re-indexing ${processed} files`);
     return processed;
   }

--- a/src/analyzer/utils/PathResolver.ts
+++ b/src/analyzer/utils/PathResolver.ts
@@ -545,6 +545,15 @@ export class PathResolver {
       return normalizePath(basePath);
     }
 
+    // TypeScript's NodeNext/ESM resolution requires import specifiers to carry the
+    // *emitted* extension: `./commands/scan.js` is how you import `scan.ts`. Without
+    // this remap the source file is never found, and every such edge — including all
+    // dynamic imports in an ESM codebase — is silently missing from the graph.
+    const emittedToSource = await this.resolveEmittedExtension(basePath);
+    if (emittedToSource) {
+      return emittedToSource;
+    }
+
     // Try with extensions
     for (const ext of extensions) {
       const pathWithExt = basePath + ext;
@@ -561,6 +570,34 @@ export class PathResolver {
       }
     }
 
+    return null;
+  }
+
+  /**
+   * Map an emitted-JavaScript specifier back to the TypeScript source it compiles
+   * from: `.js` → `.ts`/`.tsx`, `.mjs` → `.mts`, `.cjs` → `.cts`.
+   * Returns null when the specifier carries no such extension.
+   */
+  private async resolveEmittedExtension(basePath: string): Promise<string | null> {
+    const sourceExtensions: Record<string, string[]> = {
+      ".js": [".ts", ".tsx"],
+      ".jsx": [".tsx"],
+      ".mjs": [".mts"],
+      ".cjs": [".cts"],
+    };
+    const emitted = path.extname(basePath).toLowerCase();
+    const candidates = sourceExtensions[emitted];
+    if (!candidates) {
+      return null;
+    }
+
+    const withoutExtension = basePath.slice(0, -emitted.length);
+    for (const extension of candidates) {
+      const candidate = withoutExtension + extension;
+      if (await this.fileExists(candidate)) {
+        return normalizePath(candidate);
+      }
+    }
     return null;
   }
 

--- a/src/cli/formatter.ts
+++ b/src/cli/formatter.ts
@@ -232,6 +232,9 @@ function formatScalar(value: unknown): string {
 function formatTextObject(obj: Record<string, unknown>, indent: number): string {
   const prefix = "  ".repeat(indent);
   return Object.entries(obj)
+    // An absent optional field reads as missing information, not as the literal
+    // text "undefined".
+    .filter(([, v]) => v !== undefined)
     .map(([k, v]) => {
       if (typeof v === "object" && v !== null && !Array.isArray(v)) {
         return `${prefix}${k}:\n${formatTextObject(v as Record<string, unknown>, indent + 1)}`;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,8 @@
  *   --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
  *   --help, -h        Show this help message
  *   --version, -v     Show version
+ *   --reindex         Discard the cached index and rebuild it from scratch
+ *   --no-cache        Neither read nor write the index cache (also GRAPH_IT_NO_CACHE=1)
  *
  * CRITICAL ARCHITECTURE RULE: This module is completely VS Code agnostic!
  * NO import * as vscode from 'vscode' allowed!
@@ -53,6 +55,8 @@ const GLOBAL_OPTIONS: Record<string, { type: "string" | "boolean"; short?: strin
   format: { type: "string", short: "f" },
   help: { type: "boolean", short: "h" },
   version: { type: "boolean", short: "v" },
+  reindex: { type: "boolean" },
+  "no-cache": { type: "boolean" },
 };
 
 // Session stats: this process is the CLI entry point.
@@ -91,6 +95,8 @@ const HELP = `
 graph-it — Graph-It-Live standalone CLI
 
 Usage: graph-it <command> [options]
+       graph-it                      Start the interactive REPL (TTY only)
+       graph-it <command> --help     Per-command help and options
 
 Commands:
   scan              Index/re-index the workspace
@@ -120,6 +126,8 @@ Options:
   --format, -f      Output format: text|json|toon|markdown|mermaid (default: text)
   --help, -h        Show this help
   --version, -v     Show version
+  --reindex         Discard the cached index and rebuild it from scratch
+  --no-cache        Neither read nor write the index cache (also GRAPH_IT_NO_CACHE=1)
 
 Output Format Availability:
   Format    | scan | summary | trace | explain | path | architecture | check | tool
@@ -216,7 +224,6 @@ Examples:
   graph-it export --format html --output graph.html
   graph-it update
 `.trimStart();
-const HELP_WITH_CONTEXT = `${HELP}\n context <question>|--from <endpoint> --to <endpoint> Retrieve unified graph context`;
 
 // ============================================================================
 // Helpers
@@ -246,6 +253,23 @@ export function findCommandStart(argv: string[], command: string): number {
   return -1;
 }
 
+/**
+ * Build the runtime for this invocation, applying the index-cache flags.
+ *
+ * Exported so the flag semantics are unit-testable: `main()` itself only runs
+ * when the built bundle is the process entry point.
+ */
+export function createRuntime(
+  workspaceRoot: string,
+  values: { reindex?: unknown; "no-cache"?: unknown },
+): CliRuntime {
+  const runtime = new CliRuntime(workspaceRoot, { cache: !values["no-cache"] });
+  if (values.reindex) {
+    runtime.clearCache();
+  }
+  return runtime;
+}
+
 export function commandWantsHelp(command: string, commandArgs: string[], rawArgvSlice: string[]): boolean {
   return commandArgs.includes("--help") || commandArgs.includes("-h") ||
     (rawArgvSlice.includes("--help") && rawArgvSlice.indexOf(command) < rawArgvSlice.indexOf("--help")) ||
@@ -263,10 +287,10 @@ async function handleNoCommand(values: Record<string, unknown>): Promise<void> {
     const workspaceRoot = findWorkspaceRoot(path.resolve(workspaceRaw));
     await maybeNotifyCliUpdate({ workspaceRoot, currentVersion: VERSION });
     const { run } = await import("./commands/repl.js");
-    await run(new CliRuntime(workspaceRoot));
+    await run(createRuntime(workspaceRoot, values));
     process.exit(ExitCode.SUCCESS);
   }
-  process.stdout.write(HELP_WITH_CONTEXT);
+  process.stdout.write(HELP);
   process.exit(ExitCode.SUCCESS);
 }
 
@@ -305,7 +329,7 @@ async function main(): Promise<void> {
   // generic top-level HELP text. Only fall back to the generic HELP when
   // no command was given at all.
   if (values.help && !command) {
-    process.stdout.write(HELP_WITH_CONTEXT);
+    process.stdout.write(HELP);
     process.exit(ExitCode.SUCCESS);
   }
 
@@ -350,7 +374,7 @@ async function main(): Promise<void> {
   // Resolve workspace
   const workspaceRaw = (values.workspace as string | undefined) ?? process.cwd();
   const workspaceRoot = findWorkspaceRoot(path.resolve(workspaceRaw));
-  const runtime = new CliRuntime(workspaceRoot);
+  const runtime = createRuntime(workspaceRoot, values);
 
   // Commands that don't need a workspace (skip runtime init to avoid side-effects)
   const WORKSPACE_FREE = new Set(["install", "update", "stats"]);

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -17,6 +17,7 @@ import type { Spider } from "../analyzer/Spider";
 import { SpiderBuilder } from "../analyzer/SpiderBuilder";
 import { PathResolver } from "../analyzer/utils/PathResolver";
 import { workerState } from "../mcp/shared/state";
+import { normalizePath } from "../shared/path";
 import {
   getLogger,
   getLogLevelFromEnv,
@@ -305,7 +306,7 @@ export class CliRuntime {
       return (
         meta.schema === CACHE_SCHEMA &&
         meta.cliVersion === CLI_VERSION &&
-        meta.workspaceRoot === this.workspaceRoot
+        normalizePath(meta.workspaceRoot) === normalizePath(this.workspaceRoot)
       );
     } catch {
       return false;

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -12,6 +12,8 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { AstWorkerHost } from "../analyzer/ast/AstWorkerHost";
 import { Parser } from "../analyzer/Parser";
+import { SourceFileCollector } from "../analyzer/SourceFileCollector";
+import type { Spider } from "../analyzer/Spider";
 import { SpiderBuilder } from "../analyzer/SpiderBuilder";
 import { PathResolver } from "../analyzer/utils/PathResolver";
 import { workerState } from "../mcp/shared/state";
@@ -35,11 +37,63 @@ loggerFactory.setDefaultLevel(getLogLevelFromEnv("LOG_LEVEL"));
 
 const log = getLogger("CliRuntime");
 
+/** Injected at build time; "0.0.0-dev" in local builds. */
+const CLI_VERSION = process.env.CLI_VERSION ?? "0.0.0-dev";
+
 /** Persisted state written to .graph-it/state.json */
 export interface CliState {
   lastScanTimestamp?: string;
   filesIndexed?: number;
   workspaceRoot: string;
+}
+
+/** Layout version of .graph-it/cache/ itself. Bump when file names or roles change. */
+const CACHE_SCHEMA = 1;
+
+/**
+ * Above this fraction of added/changed/deleted files, a full rebuild is cheaper
+ * and safer than an incremental pass. Also the periodic self-heal for the
+ * known drift in incremental call-graph edge resolution.
+ */
+const STALE_THRESHOLD = 0.2;
+
+/** File names inside .graph-it/cache/ */
+const CACHE_META_FILE = "meta.json";
+const CACHE_REVERSE_INDEX_FILE = "reverse-index.json";
+const CACHE_CALLGRAPH_FILE = "callgraph.db";
+
+/** What one ensureIndexed() call actually did. */
+export interface IndexOutcome {
+  /** Source files held in the index once this run finished. */
+  filesIndexed: number;
+  /** Source files discovered on disk for this workspace. */
+  filesFound: number;
+  /** Files parsed during this run — 0 on a fully warm cache hit. */
+  filesAnalyzed: number;
+  /** Whether the index was restored from .graph-it/cache/ rather than rebuilt. */
+  fromCache: boolean;
+  /** Wall-clock time spent in ensureIndexed(). */
+  durationMs: number;
+}
+
+/** Guard written alongside the cached indexes. */
+interface CliCacheMeta {
+  schema: number;
+  cliVersion: string;
+  savedAt: string;
+  workspaceRoot: string;
+}
+
+/**
+ * Write a file atomically: temp file in the same directory, then rename.
+ * The pid suffix keeps concurrent CLI processes from colliding on the temp name.
+ * Mirrors the pattern in analyzer/stats/statsPersistence.ts.
+ */
+function writeFileAtomic(filePath: string, data: string | Uint8Array): void {
+  const dir = path.dirname(filePath);
+  const tmpPath = path.join(dir, `.${path.basename(filePath)}.${process.pid}.tmp`);
+  fs.writeFileSync(tmpPath, data);
+  fs.renameSync(tmpPath, filePath);
 }
 
 /**
@@ -78,13 +132,24 @@ function findTsConfig(rootDir: string): string | undefined {
 export class CliRuntime {
   readonly workspaceRoot: string;
   private readonly stateDir: string;
+  private readonly cacheDir: string;
+  private readonly cacheEnabled: boolean;
   private _initialized = false;
   private _indexReady = false;
+  private _reverseIndexRestored = false;
+  private _sourceFiles: string[] | null = null;
   private errorCollectorBackend: ErrorCollectorBackend | null = null;
 
-  constructor(workspaceRoot: string) {
+  constructor(workspaceRoot: string, options?: { cache?: boolean }) {
     this.workspaceRoot = path.resolve(workspaceRoot);
     this.stateDir = path.join(this.workspaceRoot, ".graph-it");
+    this.cacheDir = path.join(this.stateDir, "cache");
+    this.cacheEnabled = (options?.cache ?? true) && !process.env.GRAPH_IT_NO_CACHE;
+  }
+
+  /** Delete the persisted index cache. Backs the `--reindex` flag. */
+  clearCache(): void {
+    fs.rmSync(this.cacheDir, { recursive: true, force: true });
   }
 
   /** Whether the runtime has been initialized (Spider built + index ready) */
@@ -191,18 +256,67 @@ export class CliRuntime {
       excludeNodeModules: true,
       maxDepth: 50,
       extensionPath: cliExtensionPath,
+      // Undefined disables call-graph persistence — the MCP worker never sets it.
+      cacheDir: this.cacheEnabled ? this.cacheDir : undefined,
     };
     workerState.isReady = true;
     this._initialized = true;
 
+    if (this.cacheEnabled) {
+      this._reverseIndexRestored = this.tryRestoreReverseIndex();
+    }
+
     log.info("Runtime initialized for", this.workspaceRoot);
+  }
+
+  /**
+   * Restore the reverse index persisted by a previous CLI process.
+   * Any failure (missing, corrupt, stale guard) falls back to a cold build.
+   */
+  private tryRestoreReverseIndex(): boolean {
+    if (!this.isCacheMetaValid()) return false;
+
+    try {
+      const raw = fs.readFileSync(
+        path.join(this.cacheDir, CACHE_REVERSE_INDEX_FILE),
+        "utf-8",
+      );
+      // deserialize() re-checks the index version and rootDir on its own.
+      const restored = workerState.spider?.enableReverseIndex(raw) ?? false;
+      if (restored) log.info("Restored reverse index from cache");
+      return restored;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Validate the cache guard file.
+   *
+   * NOTE: CLI_VERSION is "0.0.0-dev" in a local build, so a rebuilt analyzer does
+   * NOT invalidate the cache during development — use `--reindex` there. Released
+   * builds carry a real version, and the extractor half is additionally covered by
+   * the dist/queries/*.scm mtime check.
+   */
+  private isCacheMetaValid(): boolean {
+    try {
+      const raw = fs.readFileSync(path.join(this.cacheDir, CACHE_META_FILE), "utf-8");
+      const meta = JSON.parse(raw) as CliCacheMeta;
+      return (
+        meta.schema === CACHE_SCHEMA &&
+        meta.cliVersion === CLI_VERSION &&
+        meta.workspaceRoot === this.workspaceRoot
+      );
+    } catch {
+      return false;
+    }
   }
 
   /**
    * Ensure the workspace is indexed (warmup / full build).
    * Streams progress to stderr.
    */
-  async ensureIndexed(options?: { silent?: boolean }): Promise<{ filesIndexed: number; durationMs: number }> {
+  async ensureIndexed(options?: { silent?: boolean }): Promise<IndexOutcome> {
     if (!this._initialized || !workerState.spider) {
       throw new CliError(
         "Runtime not initialized. Call init() first.",
@@ -214,6 +328,9 @@ export class CliRuntime {
       const warm = workerState.warmupInfo;
       return {
         filesIndexed: warm?.filesIndexed ?? 0,
+        filesFound: warm?.filesFound ?? warm?.filesIndexed ?? 0,
+        filesAnalyzed: warm?.filesAnalyzed ?? 0,
+        fromCache: warm?.fromCache ?? false,
         durationMs: warm?.durationMs ?? 0,
       };
     }
@@ -221,42 +338,164 @@ export class CliRuntime {
     const spider = workerState.spider;
     const startTime = Date.now();
     const silent = options?.silent ?? false;
+    // Names the work actually in progress: a warm run re-analyzes only the files
+    // that changed, and calling that "Indexing" over the whole workspace count
+    // would misreport where the answers come from.
+    let progressLabel = "Indexing";
 
-    // Subscribe to progress → stderr
     const unsubscribe = spider.subscribeToIndexStatus((snapshot) => {
-      if (!silent && snapshot.state === "indexing") {
+      // total === 0 means there is nothing to do — printing "0/0" reads as a bug.
+      if (!silent && snapshot.state === "indexing" && snapshot.total > 0) {
         process.stderr.write(
-          `\r  Indexing: ${snapshot.processed}/${snapshot.total} files...`,
+          `\r  ${progressLabel}: ${snapshot.processed}/${snapshot.total} files...`,
         );
       }
     });
 
     try {
-      const result = await spider.buildFullIndex();
+      const incremental = await this.tryIncrementalIndex(spider, {
+        silent,
+        onReindexStart: () => {
+          progressLabel = "Re-indexing changed";
+        },
+      });
+      const result = incremental ?? (await this.runFullIndex(spider, silent));
+
       const durationMs = Date.now() - startTime;
       if (!silent) {
-        process.stderr.write("\n");
+        process.stderr.write(this.describeOutcome(result) + "\n");
       }
-      log.info("Indexed", result.indexedFiles, "files in", result.duration, "ms");
+      log.info(
+        `${result.fromCache ? "Cache" : "Index"}: ${result.filesIndexed} files,`,
+        `${result.filesAnalyzed} analyzed in ${durationMs}ms`,
+      );
 
-      // Persist state
       this.saveState({
         lastScanTimestamp: new Date().toISOString(),
-        filesIndexed: result.indexedFiles,
+        filesIndexed: result.filesIndexed,
         workspaceRoot: this.workspaceRoot,
       });
 
-      workerState.warmupInfo = {
-        completed: true,
-        durationMs: result.duration,
-        filesIndexed: result.indexedFiles,
-      };
-
+      workerState.warmupInfo = { completed: true, durationMs, ...result };
       this._indexReady = true;
 
-      return { filesIndexed: result.indexedFiles, durationMs };
+      return { ...result, durationMs };
     } finally {
       unsubscribe();
+    }
+  }
+
+  /** One-line stderr summary naming where this run's index came from. */
+  private describeOutcome(result: Omit<IndexOutcome, "durationMs">): string {
+    if (!result.fromCache) {
+      return `\r  Indexed ${result.filesIndexed}/${result.filesFound} files`;
+    }
+    if (result.filesAnalyzed === 0) {
+      return `\r  Loaded ${result.filesIndexed} files from cache (nothing changed)`;
+    }
+    return `\r  Loaded ${result.filesIndexed} files from cache, re-indexed ${result.filesAnalyzed} changed`;
+  }
+
+  private async runFullIndex(
+    spider: Spider,
+    silent: boolean,
+  ): Promise<Omit<IndexOutcome, "durationMs">> {
+    if (!silent) {
+      process.stderr.write("\r  Indexing workspace...");
+    }
+    const result = await spider.buildFullIndex();
+    return {
+      // buildFullIndex counts every file it attempted, including ones that failed
+      // to parse; the reverse index holds only the files actually indexed.
+      filesIndexed: spider.getCacheStats().reverseIndexStats?.indexedFiles ?? result.indexedFiles,
+      filesFound: result.indexedFiles,
+      filesAnalyzed: result.indexedFiles,
+      fromCache: false,
+    };
+  }
+
+  /**
+   * Re-index only what changed since the cached index was written.
+   * Returns null when there is no usable cache or the workspace churned too much,
+   * in which case the caller falls back to a full build.
+   */
+  private async tryIncrementalIndex(
+    spider: Spider,
+    hooks: { silent: boolean; onReindexStart: () => void },
+  ): Promise<Omit<IndexOutcome, "durationMs"> | null> {
+    if (!this._reverseIndexRestored) return null;
+
+    const filesOnDisk = await this.collectSourceFiles();
+    const validation = await spider.validateReverseIndex(STALE_THRESHOLD, filesOnDisk);
+
+    if (!validation?.isValid) {
+      log.info("Cached index too stale, rebuilding from scratch");
+      return null;
+    }
+
+    for (const deleted of validation.missingFiles) {
+      spider.handleFileDeleted(deleted);
+    }
+
+    if (validation.staleFiles.length > 0) {
+      hooks.onReindexStart();
+    }
+    const reindexed = await spider.reindexStaleFiles(validation.staleFiles);
+
+    log.info(
+      `Incremental index: ${reindexed} changed, ${validation.missingFiles.length} deleted`,
+    );
+    return {
+      filesIndexed:
+        spider.getCacheStats().reverseIndexStats?.indexedFiles ?? filesOnDisk.length,
+      filesFound: filesOnDisk.length,
+      filesAnalyzed: reindexed,
+      fromCache: true,
+    };
+  }
+
+  /** Walk the workspace once per process and memoize the result. */
+  private async collectSourceFiles(): Promise<string[]> {
+    this._sourceFiles ??= await new SourceFileCollector({
+      excludeNodeModules: true,
+      yieldIntervalMs: 30,
+      isCancelled: () => false,
+    }).collectAllSourceFiles(this.workspaceRoot);
+    return this._sourceFiles;
+  }
+
+  /**
+   * Persist the reverse index and the call graph DB for the next CLI process.
+   * Best-effort: a cache that fails to write only costs the next run some time.
+   */
+  private saveCache(): void {
+    if (!this.cacheEnabled || !this._indexReady) return;
+
+    try {
+      fs.mkdirSync(this.cacheDir, { recursive: true });
+
+      const serialized = workerState.spider?.getSerializedReverseIndex();
+      if (serialized) {
+        writeFileAtomic(path.join(this.cacheDir, CACHE_REVERSE_INDEX_FILE), serialized);
+      }
+
+      if (workerState.callGraphIndexer) {
+        writeFileAtomic(
+          path.join(this.cacheDir, CACHE_CALLGRAPH_FILE),
+          workerState.callGraphIndexer.exportDb(),
+        );
+      }
+
+      const meta: CliCacheMeta = {
+        schema: CACHE_SCHEMA,
+        cliVersion: CLI_VERSION,
+        savedAt: new Date().toISOString(),
+        workspaceRoot: this.workspaceRoot,
+      };
+      // Written last: the guard is only valid once the payloads are on disk.
+      writeFileAtomic(path.join(this.cacheDir, CACHE_META_FILE), JSON.stringify(meta, null, 2));
+    } catch (err) {
+      log.warn("Could not save cache:", err instanceof Error ? err.message : String(err));
     }
   }
 
@@ -264,6 +503,11 @@ export class CliRuntime {
    * Dispose all resources.
    */
   async dispose(): Promise<void> {
+    // ponytail: last-writer-wins across concurrent CLI processes; both wrote a
+    // valid index of the same workspace. Add an flock if redundant indexing shows
+    // up in a profile.
+    this.saveCache();
+
     if (workerState.astWorkerHost) {
       await workerState.astWorkerHost.stop();
     }

--- a/src/extension/services/CallGraphViewService.ts
+++ b/src/extension/services/CallGraphViewService.ts
@@ -16,7 +16,7 @@
 import { CallGraphIndexer, getSqlJsWasmPath } from "@/analyzer/callgraph/CallGraphIndexer";
 import { queryNeighbourhood } from "@/analyzer/callgraph/CallGraphQuery";
 import { detectCycleEdges } from "@/analyzer/callgraph/cycleUtils";
-import { GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
+import { collectChangedFiles, getQueryFreshnessCutoffs, GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
 import { SourceFileCollector } from "@/analyzer/SourceFileCollector";
 import type {
   CallGraphExtensionMessage,
@@ -28,7 +28,6 @@ import type {
 import { normalizePath } from "@/shared/path";
 import { resolveReviewCallGraphPath, REVIEW_CALL_GRAPH_MAX_DEPTH, validateReviewCallGraphTarget } from "@/shared/reviewTarget";
 import crypto from "node:crypto";
-import fs from "node:fs/promises";
 import path from "node:path";
 import * as vscode from "vscode";
 import type { ExternalCallerResult, ICallGraphQueryService } from "./ICallGraphQueryService";
@@ -96,37 +95,6 @@ function langFromPath(filePath: string): SupportedLang | null {
   if (ext === ".java") return "java";
   // .csproj is XML — not suitable for call graph extraction
   return null;
-}
-
-/**
- * Returns per-language freshness cutoffs derived from query-file mtimes.
- * If a file was indexed before its language query was updated, it must be
- * re-extracted even if the source file mtime itself is unchanged.
- */
-async function getQueryFreshnessCutoffs(extensionPath: string): Promise<Record<SupportedLang, number>> {
-  const queryFiles: Record<SupportedLang, string> = {
-    typescript: path.join(extensionPath, "dist", "queries", "typescript.scm"),
-    javascript: path.join(extensionPath, "dist", "queries", "typescript.scm"),
-    python: path.join(extensionPath, "dist", "queries", "python.scm"),
-    rust: path.join(extensionPath, "dist", "queries", "rust.scm"),
-    csharp: path.join(extensionPath, "dist", "queries", "csharp.scm"),
-    go: path.join(extensionPath, "dist", "queries", "go.scm"),
-    java: path.join(extensionPath, "dist", "queries", "java.scm"),
-  };
-
-  const entries = await Promise.all(
-    (Object.entries(queryFiles) as Array<[SupportedLang, string]>).map(async ([lang, queryPath]) => {
-      try {
-        const stat = await fs.stat(queryPath);
-        return [lang, Math.floor(stat.mtimeMs)] as const;
-      } catch {
-        // Missing query file should not block indexing.
-        return [lang, 0] as const;
-      }
-    }),
-  );
-
-  return Object.fromEntries(entries) as Record<SupportedLang, number>;
 }
 
 // ---------------------------------------------------------------------------
@@ -577,51 +545,6 @@ export class CallGraphViewService implements vscode.Disposable, ICallGraphQueryS
   }
 
   /**
-   * Batch `fs.stat` all files and filter out those already fresh in the DB.
-   * Returns an array of jobs that need (re-)extraction plus the count of skipped files.
-   */
-  private async collectChangedFiles(
-    callgraphFiles: string[],
-    indexer: CallGraphIndexer,
-    queryFreshnessCutoffs: Record<SupportedLang, number>,
-  ): Promise<{ jobs: Array<{ filePath: string; lang: SupportedLang; mtime: number }>; skipped: number }> {
-    const jobs: Array<{ filePath: string; lang: SupportedLang; mtime: number }> = [];
-    let skipped = 0;
-    const STAT_BATCH = 32;
-
-    for (let i = 0; i < callgraphFiles.length; i += STAT_BATCH) {
-      const batch = callgraphFiles.slice(i, i + STAT_BATCH);
-      const stats = await Promise.all(
-        batch.map(async (fp) => {
-          try {
-            const s = await fs.stat(fp);
-            return { fp, mtime: Math.floor(s.mtimeMs), ok: true as const };
-          } catch {
-            return { fp, mtime: 0, ok: false as const };
-          }
-        }),
-      );
-      for (const s of stats) {
-        if (!s.ok) { skipped++; continue; }
-        const lang = langFromPath(s.fp);
-        if (!lang) { skipped++; continue; }
-
-        const record = indexer.getFileRecord(s.fp);
-        const queryCutoff = queryFreshnessCutoffs[lang] ?? 0;
-
-        // Skip only if both the source file AND extractor rules are still fresh.
-        if (record && record.lastModified >= s.mtime && record.indexedAt >= queryCutoff) {
-          skipped++;
-          continue;
-        }
-
-        jobs.push({ filePath: s.fp, lang, mtime: s.mtime });
-      }
-    }
-    return { jobs, skipped };
-  }
-
-  /**
    * Extract files in parallel batches, insert into the DB serially,
    * and accumulate edges for a final cycle-detection pass.
    */
@@ -733,7 +656,12 @@ export class CallGraphViewService implements vscode.Disposable, ICallGraphQueryS
 
     // Phase 1 — batch stat to find changed files
     const queryFreshnessCutoffs = await getQueryFreshnessCutoffs(this.context.extensionPath);
-    const { jobs, skipped } = await this.collectChangedFiles(callgraphFiles, indexer, queryFreshnessCutoffs);
+    const { jobs, skipped } = await collectChangedFiles(
+      callgraphFiles,
+      (f) => indexer.getFileRecord(f),
+      queryFreshnessCutoffs,
+      langFromPath,
+    );
     this.outputChannel.appendLine(`[CallGraph] ${jobs.length} files need (re-)extraction`);
 
     // Phase 2 — parallel extraction + serial DB insertion

--- a/src/mcp/shared/state.ts
+++ b/src/mcp/shared/state.ts
@@ -23,7 +23,14 @@ import type { McpWorkerConfig } from "../types";
 export interface WarmupInfo {
   completed: boolean;
   durationMs?: number;
+  /** Source files held in the index. */
   filesIndexed?: number;
+  /** Source files discovered on disk. */
+  filesFound?: number;
+  /** Files parsed during this run — 0 when a warm cache answered everything. */
+  filesAnalyzed?: number;
+  /** Whether the index was restored from disk rather than rebuilt. */
+  fromCache?: boolean;
 }
 
 /**

--- a/src/mcp/tools/callgraph.ts
+++ b/src/mcp/tools/callgraph.ts
@@ -12,9 +12,14 @@ import type { CallGraphEdge } from "@/analyzer/callgraph/CallGraphIndexer";
 import { CallGraphIndexer } from "@/analyzer/callgraph/CallGraphIndexer";
 import { detectCycleEdges } from "@/analyzer/callgraph/cycleUtils";
 import type { ExtractorConfig } from "@/analyzer/callgraph/GraphExtractor";
-import { fileExtToLang, GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
+import {
+  collectChangedFiles,
+  fileExtToLang,
+  getQueryFreshnessCutoffs,
+  GraphExtractor,
+} from "@/analyzer/callgraph/GraphExtractor";
 import { SourceFileCollector } from "@/analyzer/SourceFileCollector";
-import type { RelationType } from "@/shared/callgraph-types";
+import type { RelationType, SupportedLang } from "@/shared/callgraph-types";
 import { getLogger } from "@/shared/logger";
 import { normalizePath } from "@/shared/path";
 import fs from "node:fs/promises";
@@ -84,7 +89,7 @@ export async function ensureCallGraphReady(): Promise<void> {
   // Avoid duplicate indexing
   if (indexPromise !== null) return indexPromise;
 
-  indexPromise = doInitAndIndex(config.extensionPath, workspaceRoot);
+  indexPromise = doInitAndIndex(config.extensionPath, workspaceRoot, config.cacheDir);
   try {
     await indexPromise;
   } finally {
@@ -92,21 +97,133 @@ export async function ensureCallGraphReady(): Promise<void> {
   }
 }
 
+/**
+ * Above this share of files needing re-extraction, a clean rebuild beats an
+ * incremental pass — and it periodically heals the drift documented below.
+ */
+const REBUILD_THRESHOLD = 0.2;
+
+/** One file to extract, with its resolved language. */
+interface CallGraphJob {
+  filePath: string;
+  lang: SupportedLang;
+}
+
+/**
+ * Decide what to re-extract on top of a restored DB.
+ *
+ * Returns every file when the workspace churned past REBUILD_THRESHOLD, after
+ * wiping the DB clean — the caller then indexes from scratch.
+ *
+ * ponytail: two known drifts that only a rebuild heals.
+ *  1. resolveExternalEdges() permanently deletes unresolved `@@external:` stubs,
+ *     so an edge whose TARGET gained a symbol is not restored by re-extracting
+ *     the target alone. Importers of changed files are re-extracted to cover the
+ *     import-based cases; non-import resolution (dynamic dispatch, Go/Java
+ *     package-level) stays uncovered until the next full rebuild.
+ *  2. `is_cyclic` flags on edges of unchanged files are not recomputed, so a
+ *     cycle broken elsewhere can stay flagged until the next full rebuild.
+ */
+async function selectStaleJobs(
+  indexer: CallGraphIndexer,
+  callgraphFiles: string[],
+  extensionPath: string,
+): Promise<CallGraphJob[]> {
+  const onDisk = new Set(callgraphFiles);
+  invalidateMissingFiles(indexer, onDisk);
+
+  const cutoffs = await getQueryFreshnessCutoffs(extensionPath);
+  const { jobs } = await collectChangedFiles(
+    callgraphFiles,
+    (f) => indexer.getFileRecord(f),
+    cutoffs,
+  );
+
+  // Re-extract importers of changed files so cross-file edges get re-resolved.
+  // The Spider reverse index is already warm in this process, so this is free.
+  const selected = selectChangedJobs(jobs);
+  await addReferencingJobs(selected, jobs, onDisk);
+
+  if (shouldRebuild(callgraphFiles.length, selected.size)) {
+    return rebuildCallGraph(indexer, callgraphFiles);
+  }
+
+  return [...selected.values()];
+}
+
+function invalidateMissingFiles(
+  indexer: CallGraphIndexer,
+  onDisk: Set<string>,
+): void {
+  for (const indexed of indexer.getIndexSnapshot().files) {
+    if (!onDisk.has(indexed.path)) {
+      indexer.invalidateFile(indexed.path);
+    }
+  }
+}
+
+function selectChangedJobs(jobs: CallGraphJob[]): Map<string, CallGraphJob> {
+  return new Map(jobs.map((job) => [job.filePath, job]));
+}
+
+async function addReferencingJobs(
+  selected: Map<string, CallGraphJob>,
+  jobs: CallGraphJob[],
+  onDisk: Set<string>,
+): Promise<void> {
+  const spider = workerState.spider;
+  if (!spider) return;
+
+  for (const job of jobs) {
+    const referencingFiles = await spider.findReferencingFiles(job.filePath);
+    for (const referencing of referencingFiles) {
+      addImporterJob(selected, normalizePath(referencing.path), onDisk);
+    }
+  }
+}
+
+function addImporterJob(
+  selected: Map<string, CallGraphJob>,
+  importer: string,
+  onDisk: Set<string>,
+): void {
+  const lang = fileExtToLang(importer);
+  if (lang && onDisk.has(importer) && !selected.has(importer)) {
+    selected.set(importer, { filePath: importer, lang });
+  }
+}
+
+function shouldRebuild(fileCount: number, selectedCount: number): boolean {
+  return fileCount > 0 && selectedCount / fileCount > REBUILD_THRESHOLD;
+}
+
+async function rebuildCallGraph(
+  indexer: CallGraphIndexer,
+  callgraphFiles: string[],
+): Promise<CallGraphJob[]> {
+  log.info("Call graph cache too stale, rebuilding from scratch");
+  indexer.dispose();
+  await indexer.init();
+  return callgraphFiles.map((filePath) => ({
+    filePath,
+    lang: fileExtToLang(filePath) as SupportedLang,
+  }));
+}
+
 async function doInitAndIndex(
   extensionPath: string | undefined,
   workspaceRoot: string,
+  cacheDir?: string,
 ): Promise<void> {
   if (!extensionPath) {
     throw new Error("extensionPath required for call graph WASM parsers");
   }
 
   const startTime = Date.now();
-
-  // Initialize CallGraphIndexer (sql.js WASM)
-  const wasmPath = path.join(extensionPath, "dist", "wasm", "sqljs.wasm");
-  await fs.access(wasmPath); // fail fast if missing
-  const indexer = new CallGraphIndexer(wasmPath);
-  await indexer.init();
+  const { indexer, restored } = await initializeCallGraphIndexer(
+    extensionPath,
+    cacheDir,
+  );
 
   // Initialize GraphExtractor (tree-sitter WASM)
   const extractorConfig: ExtractorConfig = {
@@ -126,47 +243,23 @@ async function doInitAndIndex(
     .map(normalizePath)
     .filter((f) => fileExtToLang(f) !== null);
 
-  log.info(`Indexing ${callgraphFiles.length} files for call graph…`);
+  const jobs = await selectCallGraphJobs(
+    restored,
+    indexer,
+    callgraphFiles,
+    extensionPath,
+  );
 
-  // Extract + index all files in batches
-  const allEdges: CallGraphEdge[] = [];
-  indexer.beginBatch();
-  try {
-    for (const filePath of callgraphFiles) {
-      const lang = fileExtToLang(filePath);
-      if (!lang) continue;
-      try {
-        const stat = await fs.stat(filePath);
-        const result = await extractor.extractFile(filePath, lang, stat.mtimeMs);
-        if (result.nodes.length > 0) {
-          indexer.indexFile(result.nodes, result.edges, filePath, lang, stat.mtimeMs);
-          allEdges.push(...result.edges);
-        }
-      } catch {
-        // Skip files that fail to parse (binary files, encoding issues, etc.)
-      }
-    }
-    indexer.commitBatch();
-  } catch (err) {
-    indexer.rollbackBatch();
-    throw err;
-  }
+  log.info(
+    `Indexing ${jobs.length}/${callgraphFiles.length} files for call graph` +
+      (restored ? " (incremental)" : ""),
+  );
+
+  // Extract + index the selected files in batches
+  const allEdges = await indexCallGraphJobs(indexer, extractor, jobs);
 
   // Cycle detection
-  const nonUsesEdges = allEdges
-    .filter((e) => e.typeRelation !== "USES")
-    .map((e) => ({ source: e.sourceId, target: e.targetId }));
-  if (nonUsesEdges.length > 0) {
-    const cycleEdgeKeys = detectCycleEdges(nonUsesEdges);
-    const cyclicPairs = allEdges.filter((e) =>
-      cycleEdgeKeys.has(`${e.sourceId}->${e.targetId}`),
-    );
-    if (cyclicPairs.length > 0) {
-      indexer.markCycles(
-        cyclicPairs.map((e) => ({ sourceId: e.sourceId, targetId: e.targetId })),
-      );
-    }
-  }
+  markCycleEdges(indexer, allEdges);
 
   // Resolve cross-file edges
   const resolveStats = indexer.resolveExternalEdges();
@@ -185,6 +278,88 @@ async function doInitAndIndex(
 
   const duration = Date.now() - startTime;
   log.info(`Call graph indexed ${callgraphFiles.length} files in ${duration}ms`);
+}
+
+async function initializeCallGraphIndexer(
+  extensionPath: string,
+  cacheDir?: string,
+): Promise<{ indexer: CallGraphIndexer; restored: boolean }> {
+  const wasmPath = path.join(extensionPath, "dist", "wasm", "sqljs.wasm");
+  await fs.access(wasmPath);
+  const indexer = new CallGraphIndexer(wasmPath);
+  const dbPath = cacheDir ? path.join(cacheDir, "callgraph.db") : null;
+  const restored = dbPath ? await indexer.loadFromFile(dbPath) : false;
+  if (!restored) await indexer.init();
+  return { indexer, restored };
+}
+
+async function selectCallGraphJobs(
+  restored: boolean,
+  indexer: CallGraphIndexer,
+  callgraphFiles: string[],
+  extensionPath: string,
+): Promise<CallGraphJob[]> {
+  if (restored) {
+    return selectStaleJobs(indexer, callgraphFiles, extensionPath);
+  }
+  return callgraphFiles.map((filePath) => ({
+    filePath,
+    lang: fileExtToLang(filePath)!,
+  }));
+}
+
+async function indexCallGraphJobs(
+  indexer: CallGraphIndexer,
+  extractor: GraphExtractor,
+  jobs: CallGraphJob[],
+): Promise<CallGraphEdge[]> {
+  const allEdges: CallGraphEdge[] = [];
+  indexer.beginBatch();
+  try {
+    for (const job of jobs) {
+      await indexCallGraphJob(indexer, extractor, job, allEdges);
+    }
+    indexer.commitBatch();
+  } catch (err) {
+    indexer.rollbackBatch();
+    throw err;
+  }
+  return allEdges;
+}
+
+async function indexCallGraphJob(
+  indexer: CallGraphIndexer,
+  extractor: GraphExtractor,
+  job: CallGraphJob,
+  allEdges: CallGraphEdge[],
+): Promise<void> {
+  try {
+    const stat = await fs.stat(job.filePath);
+    const result = await extractor.extractFile(job.filePath, job.lang, stat.mtimeMs);
+    if (result.nodes.length > 0) {
+      indexer.indexFile(result.nodes, result.edges, job.filePath, job.lang, stat.mtimeMs);
+      allEdges.push(...result.edges);
+    }
+  } catch {
+    // Skip files that fail to parse (binary files, encoding issues, etc.)
+  }
+}
+
+function markCycleEdges(indexer: CallGraphIndexer, allEdges: CallGraphEdge[]): void {
+  const nonUsesEdges = allEdges
+    .filter((e) => e.typeRelation !== "USES")
+    .map((e) => ({ source: e.sourceId, target: e.targetId }));
+  if (nonUsesEdges.length === 0) return;
+
+  const cycleEdgeKeys = detectCycleEdges(nonUsesEdges);
+  const cyclicPairs = allEdges.filter((e) =>
+    cycleEdgeKeys.has(`${e.sourceId}->${e.targetId}`),
+  );
+  if (cyclicPairs.length > 0) {
+    indexer.markCycles(
+      cyclicPairs.map((e) => ({ sourceId: e.sourceId, targetId: e.targetId })),
+    );
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mcp/tools/workspace.ts
+++ b/src/mcp/tools/workspace.ts
@@ -35,6 +35,18 @@ export async function executeGetIndexStatus(): Promise<GetIndexStatusResult> {
           }
         : undefined,
     warmup: workerState.warmupInfo,
+    // Distinct from reverseIndexStats: the call graph only covers languages that
+    // have a Tree-sitter query, so its file count is legitimately lower.
+    callGraph: workerState.callGraphIndexer
+      ? (() => {
+          const counts = workerState.callGraphIndexer.getCounts();
+          return {
+            indexedFiles: counts.files,
+            symbols: counts.symbols,
+            relations: counts.relations,
+          };
+        })()
+      : undefined,
   };
 }
 

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -61,6 +61,12 @@ export interface McpWorkerConfig {
   extensionPath?: string;
   excludeNodeModules: boolean;
   maxDepth: number;
+  /**
+   * Directory where analysis indexes may be persisted between processes.
+   * Only the CLI sets this; the MCP worker leaves it undefined and keeps
+   * building a fresh in-memory index on every start.
+   */
+  cacheDir?: string;
 }
 
 /**
@@ -1181,8 +1187,24 @@ export interface GetIndexStatusResult {
     completed: boolean;
     /** Time taken for warmup in ms (if completed) */
     durationMs?: number;
-    /** Number of files indexed during warmup */
+    /** Number of source files held in the index */
     filesIndexed?: number;
+    /** Number of source files discovered on disk */
+    filesFound?: number;
+    /** Files parsed during this run — 0 when a warm cache answered everything */
+    filesAnalyzed?: number;
+    /** Whether the index was restored from disk rather than rebuilt */
+    fromCache?: boolean;
+  };
+  /**
+   * Call graph coverage, when a call graph has been built. Its file count is
+   * lower than reverseIndexStats.indexedFiles because the call graph only covers
+   * languages that ship a Tree-sitter query.
+   */
+  callGraph?: {
+    indexedFiles: number;
+    symbols: number;
+    relations: number;
   };
 }
 

--- a/tests/analyzer/EsmJsSpecifier.test.ts
+++ b/tests/analyzer/EsmJsSpecifier.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import path from 'node:path';
+import { PathResolver } from '../../src/analyzer/utils/PathResolver';
+import { normalizePath } from '../../src/analyzer/types';
+import * as fs from 'node:fs/promises';
+
+vi.mock('node:fs/promises');
+
+/**
+ * TypeScript's NodeNext/ESM resolution requires import specifiers to carry the
+ * *emitted* extension: you write `./commands/scan.js` to import `scan.ts`.
+ * Without the remap those edges are silently missing from the dependency graph —
+ * in this repository that hid every dynamic import of the CLI dispatcher, so the
+ * command modules looked as though nothing referenced them.
+ */
+describe('PathResolver - emitted ESM specifiers', () => {
+  let resolver: PathResolver;
+  const rootDir = path.resolve(process.cwd(), 'temp-esm-root');
+  const np = (value: string) => normalizePath(value);
+
+  /** Mock a filesystem containing exactly the given files. */
+  const withFiles = (...files: string[]) => {
+    const present = new Set(files.map(np));
+    vi.mocked(fs.stat).mockImplementation(async (candidate) => {
+      if (present.has(np(candidate.toString()))) {
+        return { isFile: () => true } as never;
+      }
+      throw new Error('ENOENT');
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolver = new PathResolver();
+  });
+
+  it('resolves a .js specifier to the .ts source', async () => {
+    const source = path.join(rootDir, 'commands', 'scan.ts');
+    withFiles(source);
+
+    const resolved = await resolver.resolve(path.join(rootDir, 'index.ts'), './commands/scan.js');
+
+    expect(resolved).toBe(np(source));
+  });
+
+  it('resolves a .js specifier to a .tsx source', async () => {
+    const source = path.join(rootDir, 'ui', 'Panel.tsx');
+    withFiles(source);
+
+    const resolved = await resolver.resolve(path.join(rootDir, 'index.ts'), './ui/Panel.js');
+
+    expect(resolved).toBe(np(source));
+  });
+
+  it('resolves .mjs to .mts and .cjs to .cts', async () => {
+    const esm = path.join(rootDir, 'esm.mts');
+    const cjs = path.join(rootDir, 'legacy.cts');
+    withFiles(esm, cjs);
+    const from = path.join(rootDir, 'index.ts');
+
+    expect(await resolver.resolve(from, './esm.mjs')).toBe(np(esm));
+    expect(await resolver.resolve(from, './legacy.cjs')).toBe(np(cjs));
+  });
+
+  it('prefers a real .js file over the .ts remap', async () => {
+    // A genuine JavaScript file on disk must win: the remap is a fallback, not an
+    // override, or a mixed JS/TS project would resolve to the wrong file.
+    const real = path.join(rootDir, 'vendor', 'shim.js');
+    const shadow = path.join(rootDir, 'vendor', 'shim.ts');
+    withFiles(real, shadow);
+
+    const resolved = await resolver.resolve(path.join(rootDir, 'index.ts'), './vendor/shim.js');
+
+    expect(resolved).toBe(np(real));
+  });
+
+  it('leaves an unresolvable specifier unresolved', async () => {
+    withFiles(path.join(rootDir, 'index.ts'));
+
+    const resolved = await resolver.resolve(path.join(rootDir, 'index.ts'), './missing.js');
+
+    expect(resolved).toBeNull();
+  });
+
+  it('still resolves an extensionless specifier', async () => {
+    const source = path.join(rootDir, 'commands', 'scan.ts');
+    withFiles(source);
+
+    const resolved = await resolver.resolve(path.join(rootDir, 'index.ts'), './commands/scan');
+
+    expect(resolved).toBe(np(source));
+  });
+});

--- a/tests/analyzer/ReverseIndexFilesOnDisk.test.ts
+++ b/tests/analyzer/ReverseIndexFilesOnDisk.test.ts
@@ -4,6 +4,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ReverseIndex } from "../../src/analyzer/ReverseIndex";
 import type { Dependency } from "../../src/analyzer/types";
+import { normalizePath } from "../../src/shared/path";
 
 /**
  * validateIndex() historically only checked files it had already indexed, so a
@@ -47,7 +48,9 @@ describe("ReverseIndex.validateIndex with filesOnDisk", () => {
 
     const result = await index.validateIndex(0.6, [indexed, created]);
 
-    expect(result.staleFiles).toContain(created);
+    // The index stores normalized paths: forward slashes and a lowercased
+    // Windows drive letter. Compare in that form, not in the raw OS form.
+    expect(result.staleFiles).toContain(normalizePath(created));
     expect(result.missingFiles).toHaveLength(0);
   });
 
@@ -99,7 +102,53 @@ describe("ReverseIndex.validateIndex with filesOnDisk", () => {
 
     const result = await index.validateIndex(0.2, []);
 
-    expect(result.missingFiles).toEqual([gone]);
+    expect(result.missingFiles).toEqual([normalizePath(gone)]);
+  });
+
+  // Windows path handling, runnable on every OS: filesOnDisk comes straight from
+  // the caller, so the drive-letter case and the separator style must not decide
+  // whether a file counts as already indexed. These cases need no filesystem —
+  // the "already indexed?" check is a pure lookup against the normalized keys.
+  describe("Windows-shaped input paths", () => {
+    const WIN_ROOT = "C:\\proj";
+    let winIndex: ReverseIndex;
+
+    beforeEach(() => {
+      winIndex = new ReverseIndex(WIN_ROOT);
+      winIndex.addDependencies(
+        "C:\\proj\\src\\a.ts",
+        [{ path: "C:\\proj\\src\\target.ts", type: "import", line: 1, module: "./target" }],
+        { mtime: 1, size: 1 },
+      );
+    });
+
+    it("treats a backslash path as the file already indexed under its normalized key", async () => {
+      const result = await winIndex.validateIndex(1, ["C:\\proj\\src\\a.ts"]);
+
+      expect(result.staleFiles).not.toContain("c:/proj/src/a.ts");
+      expect(result.staleFiles).toHaveLength(0);
+    });
+
+    it("matches whatever the case of the drive letter is", async () => {
+      // The index was populated through an uppercase "C:"; a lowercase "c:" must
+      // resolve to the same entry. Only the drive letter is case-folded — the rest
+      // of the path is left alone, which is what normalizePath() guarantees.
+      const result = await winIndex.validateIndex(1, ["c:\\proj\\src\\a.ts"]);
+
+      expect(result.staleFiles).toHaveLength(0);
+    });
+
+    it("reports an unknown Windows path as stale in normalized form", async () => {
+      const result = await winIndex.validateIndex(1, ["C:\\proj\\src\\b.ts"]);
+
+      expect(result.staleFiles).toEqual(["c:/proj/src/b.ts"]);
+    });
+
+    it("accepts forward-slash input for the same file", async () => {
+      const result = await winIndex.validateIndex(1, ["c:/proj/src/a.ts"]);
+
+      expect(result.staleFiles).toHaveLength(0);
+    });
   });
 
   it("behaves exactly as before when filesOnDisk is omitted", async () => {

--- a/tests/analyzer/ReverseIndexFilesOnDisk.test.ts
+++ b/tests/analyzer/ReverseIndexFilesOnDisk.test.ts
@@ -1,0 +1,116 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ReverseIndex } from "../../src/analyzer/ReverseIndex";
+import type { Dependency } from "../../src/analyzer/types";
+
+/**
+ * validateIndex() historically only checked files it had already indexed, so a
+ * file created on disk since the index was written stayed invisible. The CLI has
+ * no file watcher to compensate, so it passes the on-disk file list explicitly.
+ */
+describe("ReverseIndex.validateIndex with filesOnDisk", () => {
+  let tmpDir: string;
+  let index: ReverseIndex;
+
+  const write = (name: string, content = "export const x = 1;\n"): string => {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  };
+
+  const deps = (targetPath: string): Dependency[] => [
+    { path: targetPath, type: "import", line: 1, module: "./target" },
+  ];
+
+  /** Index a file the way SpiderDependencyAnalyzer does: with its on-disk hash. */
+  const indexFile = async (filePath: string, targetPath: string): Promise<void> => {
+    const hash = await ReverseIndex.getFileHashFromDisk(filePath);
+    index.addDependencies(filePath, deps(targetPath), hash ?? undefined);
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "graph-it-validate-"));
+    index = new ReverseIndex(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reports a never-indexed file on disk as stale", async () => {
+    const target = write("target.ts");
+    const indexed = write("a.ts");
+    await indexFile(indexed, target);
+    const created = write("brand-new.ts");
+
+    const result = await index.validateIndex(0.6, [indexed, created]);
+
+    expect(result.staleFiles).toContain(created);
+    expect(result.missingFiles).toHaveLength(0);
+  });
+
+  it("leaves already-indexed unchanged files out of staleFiles", async () => {
+    const target = write("target.ts");
+    const indexed = write("a.ts");
+    await indexFile(indexed, target);
+
+    const result = await index.validateIndex(0.2, [indexed]);
+
+    expect(result.staleFiles).toHaveLength(0);
+    expect(result.isValid).toBe(true);
+    expect(result.stalePercentage).toBe(0);
+  });
+
+  it("counts new files in the denominator instead of inflating the ratio", async () => {
+    const target = write("target.ts");
+    const onDisk: string[] = [];
+    for (let i = 0; i < 9; i++) {
+      const filePath = write(`f${i}.ts`);
+      await indexFile(filePath, target);
+      onDisk.push(filePath);
+    }
+    onDisk.push(write("new.ts"));
+
+    const result = await index.validateIndex(0.2, onDisk);
+
+    // 1 new file out of 10 considered — under the 20% threshold.
+    expect(result.stalePercentage).toBeCloseTo(0.1, 5);
+    expect(result.isValid).toBe(true);
+  });
+
+  it("rejects the index when too many files are new", async () => {
+    const target = write("target.ts");
+    const indexed = write("a.ts");
+    await indexFile(indexed, target);
+
+    const result = await index.validateIndex(0.2, [indexed, write("b.ts"), write("c.ts")]);
+
+    expect(result.isValid).toBe(false);
+    expect(result.staleFiles).toHaveLength(2);
+  });
+
+  it("still reports deleted files as missing", async () => {
+    const target = write("target.ts");
+    const gone = write("gone.ts");
+    await indexFile(gone, target);
+    fs.rmSync(gone);
+
+    const result = await index.validateIndex(0.2, []);
+
+    expect(result.missingFiles).toEqual([gone]);
+  });
+
+  it("behaves exactly as before when filesOnDisk is omitted", async () => {
+    const target = write("target.ts");
+    const indexed = write("a.ts");
+    await indexFile(indexed, target);
+    write("invisible-without-the-list.ts");
+
+    const result = await index.validateIndex(0.2);
+
+    expect(result.staleFiles).toHaveLength(0);
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/tests/analyzer/ReviewGateAnalyzer.test.ts
+++ b/tests/analyzer/ReviewGateAnalyzer.test.ts
@@ -59,8 +59,10 @@ describe("ReviewGateAnalyzer", () => {
       changedFiles: ["src/<bad>|.ts"],
       symbols: [{
         name: "bad|<script>", filePath: "src/<bad>|.ts", score: 80, risk: "critical", breakingChanges: [], impactedSymbolCount: 0,
+        // Consumer paths reach the Markdown too, so they must be escaped as well.
+        consumers: { updated: [], covered: [], unverified: ["src/<evil>|.ts"] },
         cycleEvidence: [], unusedExportEvidence: false, testCandidates: [],
-        scoreFactors: { breakingChanges: 0, dependents: 0, cycles: 0, unusedExport: 0, missingTestCandidate: 0, partialImpact: 0 }, evidence: [],
+        scoreFactors: { breakingChanges: 0, unverifiedConsumers: 5, cycles: 0, unusedExport: 0, missingTestCandidate: 0, partialImpact: 0 }, evidence: [],
       }],
       score: 80,
       risk: "critical",
@@ -70,6 +72,52 @@ describe("ReviewGateAnalyzer", () => {
     expect(markdown).toContain("## Graph-It Review Gate: CRITICAL (80/100)");
     expect(markdown).not.toContain("<script>");
     expect(markdown).not.toContain("bad|<");
+    expect(markdown).not.toContain("<evil>");
+  });
+
+  it("renders the consumer buckets, not a raw dependent count", () => {
+    const markdown = renderReviewMarkdown({
+      baseRef: "main",
+      headRef: "HEAD",
+      changedFiles: ["src/api.ts"],
+      symbols: [{
+        name: "greet", filePath: "src/api.ts", score: 25, risk: "medium", breakingChanges: [], impactedSymbolCount: 42,
+        consumers: { updated: ["src/a.ts"], covered: ["src/b.ts", "src/c.ts"], unverified: ["src/d.ts"] },
+        cycleEvidence: [], unusedExportEvidence: false, testCandidates: [],
+        scoreFactors: { breakingChanges: 25, unverifiedConsumers: 5, cycles: 0, unusedExport: 0, missingTestCandidate: 0, partialImpact: 0 }, evidence: [],
+      }],
+      score: 25,
+      risk: "medium",
+      isPartial: false,
+      limitations: [],
+    });
+
+    expect(markdown).toContain("| Risk | Score | File | Symbol | Updated | Covered | Unverified |");
+    expect(markdown).toContain("| medium | 25 | src/api.ts | greet | 1 | 2 | 1 |");
+    expect(markdown).toContain("### Consumers to check");
+    expect(markdown).toContain("- greet: src/d.ts");
+    // The raw dependent count is context, not the headline the old table led with.
+    expect(markdown).not.toContain("42");
+  });
+
+  it("omits the consumer section when the change requires no call-site update", () => {
+    const markdown = renderReviewMarkdown({
+      baseRef: "main",
+      headRef: "HEAD",
+      changedFiles: ["src/api.ts"],
+      symbols: [{
+        name: "greet", filePath: "src/api.ts", score: 25, risk: "medium", breakingChanges: [], impactedSymbolCount: 3,
+        consumers: { updated: [], covered: [], unverified: ["src/d.ts"] },
+        cycleEvidence: [], unusedExportEvidence: false, testCandidates: [],
+        scoreFactors: { breakingChanges: 25, unverifiedConsumers: 0, cycles: 0, unusedExport: 0, missingTestCandidate: 0, partialImpact: 0 }, evidence: [],
+      }],
+      score: 25,
+      risk: "medium",
+      isPartial: false,
+      limitations: [],
+    });
+
+    expect(markdown).not.toContain("### Consumers to check");
   });
 
   it("maps score thresholds predictably", () => {
@@ -109,7 +157,7 @@ describe("ReviewGateAnalyzer", () => {
       score: 10,
       risk: "low",
       impactedSymbolCount: 0,
-      scoreFactors: { breakingChanges: 0, dependents: 0, missingTestCandidate: 10 },
+      scoreFactors: { breakingChanges: 0, unverifiedConsumers: 0, missingTestCandidate: 10 },
     });
     expect(result.symbols[0].evidence.some((e) => e.kind === "impact")).toBe(false);
   });
@@ -128,7 +176,7 @@ describe("ReviewGateAnalyzer", () => {
       score: 15,
       risk: "low",
       impactedSymbolCount: 0,
-      scoreFactors: { breakingChanges: 5, dependents: 0, missingTestCandidate: 10 },
+      scoreFactors: { breakingChanges: 5, unverifiedConsumers: 0, missingTestCandidate: 10 },
     });
   });
 
@@ -145,7 +193,7 @@ describe("ReviewGateAnalyzer", () => {
       name: "greet",
       score: 60,
       risk: "high",
-      scoreFactors: { breakingChanges: 50, dependents: 0, missingTestCandidate: 10 },
+      scoreFactors: { breakingChanges: 50, unverifiedConsumers: 0, missingTestCandidate: 10 },
     });
   });
 
@@ -167,10 +215,11 @@ describe("ReviewGateAnalyzer", () => {
 
     expect(result.symbols[0]).toMatchObject({
       name: "greet",
-      score: 45,
+      score: 40,
       risk: "medium",
       impactedSymbolCount: 2,
-      scoreFactors: { breakingChanges: 25, dependents: 10, missingTestCandidate: 0 },
+      // Only src/consumer.ts is unverified: the test consumer is coverage, not risk.
+      scoreFactors: { breakingChanges: 25, unverifiedConsumers: 5, partialImpact: 10, missingTestCandidate: 0 },
     });
     expect(result.symbols[0].evidence).toEqual(expect.arrayContaining([
       { kind: "test-candidate", detail: "Symbol is directly depended on by an existing test — a real incompatibility would fail that test." },
@@ -195,7 +244,7 @@ describe("ReviewGateAnalyzer", () => {
       score: 10,
       risk: "low",
       impactedSymbolCount: 0,
-      scoreFactors: { breakingChanges: 0, dependents: 0, missingTestCandidate: 10 },
+      scoreFactors: { breakingChanges: 0, unverifiedConsumers: 0, missingTestCandidate: 10 },
     });
   });
 
@@ -273,5 +322,261 @@ describe("ReviewGateAnalyzer", () => {
     expect(result.limitations).toEqual(expect.arrayContaining([
       "Signature evidence unavailable for src/api.ts: parser failure.",
     ]));
+  });
+});
+
+describe("ReviewGateAnalyzer - test candidate discovery", () => {
+  /**
+   * Regression: candidates kept the "src/" segment, so the lookup searched
+   * tests/src/<area>/ — a directory the mirrored layout never has. Every symbol
+   * of every src/** file was therefore scored as untested.
+   */
+  it("finds a mirrored test under tests/<area>/ for a src/<area>/ file", async () => {
+    const workspace = await createGitWorkspace();
+    await fs.mkdir(path.join(workspace, "tests", "src"), { recursive: true });
+    // The mirrored location the repository convention actually uses.
+    await fs.writeFile(path.join(workspace, "tests", "api.test.ts"), "// covers src/api.ts\n");
+
+    const result = await new ReviewGateAnalyzer(workspace).analyze({ baseRef: "main" });
+
+    expect(result.symbols[0].testCandidates).toContain("tests/api.test.ts");
+    expect(result.symbols[0].scoreFactors.missingTestCandidate).toBe(0);
+  });
+
+  it("still scores a symbol with no test file anywhere as untested", async () => {
+    const workspace = await createGitWorkspace();
+
+    const result = await new ReviewGateAnalyzer(workspace).analyze({ baseRef: "main" });
+
+    expect(result.symbols[0].testCandidates).toEqual([]);
+    expect(result.symbols[0].scoreFactors.missingTestCandidate).toBe(10);
+  });
+
+  it("finds a test colocated next to the source file", async () => {
+    const workspace = await createGitWorkspace();
+    await fs.writeFile(path.join(workspace, "src", "api.test.ts"), "// colocated\n");
+
+    const result = await new ReviewGateAnalyzer(workspace).analyze({ baseRef: "main" });
+
+    expect(result.symbols[0].testCandidates).toContain("src/api.test.ts");
+  });
+});
+
+describe("ReviewGateAnalyzer - member-level impact", () => {
+  // A new required parameter: every call site has to be edited, so the consumer
+  // count genuinely matters here (unlike a return-type change, which leaves calls valid).
+  const OLD_CLASS = "export class Service {\n  run(name: string): string { return name; }\n}\n";
+  const NEW_CLASS = "export class Service {\n  run(name: string, formal: boolean): string { return name; }\n}\n";
+
+  /**
+   * Regression: the dependent index is keyed on exported symbols, not on class
+   * members, so a member lookup returned 0 whether the member had no callers or
+   * was simply not tracked. The analyzer read that as "confirmed zero impact"
+   * and divided the breaking-change weight by ten.
+   */
+  it("falls back to the containing symbol and marks the count partial", async () => {
+    const workspace = await createGitWorkspaceWithDiff(OLD_CLASS, NEW_CLASS);
+    const dependents = {
+      getSymbolDependents: (_filePath: string, symbolName: string) =>
+        Promise.resolve(
+          symbolName === "Service"
+            ? [{ sourceSymbolId: `${path.join(workspace, "src/consumer.ts")}:useService` }]
+            : [],
+        ),
+    };
+
+    const result = await new ReviewGateAnalyzer(workspace, dependents as never).analyze({ baseRef: "main" });
+
+    const symbol = result.symbols.find((s) => s.name.endsWith("run"));
+    expect(symbol?.impactedSymbolCount).toBe(1);
+    // Not the 5-point "confirmed zero impact" weight.
+    expect(symbol?.scoreFactors.breakingChanges).toBeGreaterThan(5);
+    expect(symbol?.evidence.some((e) => e.kind === "partial" && e.detail.includes("per member"))).toBe(true);
+  });
+
+  it("keeps a genuine zero when the containing symbol has no dependents either", async () => {
+    const workspace = await createGitWorkspaceWithDiff(OLD_CLASS, NEW_CLASS);
+    const dependents = { getSymbolDependents: () => Promise.resolve([]) };
+
+    const result = await new ReviewGateAnalyzer(workspace, dependents as never).analyze({ baseRef: "main" });
+
+    const symbol = result.symbols.find((s) => s.name.endsWith("run"));
+    expect(symbol?.impactedSymbolCount).toBe(0);
+    expect(symbol?.scoreFactors.breakingChanges).toBe(5);
+  });
+});
+
+describe("ReviewGateAnalyzer - consumer standing", () => {
+  const OLD_API = "export function greet(name: string): string { return name; }\n";
+  const NEW_API = "export function greet(name: string, formal: boolean): string { return name; }\n";
+
+  /**
+   * The gate answers "did we update every consumer, and is the rest under test?".
+   * A widely used contract whose consumers are all handled is a well-managed
+   * change, not a risky one — so the score follows the unverified remainder, not
+   * the raw consumer count.
+   */
+  const analyzerWith = async (consumerFiles: string[], edges: Record<string, string[]> = {}) => {
+    const workspace = await createGitWorkspaceWithDiff(OLD_API, NEW_API);
+    const dependents = {
+      getSymbolDependents: (filePath: string) => {
+        const relative = filePath.slice(workspace.length + 1).replaceAll("\\", "/");
+        const children = relative === "src/api.ts" ? consumerFiles : (edges[relative] ?? []);
+        return Promise.resolve(
+          children.map((file) => ({ sourceSymbolId: `${path.join(workspace, file)}:consumer` })),
+        );
+      },
+    };
+    return { workspace, analyzer: new ReviewGateAnalyzer(workspace, dependents as never) };
+  };
+
+  it("counts a consumer the diff does not touch and no test reaches as unverified", async () => {
+    const { analyzer } = await analyzerWith(["src/consumer.ts"]);
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main" })).symbols;
+
+    expect(symbol.consumers).toEqual({ updated: [], covered: [], unverified: ["src/consumer.ts"] });
+    expect(symbol.scoreFactors.unverifiedConsumers).toBe(5);
+  });
+
+  it("treats a consumer the diff already updates as handled", async () => {
+    const { workspace, analyzer } = await analyzerWith(["src/consumer.ts"]);
+    // The author updated the consumer in the same change set. It has to be tracked:
+    // git diff reports added and modified files, never untracked ones.
+    await fs.writeFile(path.join(workspace, "src", "consumer.ts"), "export const consumer = 1;\n");
+    execFileSync("git", ["add", "src/consumer.ts"], { cwd: workspace });
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main" })).symbols
+      .filter((candidate) => candidate.filePath === "src/api.ts");
+
+    expect(symbol.consumers.updated).toEqual(["src/consumer.ts"]);
+    expect(symbol.consumers.unverified).toEqual([]);
+    expect(symbol.scoreFactors.unverifiedConsumers).toBe(0);
+  });
+
+  it("treats a consumer reached by a test as covered, not as risk", async () => {
+    const { analyzer } = await analyzerWith(
+      ["src/consumer.ts"],
+      { "src/consumer.ts": ["tests/consumer.test.ts"] },
+    );
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main" })).symbols;
+
+    expect(symbol.consumers.covered).toEqual(["src/consumer.ts"]);
+    expect(symbol.consumers.unverified).toEqual([]);
+    expect(symbol.scoreFactors.unverifiedConsumers).toBe(0);
+  });
+
+  it("does not score many consumers when every one of them is covered", async () => {
+    const many = Array.from({ length: 12 }, (_, i) => `src/consumer${i}.ts`);
+    const edges = Object.fromEntries(many.map((file, i) => [file, [`tests/consumer${i}.test.ts`]]));
+    const { analyzer } = await analyzerWith(many, edges);
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main" })).symbols;
+
+    expect(symbol.consumers.covered).toHaveLength(12);
+    expect(symbol.scoreFactors.unverifiedConsumers).toBe(0);
+    expect(symbol.risk).not.toBe("critical");
+  });
+
+  it("reports the three buckets as evidence a reviewer can act on", async () => {
+    const { analyzer } = await analyzerWith(
+      ["src/consumer.ts", "src/other.ts"],
+      { "src/consumer.ts": ["tests/consumer.test.ts"] },
+    );
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main" })).symbols;
+    const consumerEvidence = symbol.evidence.find((e) => e.kind === "consumers");
+
+    expect(consumerEvidence?.detail).toContain("2 consumer file(s)");
+    expect(consumerEvidence?.detail).toContain("1 covered by tests");
+    expect(consumerEvidence?.detail).toContain("1 unverified: src/other.ts");
+  });
+});
+
+describe("ReviewGateAnalyzer - does the change require consumers to act?", () => {
+  const withDependent = (workspace: string) => ({
+    getSymbolDependents: (filePath: string) =>
+      Promise.resolve(
+        filePath.endsWith("api.ts")
+          ? [{ sourceSymbolId: `${path.join(workspace, "src/consumer.ts")}:useApi` }]
+          : [],
+      ),
+  });
+
+  it("counts unverified consumers when a parameter changed — every call site must be edited", async () => {
+    const workspace = await createGitWorkspaceWithDiff(
+      "export function greet(name: string): string { return name; }\n",
+      "export function greet(name: string, formal: boolean): string { return name; }\n",
+    );
+    const analyzer = new ReviewGateAnalyzer(workspace, withDependent(workspace) as never);
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main" })).symbols;
+
+    expect(symbol.consumers.unverified).toEqual(["src/consumer.ts"]);
+    expect(symbol.scoreFactors.unverifiedConsumers).toBe(5);
+  });
+
+  it("does not count them when only the return type changed — the calls stay valid", async () => {
+    const workspace = await createGitWorkspaceWithDiff(
+      "export function greet(name: string): string { return name; }\n",
+      "export function greet(name: string): Promise<string> { return Promise.resolve(name); }\n",
+    );
+    const analyzer = new ReviewGateAnalyzer(workspace, withDependent(workspace) as never);
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main" })).symbols;
+
+    // Still listed, still evidenced — just not charged to the author as unhandled work.
+    expect(symbol.consumers.unverified).toEqual(["src/consumer.ts"]);
+    expect(symbol.scoreFactors.unverifiedConsumers).toBe(0);
+    expect(symbol.evidence.some((e) => e.kind === "consumers" && e.detail.includes("requires no call-site update"))).toBe(true);
+  });
+});
+
+describe("ReviewGateAnalyzer - residual weight", () => {
+  const RETURN_TYPE_ONLY = [
+    "export function greet(name: string): string { return name; }\n",
+    "export function greet(name: string): Promise<string> { return Promise.resolve(name); }\n",
+  ] as const;
+  const PARAMETER_CHANGE = [
+    "export function greet(name: string): string { return name; }\n",
+    "export function greet(name: string, formal: boolean): string { return name; }\n",
+  ] as const;
+
+  const manyConsumers = (workspace: string) => ({
+    getSymbolDependents: (filePath: string) =>
+      Promise.resolve(
+        filePath.endsWith("api.ts")
+          ? Array.from({ length: 8 }, (_, i) => ({
+              sourceSymbolId: `${path.join(workspace, `src/consumer${i}.ts`)}:use`,
+            }))
+          : [],
+      ),
+  });
+
+  it("keeps a change that requires no call-site update visible but low", async () => {
+    const workspace = await createGitWorkspaceWithDiff(...RETURN_TYPE_ONLY);
+    const analyzer = new ReviewGateAnalyzer(workspace, manyConsumers(workspace) as never);
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main", maxDepth: 1 })).symbols;
+
+    // Residual, not zero: the symbol must still appear in the report.
+    expect(symbol.scoreFactors.breakingChanges).toBe(5);
+    expect(symbol.scoreFactors.partialImpact).toBe(0);
+    expect(symbol.risk).toBe("low");
+    expect(symbol.score).toBeGreaterThan(0);
+  });
+
+  it("keeps full weight when call sites do have to change", async () => {
+    const workspace = await createGitWorkspaceWithDiff(...PARAMETER_CHANGE);
+    const analyzer = new ReviewGateAnalyzer(workspace, manyConsumers(workspace) as never);
+
+    const [symbol] = (await analyzer.analyze({ baseRef: "main", maxDepth: 1 })).symbols;
+
+    expect(symbol.scoreFactors.breakingChanges).toBe(50);
+    expect(symbol.scoreFactors.unverifiedConsumers).toBe(40);
+    // An incomplete walk is a real unknown here: there may be more call sites.
+    expect(symbol.scoreFactors.partialImpact).toBe(10);
+    expect(symbol.risk).toBe("critical");
   });
 });

--- a/tests/analyzer/SpiderDependencyAnalyzer.test.ts
+++ b/tests/analyzer/SpiderDependencyAnalyzer.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SpiderDependencyAnalyzer } from '../../src/analyzer/spider/SpiderDependencyAnalyzer';
 import { SpiderError, SpiderErrorCode } from '../../src/analyzer/types';
 import { Cache } from '../../src/analyzer/Cache';
+import { normalizePath } from '../../src/shared/path';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 function makeAnalyzer(
   parseImports: () => Promise<unknown>,
@@ -78,5 +82,78 @@ describe('SpiderDependencyAnalyzer', () => {
       await expect(dependencyAnalyzer.analyze('/workspace/app.ts')).resolves.toEqual([]);
       expect(resolver.isWithinWorkspace).toHaveBeenCalledWith(resolvedPath);
     });
+  });
+});
+
+describe('SpiderDependencyAnalyzer - reverse index file hashes', () => {
+  /**
+   * Regression: the analyzer used to bail out before recording a file hash when a
+   * file had no dependencies. fileHashes is the "already analyzed" set, so those
+   * files stayed indistinguishable from never-indexed ones — a restored index
+   * looked massively incomplete and was rebuilt from scratch every time.
+   */
+  it('records a file hash for a file with no dependencies', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'graph-it-nodeps-'));
+    try {
+      const filePath = path.join(tmpDir, 'leaf.ts');
+      fs.writeFileSync(filePath, 'export const leaf = 1;\n');
+
+      const addDependencies = vi.fn();
+      const analyzer = makeAnalyzer(() => Promise.resolve([]));
+      Object.assign(
+        (analyzer as unknown as { reverseIndexManager: Record<string, unknown> }).reverseIndexManager,
+        { isEnabled: () => true, addDependencies },
+      );
+
+      await analyzer.analyze(filePath);
+
+      expect(addDependencies).toHaveBeenCalledWith(
+        normalizePath(filePath),
+        [],
+        expect.objectContaining({ mtime: expect.any(Number), size: expect.any(Number) }),
+      );
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('SpiderDependencyAnalyzer - module resolution and cache invalidation', () => {
+  function makeAnalyzerWithResolver(resolve: (from: string, spec: string) => Promise<string | null>) {
+    const languageService = {
+      getAnalyzer: vi.fn(() => ({ parseImports: () => Promise.resolve([]), resolvePath: vi.fn() })),
+    } as unknown as ConstructorParameters<typeof SpiderDependencyAnalyzer>[0];
+    const resolver = { isWithinWorkspace: () => true, resolve } as unknown as ConstructorParameters<typeof SpiderDependencyAnalyzer>[1];
+    const cache = new Cache<never[]>({ maxSize: 10 });
+    const reverseIndexManager = {
+      isEnabled: () => false,
+      addDependencies: vi.fn(),
+    } as unknown as ConstructorParameters<typeof SpiderDependencyAnalyzer>[3];
+    return {
+      analyzer: new SpiderDependencyAnalyzer(languageService, resolver, cache as never, reverseIndexManager),
+      cache,
+    };
+  }
+
+  it('resolveModuleSpecifier returns the resolved path', async () => {
+    const { analyzer } = makeAnalyzerWithResolver(() => Promise.resolve('/abs/target.ts'));
+
+    await expect(analyzer.resolveModuleSpecifier('/abs/src.ts', './target')).resolves.toBe('/abs/target.ts');
+  });
+
+  it('resolveModuleSpecifier returns null when the resolver throws', async () => {
+    const { analyzer } = makeAnalyzerWithResolver(() => Promise.reject(new Error('nope')));
+
+    await expect(analyzer.resolveModuleSpecifier('/abs/src.ts', 'missing-pkg')).resolves.toBeNull();
+  });
+
+  it('invalidateDependencyCache drops the entry under its normalized key', () => {
+    const { analyzer, cache } = makeAnalyzerWithResolver(() => Promise.resolve(null));
+    const filePath = '/abs/src/a.ts';
+    cache.set(normalizePath(filePath), [] as never[]);
+
+    analyzer.invalidateDependencyCache(filePath);
+
+    expect(cache.get(normalizePath(filePath))).toBeUndefined();
   });
 });

--- a/tests/analyzer/SpiderIndexing.test.ts
+++ b/tests/analyzer/SpiderIndexing.test.ts
@@ -320,3 +320,25 @@ describe('Spider - Index Performance', () => {
         expect(result.cancelled).toBe(false);
     }, 30_000);
 });
+
+describe('Spider - worker-backed indexing lifecycle', () => {
+    let spider: Spider;
+
+    beforeEach(() => {
+        spider = new SpiderBuilder()
+            .withRootDir(fixturesPath)
+            .withTsConfigPath(path.join(fixturesPath, 'tsconfig.json'))
+            .withReverseIndex(true)
+            .build();
+    });
+
+    it('disposeWorker() is safe when no worker was ever started', () => {
+        expect(() => spider.disposeWorker()).not.toThrow();
+    });
+
+    it('buildFullIndexInWorker() surfaces a missing worker script instead of hanging', async () => {
+        const missingWorker = path.join(fixturesPath, 'no-such-indexer-worker.js');
+
+        await expect(spider.buildFullIndexInWorker(missingWorker)).rejects.toThrow();
+    });
+});

--- a/tests/analyzer/SpiderIndexing.test.ts
+++ b/tests/analyzer/SpiderIndexing.test.ts
@@ -295,16 +295,20 @@ describe('Spider - Index Performance', () => {
         const refsFallback = await spiderNoIndex.findReferencingFiles(sharedFile);
         const durationFallback = performance.now() - startFallback;
 
-        // Both should find the same files
+        // Both lookup paths must agree — this is the property worth pinning.
         expect(refsIndexed.length).toBe(NUM_FILES);
         expect(refsFallback.length).toBe(NUM_FILES);
+        expect(refsIndexed.map((r) => r.path).sort()).toEqual(
+            refsFallback.map((r) => r.path).sort()
+        );
 
-        // Indexed should be faster
+        // NOT asserted: durationIndexed < durationFallback * N. Both lookups take
+        // well under a millisecond on this fixture, so the ratio measures scheduler
+        // noise rather than the index — it failed intermittently under parallel
+        // suite load. The indexed path's advantage only shows on a cold cache or a
+        // large project, which this fixture is not; a real measurement belongs in a
+        // benchmark, not in a unit test.
         console.log(`Indexed lookup: ${durationIndexed.toFixed(2)}ms, Fallback: ${durationFallback.toFixed(2)}ms`);
-        
-        // With warm caches, indexed should be at least as fast
-        // The real difference shows on cold cache / large projects
-        expect(durationIndexed).toBeLessThan(durationFallback * 2); // Allow some margin
     }, 30_000);
 
     it('should handle many files during indexing', async () => {

--- a/tests/analyzer/callgraph/CallGraphIndexer.test.ts
+++ b/tests/analyzer/callgraph/CallGraphIndexer.test.ts
@@ -85,6 +85,29 @@ describe("CallGraphIndexer", () => {
   // Lifecycle
   // -------------------------------------------------------------------------
 
+  it("getCounts() reports zero on an empty database", () => {
+    expect(indexer.getCounts()).toEqual({ files: 0, symbols: 0, relations: 0 });
+  });
+
+  it("getCounts() counts files, symbols and relations", () => {
+    indexer.indexFile(
+      [makeNode(), makeNode({ id: `${FILE_A}:helper:12`, name: "helper", startLine: 12 })],
+      [makeEdge()],
+      FILE_A,
+      "typescript",
+      1000,
+    );
+
+    expect(indexer.getCounts()).toEqual({ files: 1, symbols: 2, relations: 1 });
+  });
+
+  it("getCounts() follows invalidateFile()", () => {
+    indexer.indexFile([makeNode()], [], FILE_A, "typescript", 1000);
+    indexer.invalidateFile(FILE_A);
+
+    expect(indexer.getCounts()).toEqual({ files: 0, symbols: 0, relations: 0 });
+  });
+
   it("init() resolves without throwing", async () => {
     const fresh = new CallGraphIndexer(SQL_WASM_PATH);
     await expect(fresh.init()).resolves.not.toThrow();

--- a/tests/analyzer/callgraph/CallGraphIndexer.test.ts
+++ b/tests/analyzer/callgraph/CallGraphIndexer.test.ts
@@ -603,26 +603,28 @@ describe("CallGraphIndexer", () => {
     expect(edgeToUnexported.length).toBe(0);
   });
 
-  it("resolveExternalEdges() picks most-recently-indexed candidate when exported/similarity tie (pickBestCandidate)", () => {
-    // Two exported candidates in the same directory — tie in both similarity and export.
-    // The more recently indexed one must win.
-    // We force distinct indexed_at values by updating the DB directly after indexFile().
+  it("resolveExternalEdges() breaks an exported/similarity tie on the node id, not the clock", () => {
+    // Two exported candidates in the same directory — tie in both similarity and
+    // export. The tie-break used to be indexed_at, a wall-clock stamp: which of two
+    // files landed in the same millisecond varied between indexing runs, so the same
+    // unchanged workspace resolved this edge differently from one run to the next.
+    // Resolution is now pinned to the lowest node id, which is stable.
     const CALLER_FILE = "/workspace/src/caller.ts";
-    const OLDER_FILE  = "/workspace/src/older.ts";
-    const NEWER_FILE  = "/workspace/src/newer.ts";
+    const A_FILE = "/workspace/src/aaa.ts";
+    const Z_FILE = "/workspace/src/zzz.ts";
 
     const callerNode = makeNode({
       id: `${CALLER_FILE}:caller:1`, name: "caller", startLine: 1,
       path: CALLER_FILE, folder: "/workspace/src",
     });
-    const olderNode = makeNode({
-      id: `${OLDER_FILE}:doWork:1`, name: "doWork", startLine: 1,
-      path: OLDER_FILE, folder: "/workspace/src",
+    const lowerIdNode = makeNode({
+      id: `${A_FILE}:doWork:1`, name: "doWork", startLine: 1,
+      path: A_FILE, folder: "/workspace/src",
       lang: "typescript", isExported: true,
     });
-    const newerNode = makeNode({
-      id: `${NEWER_FILE}:doWork:1`, name: "doWork", startLine: 1,
-      path: NEWER_FILE, folder: "/workspace/src",
+    const higherIdNode = makeNode({
+      id: `${Z_FILE}:doWork:1`, name: "doWork", startLine: 1,
+      path: Z_FILE, folder: "/workspace/src",
       lang: "typescript", isExported: true,
     });
 
@@ -634,36 +636,74 @@ describe("CallGraphIndexer", () => {
     });
 
     indexer.indexFile([callerNode], [stubEdge], CALLER_FILE, "typescript", 1000);
-    indexer.indexFile([olderNode], [], OLDER_FILE, "typescript", 1000);
-    indexer.indexFile([newerNode], [], NEWER_FILE, "typescript", 9999);
+    indexer.indexFile([lowerIdNode], [], A_FILE, "typescript", 1000);
+    indexer.indexFile([higherIdNode], [], Z_FILE, "typescript", 1000);
 
-    // Force distinct indexed_at values so the tie-breaker is deterministic.
     const db = indexer.getDb();
-    db.run("UPDATE nodes SET indexed_at = 1000 WHERE id = ?", [olderNode.id]);
-    db.run("UPDATE nodes SET indexed_at = 9999 WHERE id = ?", [newerNode.id]);
+    // The candidate indexed LAST carries the higher indexed_at. Under the old rule
+    // it would win; the id must decide instead.
+    db.run("UPDATE nodes SET indexed_at = 1000 WHERE id = ?", [lowerIdNode.id]);
+    db.run("UPDATE nodes SET indexed_at = 9999 WHERE id = ?", [higherIdNode.id]);
 
-    const result = indexer.resolveExternalEdges();
-    expect(result.resolved).toBeGreaterThanOrEqual(1);
+    expect(indexer.resolveExternalEdges().resolved).toBeGreaterThanOrEqual(1);
 
-    // Must resolve to newer (higher indexed_at) node
-    const edgeToNewer = db.exec(
+    const edgeToLowerId = db.exec(
       "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
-      [callerNode.id, newerNode.id],
+      [callerNode.id, lowerIdNode.id],
     );
-    expect(edgeToNewer[0]?.values.length).toBe(1);
+    expect(edgeToLowerId[0]?.values.length).toBe(1);
 
-    // Must NOT resolve to older node
-    const edgeToOlder = db.exec(
+    const edgeToHigherId = db.exec(
       "SELECT source_id, target_id FROM edges WHERE source_id = ? AND target_id = ?",
-      [callerNode.id, olderNode.id],
+      [callerNode.id, higherIdNode.id],
     );
-    expect(edgeToOlder.length).toBe(0);
+    expect(edgeToHigherId.length).toBe(0);
   });
 
-  // -------------------------------------------------------------------------
-  // resolveExternalEdges — cross-language isolation
-  // -------------------------------------------------------------------------
+  it("resolveExternalEdges() resolves identically whatever the indexing timestamps are", () => {
+    // Regression guard for the non-determinism itself: the same graph indexed with
+    // different wall-clock stamps must produce the same edges.
+    const CALLER_FILE = "/workspace/src/caller.ts";
+    const A_FILE = "/workspace/src/aaa.ts";
+    const Z_FILE = "/workspace/src/zzz.ts";
 
+    const run = async (stamps: [number, number]): Promise<string[]> => {
+      const local = new CallGraphIndexer(SQL_WASM_PATH);
+      await local.init();
+      const caller = makeNode({
+        id: `${CALLER_FILE}:caller:1`, name: "caller", startLine: 1,
+        path: CALLER_FILE, folder: "/workspace/src",
+      });
+      const a = makeNode({
+        id: `${A_FILE}:doWork:1`, name: "doWork", startLine: 1,
+        path: A_FILE, folder: "/workspace/src", isExported: true,
+      });
+      const z = makeNode({
+        id: `${Z_FILE}:doWork:1`, name: "doWork", startLine: 1,
+        path: Z_FILE, folder: "/workspace/src", isExported: true,
+      });
+      local.indexFile(
+        [caller],
+        [makeEdge({ sourceId: caller.id, targetId: "@@external:doWork", sourceLine: 7 })],
+        CALLER_FILE, "typescript", 1000,
+      );
+      local.indexFile([a], [], A_FILE, "typescript", 1000);
+      local.indexFile([z], [], Z_FILE, "typescript", 1000);
+      const db = local.getDb();
+      db.run("UPDATE nodes SET indexed_at = ? WHERE id = ?", [stamps[0], a.id]);
+      db.run("UPDATE nodes SET indexed_at = ? WHERE id = ?", [stamps[1], z.id]);
+      local.resolveExternalEdges();
+      const rows = db.exec("SELECT source_id, target_id FROM edges ORDER BY source_id, target_id");
+      local.dispose();
+      return (rows[0]?.values ?? []).map((r) => r.join("|"));
+    };
+
+    return Promise.all([run([1, 9999]), run([9999, 1]), run([5, 5])]).then(([x, y, z]) => {
+      expect(y).toEqual(x);
+      expect(z).toEqual(x);
+      expect(x.length).toBeGreaterThan(0);
+    });
+  });
   it("resolveExternalEdges() does not resolve @@external stub to a same-named node in a different language", () => {
     // Java file defines a `User` class; Go file also exports a `User` symbol.
     // A Java caller that references @@external:User must NOT be linked to the Go node.

--- a/tests/analyzer/callgraph/incrementalHelpers.test.ts
+++ b/tests/analyzer/callgraph/incrementalHelpers.test.ts
@@ -1,0 +1,145 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  collectChangedFiles,
+  getQueryFreshnessCutoffs,
+  type IndexedFileRecord,
+} from "@/analyzer/callgraph/GraphExtractor";
+import type { SupportedLang } from "@/shared/callgraph-types";
+
+const noCutoffs = {
+  typescript: 0,
+  javascript: 0,
+  python: 0,
+  rust: 0,
+  csharp: 0,
+  go: 0,
+  java: 0,
+} satisfies Record<SupportedLang, number>;
+
+describe("getQueryFreshnessCutoffs", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "graph-it-cutoffs-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("reports each language's query file mtime", () => {
+    const queryDir = path.join(tmpDir, "dist", "queries");
+    fs.mkdirSync(queryDir, { recursive: true });
+    fs.writeFileSync(path.join(queryDir, "python.scm"), "(x)");
+
+    return getQueryFreshnessCutoffs(tmpDir).then((cutoffs) => {
+      expect(cutoffs.python).toBeGreaterThan(0);
+      // JavaScript shares the TypeScript query file.
+      expect(cutoffs.javascript).toBe(cutoffs.typescript);
+    });
+  });
+
+  it("falls back to 0 for a missing query file instead of throwing", async () => {
+    const cutoffs = await getQueryFreshnessCutoffs(tmpDir);
+
+    expect(cutoffs.typescript).toBe(0);
+    expect(cutoffs.rust).toBe(0);
+  });
+});
+
+describe("collectChangedFiles", () => {
+  let tmpDir: string;
+
+  const write = (name: string): string => {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, "export const x = 1;\n");
+    return filePath;
+  };
+
+  const freshRecord = (filePath: string, indexedAt = Date.now()): IndexedFileRecord => ({
+    lastModified: Math.floor(fs.statSync(filePath).mtimeMs),
+    indexedAt,
+  });
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "graph-it-changed-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("queues a file that was never indexed", async () => {
+    const filePath = write("a.ts");
+
+    const { jobs, skipped } = await collectChangedFiles([filePath], () => null, noCutoffs);
+
+    expect(jobs).toEqual([expect.objectContaining({ filePath, lang: "typescript" })]);
+    expect(skipped).toBe(0);
+  });
+
+  it("skips a file whose record is still fresh", async () => {
+    const filePath = write("a.ts");
+    const record = freshRecord(filePath);
+
+    const { jobs, skipped } = await collectChangedFiles([filePath], () => record, noCutoffs);
+
+    expect(jobs).toEqual([]);
+    expect(skipped).toBe(1);
+  });
+
+  it("queues a file modified since it was indexed", async () => {
+    const filePath = write("a.ts");
+    const record = { lastModified: 0, indexedAt: Date.now() };
+
+    const { jobs } = await collectChangedFiles([filePath], () => record, noCutoffs);
+
+    expect(jobs).toHaveLength(1);
+  });
+
+  it("queues a fresh file whose language query has since been updated", async () => {
+    const filePath = write("a.ts");
+    const record = freshRecord(filePath, 1_000);
+
+    const { jobs } = await collectChangedFiles([filePath], () => record, {
+      ...noCutoffs,
+      typescript: 2_000,
+    });
+
+    expect(jobs).toHaveLength(1);
+  });
+
+  it("skips unsupported extensions and unreadable paths", async () => {
+    const unsupported = path.join(tmpDir, "notes.md");
+    fs.writeFileSync(unsupported, "# hi");
+    const missing = path.join(tmpDir, "gone.ts");
+
+    const { jobs, skipped } = await collectChangedFiles(
+      [unsupported, missing],
+      () => null,
+      noCutoffs,
+    );
+
+    expect(jobs).toEqual([]);
+    expect(skipped).toBe(2);
+  });
+
+  it("honors a custom language resolver", async () => {
+    const filePath = write("a.ts");
+
+    const { jobs } = await collectChangedFiles([filePath], () => null, noCutoffs, () => "python");
+
+    expect(jobs[0].lang).toBe("python");
+  });
+
+  it("processes more files than a single stat batch", async () => {
+    const files = Array.from({ length: 70 }, (_, i) => write(`f${i}.ts`));
+
+    const { jobs } = await collectChangedFiles(files, () => null, noCutoffs);
+
+    expect(jobs).toHaveLength(70);
+  });
+});

--- a/tests/analyzer/graph-context/GraphContextFederator.test.ts
+++ b/tests/analyzer/graph-context/GraphContextFederator.test.ts
@@ -2,7 +2,7 @@ import { createRequire } from 'node:module';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Spider } from '../../../src/analyzer/Spider';
 import { SpiderBuilder } from '../../../src/analyzer/SpiderBuilder';
 import {
@@ -106,6 +106,28 @@ describe('GraphContextFederator', () => {
         sourceLine: 11,
       }),
     }));
+  });
+
+  it('keeps the revision stable when an unchanged workspace is indexed in a new session', async () => {
+    const before = await new GraphContextFederator(spider, indexer).buildSnapshot({ question: 'user service' });
+    const originalIndex = indexer.getIndexSnapshot();
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1_000);
+
+    try {
+      indexer.dispose();
+      indexer = new CallGraphIndexer(SQL_WASM_PATH);
+      await indexer.init();
+      await indexFixture(indexer, workspaceRoot);
+
+      const after = await new GraphContextFederator(spider, indexer).buildSnapshot({ question: 'user service' });
+
+      expect(indexer.getIndexSnapshot().files[0].indexedAt).not.toBe(originalIndex.files[0].indexedAt);
+      expect(after.nodes).toEqual(before.nodes);
+      expect(after.edges).toEqual(before.edges);
+      expect(after.revision).toBe(before.revision);
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it('applies scope before adding files, symbols, and edges', async () => {

--- a/tests/cli/cacheFlags.e2e.test.ts
+++ b/tests/cli/cacheFlags.e2e.test.ts
@@ -1,0 +1,156 @@
+/**
+ * E2E coverage for the index-cache global flags.
+ *
+ * The flags are wired in `main()` (`src/cli/index.ts`), which only runs when the
+ * built bundle is the process entry point — importing the module under Vitest
+ * never exercises that path. These tests drive the real binary against a
+ * throwaway workspace, which is also the only way to observe the cache surviving
+ * between two processes, the thing the cache exists for.
+ */
+
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const DIST_ENTRY = path.join(REPO_ROOT, "dist/graph-it.js");
+const distExists = fs.existsSync(DIST_ENTRY);
+
+describe.skipIf(!distExists)("CLI index cache flags (E2E)", () => {
+  let tmpDir: string;
+  let cacheDir: string;
+
+  /** Run the built CLI and return its stdout. */
+  const cli = (...args: string[]): string =>
+    execFileSync(process.execPath, [DIST_ENTRY, "-w", tmpDir, ...args], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+
+  /** Same, but capturing stderr (where progress and cache provenance are printed). */
+  const cliStderr = (...args: string[]): string => {
+    const errFile = path.join(tmpDir, "stderr.log");
+    const fd = fs.openSync(errFile, "w");
+    try {
+      execFileSync(process.execPath, [DIST_ENTRY, "-w", tmpDir, ...args], {
+        stdio: ["ignore", "ignore", fd],
+      });
+    } finally {
+      fs.closeSync(fd);
+    }
+    // Progress rewrites the line with \r; normalize so assertions stay readable.
+    return fs.readFileSync(errFile, "utf-8").replaceAll("\r", "\n");
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "graph-it-flags-")));
+    cacheDir = path.join(tmpDir, ".graph-it", "cache");
+    fs.mkdirSync(path.join(tmpDir, "src"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "package.json"), "{}");
+    fs.writeFileSync(path.join(tmpDir, "src/b.ts"), "export const b = () => 1;\n");
+    for (let i = 0; i < 12; i++) {
+      fs.writeFileSync(
+        path.join(tmpDir, `src/f${i}.ts`),
+        `import { b } from "./b";\nexport const f${i} = () => b();\n`,
+      );
+    }
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes a cache on the first run and reuses it on the second", () => {
+    const first = cliStderr("summary");
+    expect(first).toContain("Indexed");
+    expect(first).not.toContain("from cache");
+    expect(fs.existsSync(path.join(cacheDir, "reverse-index.json"))).toBe(true);
+
+    const second = cliStderr("summary");
+    expect(second).toContain("from cache");
+  });
+
+  it("produces the same analysis warm as with --no-cache", () => {
+    cli("summary");
+
+    // Provenance fields (fromCache, filesAnalyzed, timings) differ by design;
+    // the analysis itself must not.
+    const warm = cli("explain", "src/b.ts", "-f", "json");
+    const cold = cli("--no-cache", "explain", "src/b.ts", "-f", "json");
+
+    const strip = (out: string) => out.replace(/"analysisTimeMs":\s*\d+/g, "");
+    expect(strip(warm)).toBe(strip(cold));
+    expect(warm).toContain("b.ts");
+  });
+
+  it("--no-cache writes no cache at all", () => {
+    cli("--no-cache", "summary");
+
+    expect(fs.existsSync(cacheDir)).toBe(false);
+  });
+
+  it("GRAPH_IT_NO_CACHE=1 writes no cache at all", () => {
+    execFileSync(process.execPath, [DIST_ENTRY, "-w", tmpDir, "summary"], {
+      stdio: "ignore",
+      env: { ...process.env, GRAPH_IT_NO_CACHE: "1" },
+    });
+
+    expect(fs.existsSync(cacheDir)).toBe(false);
+  });
+
+  it("--reindex discards the cache and rebuilds", () => {
+    cli("summary");
+    const before = fs.readFileSync(path.join(cacheDir, "meta.json"), "utf-8");
+
+    const stderr = cliStderr("--reindex", "summary");
+
+    expect(stderr).toContain("Indexed");
+    expect(stderr).not.toContain("from cache");
+    expect(fs.readFileSync(path.join(cacheDir, "meta.json"), "utf-8")).not.toBe(before);
+  });
+
+  it("lists the cache flags in --help", () => {
+    const out = execFileSync(process.execPath, [DIST_ENTRY, "--help"], { encoding: "utf-8" });
+
+    expect(out).toContain("--reindex");
+    expect(out).toContain("--no-cache");
+  });
+});
+
+describe.skipIf(!distExists)("CLI help completeness (E2E)", () => {
+  const help = (): string =>
+    execFileSync(process.execPath, [DIST_ENTRY, "--help"], { encoding: "utf-8" });
+
+  /** Command names the dispatcher actually accepts, read from the source. */
+  const dispatchedCommands = (): string[] => {
+    const src = fs.readFileSync(path.join(REPO_ROOT, "src/cli/index.ts"), "utf-8");
+    const dispatch = src.slice(src.indexOf("async function dispatch("));
+    const fromSwitch = [...dispatch.matchAll(/case "([a-z][a-z-]*)":/g)].map((m) => m[1]);
+    // `context` is handled before the switch, so it never appears as a case.
+    return [...new Set([...fromSwitch, "context"])];
+  };
+
+  it("lists every command the dispatcher accepts", () => {
+    const out = help();
+    const missing = dispatchedCommands().filter(
+      (cmd) => !new RegExp(`^\\s{2}${cmd}[\\s<[]`, "m").test(out),
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it("documents the no-argument REPL and per-command help", () => {
+    const out = help();
+
+    expect(out).toContain("interactive REPL");
+    expect(out).toContain("<command> --help");
+  });
+
+  it("ends on the examples block, with no dangling command line after it", () => {
+    const lines = help().trimEnd().split("\n");
+
+    expect(lines.at(-1)).toMatch(/^ {2}graph-it /);
+  });
+});

--- a/tests/cli/cacheFlags.e2e.test.ts
+++ b/tests/cli/cacheFlags.e2e.test.ts
@@ -18,7 +18,9 @@ const REPO_ROOT = path.resolve(__dirname, "../..");
 const DIST_ENTRY = path.join(REPO_ROOT, "dist/graph-it.js");
 const distExists = fs.existsSync(DIST_ENTRY);
 
-describe.skipIf(!distExists)("CLI index cache flags (E2E)", () => {
+const SUBPROCESS_TIMEOUT_MS = 60_000;
+
+describe.skipIf(!distExists)("CLI index cache flags (E2E)", { timeout: SUBPROCESS_TIMEOUT_MS }, () => {
   let tmpDir: string;
   let cacheDir: string;
 
@@ -75,14 +77,23 @@ describe.skipIf(!distExists)("CLI index cache flags (E2E)", () => {
   it("produces the same analysis warm as with --no-cache", () => {
     cli("summary");
 
-    // Provenance fields (fromCache, filesAnalyzed, timings) differ by design;
-    // the analysis itself must not.
-    const warm = cli("explain", "src/b.ts", "-f", "json");
-    const cold = cli("--no-cache", "explain", "src/b.ts", "-f", "json");
+    // Provenance and timing fields (fromCache, filesAnalyzed, analysisTimeMs)
+    // differ by design; compare the analysis payload itself instead of the raw
+    // text, so the assertion cannot be tripped by a field that is meant to vary.
+    const analysis = (...args: string[]) => {
+      const parsed = JSON.parse(cli(...args, "-f", "json")) as {
+        filePath: string;
+        language: string;
+        graph: unknown;
+      };
+      return { filePath: parsed.filePath, language: parsed.language, graph: parsed.graph };
+    };
 
-    const strip = (out: string) => out.replace(/"analysisTimeMs":\s*\d+/g, "");
-    expect(strip(warm)).toBe(strip(cold));
-    expect(warm).toContain("b.ts");
+    const warm = analysis("explain", "src/b.ts");
+    const cold = analysis("--no-cache", "explain", "src/b.ts");
+
+    expect(warm).toEqual(cold);
+    expect(warm.filePath).toContain("b.ts");
   });
 
   it("--no-cache writes no cache at all", () => {
@@ -119,7 +130,7 @@ describe.skipIf(!distExists)("CLI index cache flags (E2E)", () => {
   });
 });
 
-describe.skipIf(!distExists)("CLI help completeness (E2E)", () => {
+describe.skipIf(!distExists)("CLI help completeness (E2E)", { timeout: SUBPROCESS_TIMEOUT_MS }, () => {
   const help = (): string =>
     execFileSync(process.execPath, [DIST_ENTRY, "--help"], { encoding: "utf-8" });
 

--- a/tests/cli/index.test.ts
+++ b/tests/cli/index.test.ts
@@ -12,8 +12,11 @@
  *     flag before dispatching to a command, so `graph-it <cmd> --help` always
  *     printed the generic top-level help instead of the per-command help.
  */
-import { describe, expect, it } from "vitest";
-import { commandWantsHelp, findCommandStart } from "../../src/cli/index";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as fsSync from "node:fs";
+import * as osMod from "node:os";
+import * as pathMod from "node:path";
+import { commandWantsHelp, createRuntime, findCommandStart } from "../../src/cli/index";
 
 describe("findCommandStart", () => {
   it("finds the command when it is the first token", () => {
@@ -65,5 +68,45 @@ describe("commandWantsHelp", () => {
 
   it("returns false when --help appears before the command (belongs to a different context)", () => {
     expect(commandWantsHelp("wiki", [], ["--help", "wiki"])).toBe(false);
+  });
+});
+
+describe("createRuntime — index cache flags", () => {
+  let tmpDir: string;
+  let cacheDir: string;
+
+  beforeEach(() => {
+    tmpDir = fsSync.mkdtempSync(pathMod.join(osMod.tmpdir(), "graph-it-flags-unit-"));
+    fsSync.writeFileSync(pathMod.join(tmpDir, "package.json"), "{}");
+    cacheDir = pathMod.join(tmpDir, ".graph-it", "cache");
+    fsSync.mkdirSync(cacheDir, { recursive: true });
+    fsSync.writeFileSync(pathMod.join(cacheDir, "meta.json"), "{}");
+  });
+
+  afterEach(() => {
+    fsSync.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("keeps the cache by default", () => {
+    const runtime = createRuntime(tmpDir, {});
+
+    expect(runtime.workspaceRoot).toBe(pathMod.resolve(tmpDir));
+    expect(fsSync.existsSync(cacheDir)).toBe(true);
+  });
+
+  it("--reindex deletes the existing cache up front", () => {
+    createRuntime(tmpDir, { reindex: true });
+
+    expect(fsSync.existsSync(cacheDir)).toBe(false);
+  });
+
+  it("--no-cache leaves an existing cache on disk but writes none", async () => {
+    const runtime = createRuntime(tmpDir, { "no-cache": true });
+    await runtime.init();
+    await runtime.ensureIndexed({ silent: true });
+    fsSync.rmSync(cacheDir, { recursive: true, force: true });
+    await runtime.dispose();
+
+    expect(fsSync.existsSync(cacheDir)).toBe(false);
   });
 });

--- a/tests/cli/runtimeCache.test.ts
+++ b/tests/cli/runtimeCache.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Spider } from "@/analyzer/Spider";
 import { CliRuntime, type IndexOutcome } from "@/cli/runtime";
 import { workerState } from "@/mcp/shared/state";
+import { normalizePath } from "@/shared/path";
 
 /**
  * The CLI process dies between commands, so both the reverse index and the call
@@ -79,7 +80,7 @@ describe("CliRuntime index cache", () => {
     expect(callers).toBe(12);
     expect(fs.existsSync(path.join(cacheDir, "reverse-index.json"))).toBe(true);
     const meta = JSON.parse(fs.readFileSync(path.join(cacheDir, "meta.json"), "utf-8"));
-    expect(meta.workspaceRoot).toBe(tmpDir);
+    expect(normalizePath(meta.workspaceRoot)).toBe(normalizePath(tmpDir));
     expect(meta.schema).toBe(1);
   });
 
@@ -261,19 +262,61 @@ describe("CliRuntime index cache", () => {
     );
   });
 
-  it("does not fail the command when the cache cannot be written", async () => {
+  // chmod does not remove write access to a directory on Windows, so the
+  // read-only case can only be exercised on POSIX. The failure path itself is
+  // covered on every OS by the next test, which makes the write throw outright.
+  it.skipIf(process.platform === "win32")(
+    "does not fail the command when the cache directory is read-only",
+    async () => {
+      const runtime = new CliRuntime(tmpDir);
+      runtimes.push(runtime);
+      await runtime.init();
+      await runtime.ensureIndexed({ silent: true });
+      fs.mkdirSync(cacheDir, { recursive: true });
+      fs.chmodSync(cacheDir, 0o500);
+
+      try {
+        await expect(runtime.dispose()).resolves.not.toThrow();
+      } finally {
+        fs.chmodSync(cacheDir, 0o700);
+      }
+    },
+  );
+
+  it("does not fail the command when the cache cannot be created", async () => {
     const runtime = new CliRuntime(tmpDir);
     runtimes.push(runtime);
     await runtime.init();
     await runtime.ensureIndexed({ silent: true });
-    // A read-only cache directory must degrade to "no cache", never to a crash.
-    fs.mkdirSync(cacheDir, { recursive: true });
-    fs.chmodSync(cacheDir, 0o500);
+    // A plain file where the cache directory belongs makes the mkdir fail on
+    // every OS. A cache that cannot be written costs the next run some time; it
+    // must never turn into a failed command.
+    fs.mkdirSync(path.dirname(cacheDir), { recursive: true });
+    fs.writeFileSync(cacheDir, "not a directory");
 
+    await expect(runtime.dispose()).resolves.not.toThrow();
+    expect(fs.statSync(cacheDir).isFile()).toBe(true);
+  });
+
+  it("accepts a guard whose workspace root differs only in separator style", async () => {
+    await run();
+    const metaPath = path.join(cacheDir, "meta.json");
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+    // What a Windows run writes vs. what path.resolve() returns can differ in
+    // separator style and drive-letter case; that must not force a rebuild.
+    // Swap to the other platform's separator so the case is exercised on both.
+    const swapped: string = meta.workspaceRoot.includes("/")
+      ? meta.workspaceRoot.replaceAll("/", "\\")
+      : meta.workspaceRoot.replaceAll("\\", "/");
+    fs.writeFileSync(metaPath, JSON.stringify({ ...meta, workspaceRoot: swapped }));
+    expect(swapped).not.toBe(meta.workspaceRoot);
+
+    const buildFullIndex = vi.spyOn(Spider.prototype, "buildFullIndex");
     try {
-      await expect(runtime.dispose()).resolves.not.toThrow();
+      expect((await run()).callers).toBe(12);
+      expect(buildFullIndex).not.toHaveBeenCalled();
     } finally {
-      fs.chmodSync(cacheDir, 0o700);
+      buildFullIndex.mockRestore();
     }
   });
 

--- a/tests/cli/runtimeCache.test.ts
+++ b/tests/cli/runtimeCache.test.ts
@@ -1,0 +1,286 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Spider } from "@/analyzer/Spider";
+import { CliRuntime, type IndexOutcome } from "@/cli/runtime";
+import { workerState } from "@/mcp/shared/state";
+
+/**
+ * The CLI process dies between commands, so both the reverse index and the call
+ * graph are rebuilt from scratch every invocation unless they are persisted.
+ * These tests cover the persistence round-trip and every invalidation path.
+ */
+describe("CliRuntime index cache", () => {
+  let tmpDir: string;
+  let cacheDir: string;
+  const runtimes: CliRuntime[] = [];
+
+  const write = (relPath: string, content: string): string => {
+    const filePath = path.join(tmpDir, relPath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  };
+
+  /** Full init → index → dispose cycle, like one `graph-it <command>` run. */
+  const run = async (options?: { cache?: boolean }): Promise<{ callers: number }> => {
+    const runtime = new CliRuntime(tmpDir, options);
+    runtimes.push(runtime);
+    await runtime.init();
+    await runtime.ensureIndexed({ silent: true });
+    const callers = workerState.spider?.getCallerCount(path.join(tmpDir, "src/b.ts")) ?? -1;
+    await runtime.dispose();
+    return { callers };
+  };
+
+  /** Same cycle, but not silent: returns what the user would see on stderr. */
+  const runVerbose = async (): Promise<{ stderr: string; outcome: IndexOutcome }> => {
+    const runtime = new CliRuntime(tmpDir);
+    runtimes.push(runtime);
+    let stderr = "";
+    const write = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation((chunk: string | Uint8Array) => {
+        stderr += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+        return true;
+      });
+    try {
+      await runtime.init();
+      const outcome = await runtime.ensureIndexed();
+      await runtime.dispose();
+      return { stderr, outcome };
+    } finally {
+      write.mockRestore();
+    }
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "graph-it-cache-")));
+    cacheDir = path.join(tmpDir, ".graph-it", "cache");
+    write("package.json", "{}");
+    write("src/b.ts", "export const b = () => 1;\n");
+    for (let i = 0; i < 12; i++) {
+      write(`src/f${i}.ts`, `import { b } from "./b";\nexport const f${i} = () => b();\n`);
+    }
+  });
+
+  afterEach(async () => {
+    for (const runtime of runtimes.splice(0)) {
+      await runtime.dispose().catch(() => {/* already disposed */});
+    }
+    delete process.env.GRAPH_IT_NO_CACHE;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes the reverse index and its guard on a cold run", async () => {
+    const { callers } = await run();
+
+    expect(callers).toBe(12);
+    expect(fs.existsSync(path.join(cacheDir, "reverse-index.json"))).toBe(true);
+    const meta = JSON.parse(fs.readFileSync(path.join(cacheDir, "meta.json"), "utf-8"));
+    expect(meta.workspaceRoot).toBe(tmpDir);
+    expect(meta.schema).toBe(1);
+  });
+
+  it("restores the cached index on the next run", async () => {
+    await run();
+    expect(await run()).toEqual({ callers: 12 });
+  });
+
+  it("skips the full rebuild on a warm run, and performs one on a cold run", async () => {
+    const buildFullIndex = vi.spyOn(Spider.prototype, "buildFullIndex");
+    try {
+      await run();
+      expect(buildFullIndex).toHaveBeenCalledTimes(1);
+
+      buildFullIndex.mockClear();
+      await run();
+      expect(buildFullIndex).not.toHaveBeenCalled();
+    } finally {
+      buildFullIndex.mockRestore();
+    }
+  });
+
+  it("falls back to a full rebuild when churn passes the threshold", async () => {
+    await run();
+    for (let i = 0; i < 6; i++) {
+      write(`src/extra${i}.ts`, 'import { b } from "./b";\nexport const e = () => b();\n');
+    }
+
+    const buildFullIndex = vi.spyOn(Spider.prototype, "buildFullIndex");
+    try {
+      expect((await run()).callers).toBe(18);
+      expect(buildFullIndex).toHaveBeenCalledTimes(1);
+    } finally {
+      buildFullIndex.mockRestore();
+    }
+  });
+
+  it("picks up a file created between two runs", async () => {
+    await run();
+    write("src/new.ts", 'import { b } from "./b";\nexport const n = () => b();\n');
+
+    expect((await run()).callers).toBe(13);
+  });
+
+  it("drops a file deleted between two runs", async () => {
+    await run();
+    fs.rmSync(path.join(tmpDir, "src/f0.ts"));
+
+    expect((await run()).callers).toBe(11);
+  });
+
+  it("follows a file renamed between two runs", async () => {
+    await run();
+    fs.renameSync(path.join(tmpDir, "src/f0.ts"), path.join(tmpDir, "src/moved.ts"));
+
+    expect((await run()).callers).toBe(12);
+  });
+
+  it("rebuilds when the guard records a different CLI version", async () => {
+    await run();
+    const metaPath = path.join(cacheDir, "meta.json");
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+    fs.writeFileSync(metaPath, JSON.stringify({ ...meta, cliVersion: "999.0.0" }));
+
+    expect((await run()).callers).toBe(12);
+  });
+
+  it("rebuilds when the guard records a different workspace root", async () => {
+    await run();
+    const metaPath = path.join(cacheDir, "meta.json");
+    const meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+    fs.writeFileSync(metaPath, JSON.stringify({ ...meta, workspaceRoot: "/somewhere/else" }));
+
+    expect((await run()).callers).toBe(12);
+  });
+
+  it("rebuilds instead of throwing when the cached index is corrupt", async () => {
+    await run();
+    fs.writeFileSync(path.join(cacheDir, "reverse-index.json"), "{ not json");
+
+    expect((await run()).callers).toBe(12);
+  });
+
+  it("rebuilds when the cached index is gone but the guard remains", async () => {
+    await run();
+    fs.rmSync(path.join(cacheDir, "reverse-index.json"));
+
+    expect((await run()).callers).toBe(12);
+  });
+
+  it("writes nothing when caching is turned off per run", async () => {
+    await run({ cache: false });
+
+    expect(fs.existsSync(cacheDir)).toBe(false);
+  });
+
+  it("writes nothing when GRAPH_IT_NO_CACHE is set", async () => {
+    process.env.GRAPH_IT_NO_CACHE = "1";
+    await run();
+
+    expect(fs.existsSync(cacheDir)).toBe(false);
+  });
+
+  it("clearCache() removes the cache and is safe when there is none", async () => {
+    await run();
+    expect(fs.existsSync(cacheDir)).toBe(true);
+
+    const runtime = new CliRuntime(tmpDir);
+    runtime.clearCache();
+    expect(fs.existsSync(cacheDir)).toBe(false);
+
+    expect(() => runtime.clearCache()).not.toThrow();
+  });
+
+  it("reports a cold run as an index, not as a cache hit", async () => {
+    const { stderr, outcome } = await runVerbose();
+
+    expect(outcome).toMatchObject({ fromCache: false, filesAnalyzed: outcome.filesFound });
+    expect(stderr).toContain(`Indexed ${outcome.filesIndexed}/${outcome.filesFound} files`);
+    expect(stderr).not.toContain("from cache");
+  });
+
+  it("says the answer came from cache when nothing changed", async () => {
+    await run();
+
+    const { stderr, outcome } = await runVerbose();
+
+    expect(outcome).toMatchObject({ fromCache: true, filesAnalyzed: 0 });
+    expect(stderr).toContain(`Loaded ${outcome.filesIndexed} files from cache (nothing changed)`);
+  });
+
+  it("names the cache and the re-indexed count when files changed", async () => {
+    await run();
+    fs.writeFileSync(path.join(tmpDir, "src/f0.ts"), 'import { b } from "./b";\nexport const f0 = () => b() + 1;\n');
+
+    const { stderr, outcome } = await runVerbose();
+
+    expect(outcome).toMatchObject({ fromCache: true, filesAnalyzed: 1 });
+    expect(stderr).toContain("from cache, re-indexed 1 changed");
+  });
+
+  it("never prints a 0/0 progress line", async () => {
+    await run();
+
+    const { stderr } = await runVerbose();
+
+    expect(stderr).not.toContain("0/0");
+  });
+
+  it("reports counts from the second ensureIndexed() call of the same process", async () => {
+    const runtime = new CliRuntime(tmpDir);
+    runtimes.push(runtime);
+    await runtime.init();
+
+    const first = await runtime.ensureIndexed({ silent: true });
+    const second = await runtime.ensureIndexed({ silent: true });
+    await runtime.dispose();
+
+    expect(second.filesIndexed).toBe(first.filesIndexed);
+    expect(second.filesFound).toBe(first.filesFound);
+    expect(second.fromCache).toBe(first.fromCache);
+  });
+
+  it("persists the call graph database alongside the reverse index", async () => {
+    const runtime = new CliRuntime(tmpDir);
+    runtimes.push(runtime);
+    await runtime.init();
+    await runtime.ensureIndexed({ silent: true });
+    // Stand in for a command that built a call graph (query / context / wiki).
+    workerState.callGraphIndexer = {
+      exportDb: () => new Uint8Array([1, 2, 3]),
+      dispose: vi.fn(),
+    } as unknown as typeof workerState.callGraphIndexer;
+
+    await runtime.dispose();
+
+    expect(fs.readFileSync(path.join(cacheDir, "callgraph.db"))).toEqual(
+      Buffer.from([1, 2, 3]),
+    );
+  });
+
+  it("does not fail the command when the cache cannot be written", async () => {
+    const runtime = new CliRuntime(tmpDir);
+    runtimes.push(runtime);
+    await runtime.init();
+    await runtime.ensureIndexed({ silent: true });
+    // A read-only cache directory must degrade to "no cache", never to a crash.
+    fs.mkdirSync(cacheDir, { recursive: true });
+    fs.chmodSync(cacheDir, 0o500);
+
+    try {
+      await expect(runtime.dispose()).resolves.not.toThrow();
+    } finally {
+      fs.chmodSync(cacheDir, 0o700);
+    }
+  });
+
+  it("leaves no temp file behind after writing the cache", async () => {
+    await run();
+
+    const leftovers = fs.readdirSync(cacheDir).filter((f) => f.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+  });
+});

--- a/tests/mcp/callgraphCache.test.ts
+++ b/tests/mcp/callgraphCache.test.ts
@@ -1,0 +1,165 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
+import { ensureCallGraphReady } from "@/mcp/tools/callgraph";
+import { workerState } from "@/mcp/shared/state";
+
+/** Package root holding dist/wasm and dist/queries. */
+const EXTENSION_PATH = path.resolve(__dirname, "..", "..");
+const HAS_WASM = fs.existsSync(path.join(EXTENSION_PATH, "dist", "wasm", "sqljs.wasm"));
+
+/**
+ * The MCP worker leaves cacheDir undefined and rebuilds every start; the CLI
+ * passes one so the SQLite call graph survives between processes.
+ */
+describe.runIf(HAS_WASM)("call graph cache", () => {
+  let tmpDir: string;
+  let cacheDir: string;
+
+  const write = (relPath: string, content: string): void => {
+    const filePath = path.join(tmpDir, relPath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  };
+
+  const configure = (withCache: boolean): void => {
+    workerState.callGraphIndexer = null;
+    workerState.callGraphIndexedRoot = null;
+    workerState.config = {
+      rootDir: tmpDir,
+      excludeNodeModules: true,
+      maxDepth: 50,
+      extensionPath: EXTENSION_PATH,
+      cacheDir: withCache ? cacheDir : undefined,
+    };
+  };
+
+  /** One "process": index, persist the DB the way CliRuntime.dispose() does. */
+  const indexOnce = async (withCache = true): Promise<void> => {
+    configure(withCache);
+    await ensureCallGraphReady();
+    if (withCache) {
+      fs.mkdirSync(cacheDir, { recursive: true });
+      await workerState.callGraphIndexer?.saveToFile(path.join(cacheDir, "callgraph.db"));
+    }
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "graph-it-cg-")));
+    cacheDir = path.join(tmpDir, ".graph-it", "cache");
+    write("package.json", "{}");
+    write("src/b.ts", "export function b() { return 1; }\n");
+    for (let i = 0; i < 12; i++) {
+      write(`src/f${i}.ts`, `import { b } from "./b";\nexport function f${i}() { return b(); }\n`);
+    }
+  });
+
+  afterEach(() => {
+    workerState.reset();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("persists a reloadable database", async () => {
+    await indexOnce();
+
+    expect(fs.existsSync(path.join(cacheDir, "callgraph.db"))).toBe(true);
+    const before = workerState.callGraphIndexer?.getIndexSnapshot().files.length ?? 0;
+    expect(before).toBe(13);
+
+    await indexOnce();
+    expect(workerState.callGraphIndexer?.getIndexSnapshot().files).toHaveLength(13);
+  });
+
+  it("re-extracts only what changed on a warm run", async () => {
+    await indexOnce();
+
+    const extractFile = vi.spyOn(GraphExtractor.prototype, "extractFile");
+    try {
+      await indexOnce();
+      expect(extractFile).not.toHaveBeenCalled();
+
+      extractFile.mockClear();
+      write("src/f0.ts", 'import { b } from "./b";\nexport function f0() { return b() + 1; }\n');
+      await indexOnce();
+      // The changed file, plus any importer of it (none here).
+      expect(extractFile).toHaveBeenCalledTimes(1);
+    } finally {
+      extractFile.mockRestore();
+    }
+  });
+
+  it("also re-extracts importers of a changed file", async () => {
+    await indexOnce();
+    // Stand in for the warm Spider reverse index: f1.ts imports f0.ts.
+    const importer = path.join(tmpDir, "src/f1.ts");
+    workerState.spider = {
+      findReferencingFiles: (target: string) =>
+        Promise.resolve(
+          target.endsWith("f0.ts")
+            ? [{ path: importer, type: "import", line: 1, module: "./f0" }]
+            : [],
+        ),
+    } as unknown as typeof workerState.spider;
+
+    const extractFile = vi.spyOn(GraphExtractor.prototype, "extractFile");
+    try {
+      write("src/f0.ts", 'import { b } from "./b";\nexport function f0() { return b() + 1; }\n');
+      await indexOnce();
+
+      const extracted = extractFile.mock.calls.map(([filePath]) => filePath);
+      expect(extracted).toHaveLength(2);
+      expect(extracted).toContain(importer);
+    } finally {
+      extractFile.mockRestore();
+    }
+  });
+
+  it("drops a file deleted between runs", async () => {
+    await indexOnce();
+    fs.rmSync(path.join(tmpDir, "src/f0.ts"));
+
+    await indexOnce();
+
+    const files = workerState.callGraphIndexer?.getIndexSnapshot().files ?? [];
+    expect(files).toHaveLength(12);
+    expect(files.some((f) => f.path.endsWith("f0.ts"))).toBe(false);
+  });
+
+  it("rebuilds everything when churn passes the threshold", async () => {
+    await indexOnce();
+    for (let i = 0; i < 6; i++) {
+      write(`src/extra${i}.ts`, `import { b } from "./b";\nexport function e${i}() { return b(); }\n`);
+    }
+
+    const extractFile = vi.spyOn(GraphExtractor.prototype, "extractFile");
+    try {
+      await indexOnce();
+      expect(extractFile).toHaveBeenCalledTimes(19);
+    } finally {
+      extractFile.mockRestore();
+    }
+  });
+
+  it("indexes from scratch when no cacheDir is configured", async () => {
+    await indexOnce();
+
+    const extractFile = vi.spyOn(GraphExtractor.prototype, "extractFile");
+    try {
+      await indexOnce(false);
+      expect(extractFile).toHaveBeenCalledTimes(13);
+    } finally {
+      extractFile.mockRestore();
+    }
+  });
+
+  it("rebuilds instead of throwing when the persisted database is corrupt", async () => {
+    await indexOnce();
+    fs.writeFileSync(path.join(cacheDir, "callgraph.db"), "not a database");
+
+    await indexOnce();
+
+    expect(workerState.callGraphIndexer?.getIndexSnapshot().files).toHaveLength(13);
+  });
+});

--- a/tests/mcp/callgraphCache.test.ts
+++ b/tests/mcp/callgraphCache.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GraphExtractor } from "@/analyzer/callgraph/GraphExtractor";
 import { ensureCallGraphReady } from "@/mcp/tools/callgraph";
 import { workerState } from "@/mcp/shared/state";
+import { normalizePath } from "@/shared/path";
 
 /** Package root holding dist/wasm and dist/queries. */
 const EXTENSION_PATH = path.resolve(__dirname, "..", "..");
@@ -110,7 +111,8 @@ describe.runIf(HAS_WASM)("call graph cache", () => {
 
       const extracted = extractFile.mock.calls.map(([filePath]) => filePath);
       expect(extracted).toHaveLength(2);
-      expect(extracted).toContain(importer);
+      // selectStaleJobs normalizes every path it takes from the reverse index.
+      expect(extracted).toContain(normalizePath(importer));
     } finally {
       extractFile.mockRestore();
     }

--- a/tests/mcp/tools/workspace.test.ts
+++ b/tests/mcp/tools/workspace.test.ts
@@ -24,6 +24,60 @@ describe("workspace tools", () => {
   });
 
   describe("executeGetIndexStatus", () => {
+    const idleSpider = {
+      getIndexStatus: () => ({ state: "complete", processed: 0, total: 0, percentage: 0 }),
+      getCacheStatsAsync: async () => ({
+        dependencyCache: { size: 0 },
+        reverseIndexStats: { indexedFiles: 708, targetFiles: 243, totalReferences: 1415 },
+      }),
+      hasReverseIndex: () => true,
+      isReverseIndexEnabled: () => true,
+    };
+
+    it("omits callGraph when no call graph has been built", async () => {
+      setupWorkerState(idleSpider);
+
+      const result = await executeGetIndexStatus();
+
+      expect(result.callGraph).toBeUndefined();
+    });
+
+    it("reports call graph coverage separately from the dependency index", async () => {
+      setupWorkerState(idleSpider);
+      // The call graph only covers languages shipping a Tree-sitter query, so its
+      // file count is legitimately lower than the dependency index's.
+      workerState.callGraphIndexer = {
+        getCounts: () => ({ files: 478, symbols: 3446, relations: 5697 }),
+        dispose: vi.fn(),
+      } as any;
+
+      const result = await executeGetIndexStatus();
+
+      expect(result.reverseIndexStats?.indexedFiles).toBe(708);
+      expect(result.callGraph).toEqual({
+        indexedFiles: 478,
+        symbols: 3446,
+        relations: 5697,
+      });
+    });
+
+    it("passes the cache provenance fields of warmup through", async () => {
+      setupWorkerState(idleSpider);
+      workerState.warmupInfo = {
+        completed: true,
+        durationMs: 24,
+        filesIndexed: 708,
+        filesFound: 708,
+        filesAnalyzed: 0,
+        fromCache: true,
+      };
+
+      const result = await executeGetIndexStatus();
+
+      expect(result.warmup).toMatchObject({ fromCache: true, filesAnalyzed: 0, filesFound: 708 });
+    });
+
+
     it("should map validating to indexing and include warmup info", async () => {
       const spiderMock = {
         getIndexStatus: () => ({


### PR DESCRIPTION
## Summary
Persist reverse-index and call-graph state between CLI/MCP invocations, while preserving continuation cursors when unchanged indexes are rebuilt. Add validation, incremental indexing, cache controls, and ReviewGateAnalyzer consumer-standing/update tracking.

## Type of change
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Build/packaging
- [ ] Documentation
- [x] Tests

## Validation evidence
- Targeted cache/call-graph/runtime/Spider tests: **86 passed, 0 failed**
- Full unit suite: **passed**
- `npm run lint`: **passed**
- `npm run check:types`: **passed**

### Quality
- [x] `npm run lint`
- [x] `npm run check:types`
- [x] `npm test`
- [ ] Sonar clean on modified files — no Sonar npm script is configured in this repository; CI remains the source of truth

### VSIX / Packaging
Not applicable: no build configuration or dependency files changed.

- [ ] `npm run package:verify` — N/A
- [ ] WASM listing — N/A
- [ ] VSIX size check — N/A

### E2E
- [ ] `npm run test:vscode:vsix` — N/A: CLI behavior is covered by `tests/cli/cacheFlags.e2e.test.ts`; no VS Code UI flow changed

## Checklist
- [x] Tests added/updated for changed behavior
- [x] Docs updated (`docs/CLI.md`)
- [x] Cross-platform impact considered (path normalization and atomic cache persistence)
- [x] No `vscode` import added under `src/analyzer/**` or `src/mcp/**`

## Implementation notes
- Add `--reindex`, `--no-cache`, and `GRAPH_IT_NO_CACHE=1` controls.
- Persist and validate reverse-index cache with root/version/staleness guards.
- Reuse call-graph SQLite state and incrementally index changed files.
- Preserve continuation cursors across unchanged-index rebuilds.
- Normalize workspace paths before cache/index keys are stored.
- Extend review analysis with consumer standing and update tracking.

Breaking changes: none.