### PR TITLE
fix(site): add the Open VSX downloads badge

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -297,6 +297,7 @@ footer{border-top:1px solid var(--line);padding:46px 0 40px;color:var(--muted);f
       <a href="https://marketplace.visualstudio.com/items?itemName=magic5644.graph-it-live" target="_blank" rel="noopener"><img src="https://vsmarketplacebadges.dev/version/magic5644.graph-it-live.svg" alt="VS Code version" loading="lazy"></a>
       <a href="https://marketplace.visualstudio.com/items?itemName=magic5644.graph-it-live" target="_blank" rel="noopener"><img src="https://vsmarketplacebadges.dev/installs-short/magic5644.graph-it-live.svg?label=vscode+installs" alt="VS Code installs" loading="lazy"></a>
       <a href="https://open-vsx.org/extension/magic5644/graph-it-live" target="_blank" rel="noopener"><img src="https://img.shields.io/open-vsx/v/magic5644/graph-it-live?label=Open%20VSX&logo=eclipse&logoColor=white" alt="Open VSX" loading="lazy"></a>
+      <a href="https://open-vsx.org/extension/magic5644/graph-it-live" target="_blank" rel="noopener"><img src="https://img.shields.io/open-vsx/dt/magic5644/graph-it-live?label=Open%20VSX%20Downloads" alt="Open VSX downloads" loading="lazy"></a>
       <a href="https://www.npmjs.com/package/@magic5644/graph-it-live" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/%40magic5644%2Fgraph-it-live?label=npm%20CLI&logo=npm&logoColor=white" alt="npm CLI" loading="lazy"></a>
       <a href="https://github.com/magic5644/Graph-It-Live/blob/main/LICENSE" target="_blank" rel="noopener"><img src="https://img.shields.io/github/license/magic5644/Graph-It-Live" alt="License MIT" loading="lazy"></a>
     </div>


### PR DESCRIPTION
Adds the Open VSX downloads badge to the landing page badge row, matching the README, which already shows both the Open VSX version and its download count.

Verified locally: the badge endpoint returns 200 and renders in the hero badge row.